### PR TITLE
add search in sidebar

### DIFF
--- a/site/config.toml
+++ b/site/config.toml
@@ -133,7 +133,7 @@ github_branch= "main"
 algolia_docsearch = false
 
 # Enable Lunr.js offline search
-offlineSearch = false
+offlineSearch = true
 
 # Enable syntax highlighting and copy buttons on code blocks with Prism
 prism_syntax_highlighting = false


### PR DESCRIPTION
Later we can upgrade to Google-indexed search, as outlined here: https://www.docsy.dev/docs/adding-content/navigation/#setting-up-site-search

Temporarily addresses #34

/cc @jihoon-seo @cjwagner 