### PR TITLE
Add example value for gcs_browser_prefix for AWS S3

### DIFF
--- a/site/content/en/docs/spyglass/_index.md
+++ b/site/content/en/docs/spyglass/_index.md
@@ -44,7 +44,7 @@ The `spyglass` block has the following properties:
 | Name | Required | Example | Description |
 |---|---|---|---|
 | `size_limit` | Yes | `100000000` | The maximum size of an artifact to download, in bytes. Larger values will be omitted or truncated. |
-| `gcs_browser_prefix` | No | `https://gcsweb.k8s.io/gcs/` | If you have a GCS browser available, the bucket and path to the artifact directory will be appended to `gcs_browser_prefix` and linked from Spyglass pages. If left unset, no artifacts link will be visible. The provided URL should have a trailing slash |
+| `gcs_browser_prefix` | No | `https://gcsweb.k8s.io/gcs/` <br> `https://s3.console.aws.amazon.com/s3/buckets/` | If you have a GCS browser available, the bucket and path to the artifact directory will be appended to `gcs_browser_prefix` and linked from Spyglass pages. If left unset, no artifacts link will be visible. The provided URL should have a trailing slash |
 | `testgrid_config` | No | `gs://k8s-testgrid/config` | If you have a TestGrid instance available, `testgrid_config` should point to the TestGrid config proto on GCS. If omitted, no TestGrid link will be visible.
 | `testgrid_root` | No | `https://testgrid.k8s.io/` | If you have a TestGrid instance available, `testgrid_root` should point to the root of the TestGrid web interface. If omitted, no TestGrid link will be visible.
 | `announcement` | No | `"Remember: friendship is magic!"` | If announcement is set, the string will appear at the top of the page. `announcement` is parsed as a Go template. The only value provided is `.ArtifactPath`, which is of the form `gcs-bucket/path/to/job/root/`.


### PR DESCRIPTION
I didn't realize it was possible to setup `gcs_browser_prefix` for S3, but I found a way to do it and thought it would be nice to share that with others in the documentation.