### PR TITLE
fix netlify preview

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,6 @@
 [build]
 base = "site/"
-publish = "site/public/"
+publish = "public/"
 command = "hugo"
 
 [build.environment]

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,7 +1,7 @@
 [build]
 base = "site/"
 publish = "public/"
-command = "hugo"
+command = "make netlify-build"
 
 [build.environment]
 HUGO_VERSION = "0.91.2"
@@ -11,7 +11,7 @@ HUGO_ENV = "production"
 HUGO_BASEURL = "https://docs.prow.k8s.io/"
 
 [context.deploy-preview]
-command = "hugo --enableGitInfo --buildFuture -b $DEPLOY_PRIME_URL"
+command = "make netlify-deploy-preview"
 
 [context.branch-deploy]
-command = "hugo --enableGitInfo --buildFuture -b $DEPLOY_PRIME_URL"
+command = "make netlify-deploy-preview"

--- a/site/Makefile
+++ b/site/Makefile
@@ -7,10 +7,20 @@ serve:
 build:
 	hugo
 
-# Update the "docsy" Hugo theme.
-update-theme:
+# Used by Netlify to build the site.
+netlify-build: init-theme build
+
+netlify-deploy-preview: init-theme
+	hugo --enableGitInfo --buildFuture -b $(DEPLOY_PRIME_URL)
+
+# Used by Netlify to pull in the theme (plain git-clone of our main repo is not enough).
+init-theme:
 	git submodule update --init --recursive
+
+# Update the "docsy" Hugo theme.
+update-theme: init-theme
 	npm update
 
 .PHONY: \
+	init-theme \
 	update-theme


### PR DESCRIPTION
The "site" folder does not need to specified again for the "publish"
field because it is relative to the "base" field, as per the docs [1]:

    # Settings in the [build] context are global and are applied to
    # all contexts unless otherwise overridden by more specific contexts.
    [build]
      # Directory to change to before starting a build.
      # This is where we will look for package.json/.nvmrc/etc.
      # If not set, defaults to the root directory.
      base = "project/"

      # Directory that contains the deploy-ready HTML files and
      # assets generated by the build. This is relative to the base
      # directory if one has been set, or the root directory if
      # a base has not been set. This sample publishes the directory
      # located at the absolute path "root/project/build-output"

      publish = "build-output/"

[1]: https://docs.netlify.com/configure-builds/file-based-configuration/