### PR TITLE
Add step to fill in webhook secret

### DIFF
--- a/site/content/en/docs/getting-started-deploy.md
+++ b/site/content/en/docs/getting-started-deploy.md
@@ -197,7 +197,8 @@ to start receiving GitHub events!
 
 To set up the webhook, you have to go the GitHub UI and edit your app. Update
 the `Webhook URL` property to `https://prow.<<your-domain.com>>/hook`. Use the URL
-shown above when getting the `Ingress`.
+shown above when getting the `Ingress` and fill in the Webhook secret using the value
+in the `hmac-token` secret created earlier.
 
 ## Install Prow for a GitHub organization or repo
 


### PR DESCRIPTION
The deploy instructions seem to miss the step where you put in the webhook secret in the GitHub App config.  It wasn't super hard to figure out what was the issue but having it here will make life easier for people.