### PR TITLE
Remove Tackle from Prow Deployment guide

### DIFF
--- a/site/content/en/docs/components/cli-tools/tackle.md
+++ b/site/content/en/docs/components/cli-tools/tackle.md
@@ -1,0 +1,66 @@
+---
+title: "tackle"
+weight: 10
+description: >
+  
+---
+
+Prow's `tackle` utility walks you through deploying a new instance of prow
+in a couple of minutes, try it out!
+
+### Installing tackle
+
+Tackle at this point in time needs to be built from source. The following
+steps will walk you through the process:
+
+1. Clone the `test-infra` repository:
+
+```shell
+git clone git@github.com:kubernetes/test-infra.git
+```
+
+2. Build `tackle` (This requires a working go installation on your system)
+
+```shell
+cd test-infra/prow/cmd/tackle && go build -o tackle
+```
+
+3. Optionally move `tackle` to your `$PATH`
+
+```shell
+sudo mv tackle /usr/sbin/tackle
+```
+
+### Deploying prow
+
+**Note**: Creating a cluster using the `tackle` utility assumes you
+have the `gcloud` application in your `$PATH` and are logged in. If you are
+doing this on another cloud skip to the **Manual deployment** below.
+
+Installing Prow using `tackle` will help you through the following steps:
+
+* Choosing a kubectl context (or creating a cluster on GCP / getting its credentials if necessary)
+* Deploying prow into that cluster
+* Configuring GitHub to send prow webhooks for your repos. This is where you'll provide the absolute `/path/to/github/token`
+
+To install prow run the following and follow the on-screen instructions:
+
+1. Run `tackle`:
+
+```sh
+tackle
+```
+
+2. Once your cluster is created, you'll get a prompt to apply a `starter.yaml`. Before you do that open another terminal and apply the prow CRDs using:
+
+```sh
+kubectl apply --server-side=true -f https://raw.githubusercontent.com/kubernetes/test-infra/master/config/prow/cluster/prowjob-crd/prowjob_customresourcedefinition.yaml
+```
+
+3. After that specify the `starter.yaml` you want to use (please make sure to replace the values mentioned [here](/docs/getting-started-deploy/#update-the-sample-manifest)). Once that is done some pods still won't be in the `Running` state because we haven't created the secret containing the credentials needed for our GCS bucket. To do that follow the steps in [Configure a GCS bucket](/docs/getting-started-deploy/#configure-a-gcs-bucket).
+
+4. Once that is done, `tackle` should show you the URL where you can access the prow dashboard. To use it with your repositories head over to the settings of the GitHub app you created and there under webhook secret, supply the HMAC token you specified in the [`starter.yaml`](https://github.com/kubernetes/test-infra/blob/master/config/prow/cluster/starter/starter-gcs.yaml#L51).
+
+5. Once that is done, install the GitHub app on the repositories you want (this is only needed if you ran `tackle` with the `--skip-github` flag) and you should now be able to use Prow :)
+
+See the [Next Steps](/docs/getting-started-deploy/#next-steps) section after running this utility.

--- a/site/content/en/docs/components/undocumented/tackle.md
+++ b/site/content/en/docs/components/undocumented/tackle.md
@@ -1,8 +1,0 @@
----
-title: "tackle"
-weight: 10
-description: >
-  
----
-
-This is a placeholder page. Some contents needs to be filled.

--- a/site/content/en/docs/getting-started-deploy.md
+++ b/site/content/en/docs/getting-started-deploy.md
@@ -7,9 +7,7 @@ description: >
 
 This document will walk you through deploying your own Prow instance to a new Kubernetes cluster. If you encounter difficulties, please open an issue so that we can make this process easier.
 
-Prow runs in any kubernetes cluster. Our `tackle` utility helps deploy it correctly, or you can perform each of the steps manually.
-
-Both of these are focused on [Kubernetes Engine](https://cloud.google.com/kubernetes-engine/) but should work on any kubernetes distro with no/minimal changes.
+Prow runs in any kubernetes cluster. The guide below is focused on [Google Kubernetes Engine](https://cloud.google.com/kubernetes-engine/) but should work on any kubernetes distro with no/minimal changes.
 
 ## GitHub App
 
@@ -42,70 +40,7 @@ After you saved the app, click "Generate Private Key" on the bottom
 and save the private key together with the `App ID` in the top of the
 page.
 
-## Tackle deployment
-
-Prow's `tackle` utility walks you through deploying a new instance of prow 
-in a couple of minutes, try it out!
-
-### Installing tackle
-
-Tackle at this point in time needs to be built from source. The following 
-steps will walk you through the process:
-
-1. Clone the `test-infra` repository:
-```shell
-$ git clone git@github.com:kubernetes/test-infra.git
-```
-
-2. Build `tackle` (This requires a working go installation on your system)
-```shell
-$ cd test-infra/prow/cmd/tackle && go build -o tackle
-```
-
-3. Optionally move `tackle` to your `$PATH`
-```shell
-$ sudo mv tackle /usr/sbin/tackle
-```
-
-
-### Deploying prow
-
-**Note**: Creating a cluster using the `tackle` utility assumes you 
-have the `gcloud` application in your `$PATH` and are logged in. If you are 
-doing this on another cloud skip to the **Manual deployment** below.
-
-
-
-Installing Prow using `tackle` will help you through the following steps:
-
-* Choosing a kubectl context (or creating a cluster on GCP / getting its credentials if necessary)
-* Deploying prow into that cluster
-* Configuring GitHub to send prow webhooks for your repos. This is where you'll provide the absolute `/path/to/github/token`
-
-To install prow run the following and follow the on-screen instructions:
-
-1. Run `tackle`:
-```sh
-tackle
-```
-
-2. Once your cluster is created, you'll get a prompt to apply a `starter.yaml`. Before you do that open another terminal and apply the prow CRDs using:
-
-```
-kubectl apply --server-side=true -f https://raw.githubusercontent.com/kubernetes/test-infra/master/config/prow/cluster/prowjob-crd/prowjob_customresourcedefinition.yaml
-```
-
-3. After that specify the `starter.yaml` you want to use (please make sure to replace the values mentioned [here](#update-the-sample-manifest)). Once that is done some pods still won't be in the `Running` state because we haven't created the secret containing the credentials needed for our GCS bucket. To do that follow the steps in [Configure a GCS bucket](#configure-a-gcs-bucket).
-
-4. Once that is done, `tackle` should show you the URL where you can access the prow dashboard. To use it with your repositories head over to the settings of the GitHub app you created and there under webhook secret, supply the HMAC token you specified in the [`starter.yaml`](https://github.com/kubernetes/test-infra/blob/master/config/prow/cluster/starter/starter-gcs.yaml#L51).
-
-5. Once that is done, install the GitHub app on the repositories you want (this is only needed if you ran `tackle` with the `--skip-github` flag) and you should now be able to use Prow :)
-
-See the [Next Steps](#next-steps) section after running this utility.
-
-## Manual deployment
-
-If you do not want to use the `tackle` utility above, here are the manual set of commands tackle will run.
+## Deploying prow
 
 Prow runs in a kubernetes cluster, so first figure out which cluster you want to deploy prow into.
 If you already have a cluster created you can skip to the **Create cluster role bindings** step.
@@ -384,7 +319,7 @@ $ gsutil iam ch allUsers:objectViewer gs://your-bucket-name # step 3
 $ gsutil iam ch "serviceAccount:${identifier}:objectAdmin" gs://your-bucket-name # step 4
 $ gcloud iam service-accounts keys create --iam-account "${identifier}" service-account.json # step 5
 $ kubectl -n test-pods create secret generic gcs-credentials --from-file=service-account.json # step 6
-$ kubectl -n prow create secret generic gcs-credentials --from-file=service-account.json # this secret is also needed by deployments in the prow namespace 
+$ kubectl -n prow create secret generic gcs-credentials --from-file=service-account.json # this secret is also needed by deployments in the prow namespace
 ```
 
 #### Configure the version of plank's utility images


### PR DESCRIPTION
- Supersedes & closes #24
  (which is a translation of https://github.com/kubernetes/test-infra/pull/26754)
- We have 2 options here for this PR:
  - We might cherrypick the first commit ('Remove Tackle from Prow Deployment guide') only,
    since the `tackle` tool is not actively maintained and thus not really supported.
  - Or, although the tool is not actively maintained and thus not really supported,
    we might preserve the doc for `tackle`.
    (If we choose this option, then it would be good to change the PR title, as it will become the commit message of squashed commit on `main` branch.)

FYI:
From my experience of deploying Prow 1) using tackle, and 2) manually,
- the Prow depolyment guide instructs to create and configure GitHub App,
  `tackle` created a webhook to my GitHub org, instead of configuring the webhook of the GitHub App that user just created.
- ... (Some other inconsistency with the guide might exist.)

/label tide/merge-method-squash