### PR TITLE
remove migration notice

### DIFF
--- a/site/content/en/docs/_index.md
+++ b/site/content/en/docs/_index.md
@@ -6,7 +6,3 @@ menu:
   main:
     weight: 20
 ---
-
-{{% pageinfo %}}
-This site is under construction. We are in the process of migrating (copying) over existing user-facing docs from https://github.com/kubernetes/test-infra/tree/master/prow.
-{{% /pageinfo %}}


### PR DESCRIPTION
This information is out-of-date and gives a false sense of incompleteness.

/cc @cjwagner @jihoon-seo 