### PR TITLE
migrate to hugo modules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "site/themes/docsy"]
-	path = site/themes/docsy
-	url = https://github.com/google/docsy.git
-	branch = main

--- a/site/.rgignore
+++ b/site/.rgignore
@@ -2,4 +2,3 @@ node_modules
 package-lock.json
 public
 resources
-themes

--- a/site/Makefile
+++ b/site/Makefile
@@ -8,24 +8,10 @@ build:
 	hugo
 
 # Used by Netlify to build the site.
-netlify-build: init-theme build
+netlify-build: build
 
-netlify-deploy-preview: init-theme
-	cd themes/docsy && npm install
+netlify-deploy-preview:
 	hugo --enableGitInfo --buildFuture -b $(DEPLOY_PRIME_URL)
-
-# Used by Netlify to pull in the theme (plain git-clone of our main repo is not enough).
-init-theme:
-	git submodule update --init --recursive
-
-# Update the "docsy" Hugo theme.
-update-theme: init-theme
-	git submodule update --remote
-	npm install
 
 check-broken-links:
 	find ./public -name "*.html" -print0 | sort -z | xargs -0 ./check-broken-links.sh
-
-.PHONY: \
-	init-theme \
-	update-theme

--- a/site/config.toml
+++ b/site/config.toml
@@ -4,7 +4,7 @@ title = "Prow"
 enableRobotsTXT = true
 
 # Hugo allows theme composition (and inheritance). The precedence is from left to right.
-theme = ["docsy"]
+theme = ["github.com/google/docsy", "github.com/google/docsy/dependencies"]
 
 # Will give values to .Lastmod etc.
 enableGitInfo = true

--- a/site/go.mod
+++ b/site/go.mod
@@ -1,0 +1,5 @@
+module github.com/kubernetes-sigs/prow
+
+go 1.20
+
+require github.com/google/docsy v0.6.0 // indirect

--- a/site/go.sum
+++ b/site/go.sum
@@ -1,0 +1,5 @@
+github.com/FortAwesome/Font-Awesome v0.0.0-20220831210243-d3a7818c253f/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
+github.com/google/docsy v0.6.0 h1:43bVF18t2JihAamelQjjGzx1vO2ljCilVrBgetCA8oI=
+github.com/google/docsy v0.6.0/go.mod h1:VKKLqD8PQ7AglJc98yBorATfW7GrNVsn0kGXVYF6G+M=
+github.com/google/docsy/dependencies v0.6.0/go.mod h1:EDGc2znMbGUw0RW5kWwy2oGgLt0iVXBmoq4UOqstuNE=
+github.com/twbs/bootstrap v4.6.2+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=


### PR DESCRIPTION
The dependencies are now tracked via go.mod and go.sum. The guide at https://www.docsy.dev/docs/updating/convert-site-to-module/ was used for this migration.