### PR TITLE
disable build skip optimization

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,6 +2,7 @@
 base = "site/"
 publish = "public/"
 command = "make netlify-build"
+ignore = "false"
 
 [build.environment]
 HUGO_VERSION = "0.91.2"


### PR DESCRIPTION
Netlify by default prevents builds where it detects that there are no
changes. This appears to be simply broken. In the case of this PR#7 [1],
we observed a successful preview at [2], and yet the deployment failed
with a

     10:35:30 AM: No changes detected in base directory. Returning early from build.

message [3], preventing the docs site from being updated.

The change here adds a workaround [4] to always make the "ignore build"
optimization fail with the "false" command. This is OK because this site
is a pure documentation site, so there is no real danger of building
when we don't need to (as is the case for repos that have docs colocated
with their source code).

[1]: https://github.com/kubernetes-sigs/prow/pull/7
[2]: https://deploy-preview-7--k8s-prow.netlify.app/
[3]: https://app.netlify.com/sites/k8s-prow/deploys/6287d154bec03f000872fcbb
[4]: https://answers.netlify.com/t/deployment-results-in-no-changes-detected-in-base-directory-returning-early-from-build/49981/2

/assign @cjwagner 