### PR TITLE
update OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -4,8 +4,6 @@ approvers:
   - alvaroaleman
   - cblecker
   - cjwagner
-  - fejta
   - stevekuznetsov
   - petr-muller
   - listx
-  - chaodaiG


### PR DESCRIPTION
fejta (Erick Fejta) has been inactive since leaving Google last year.

chaodaiG (Chao Dai) has switched teams and is no longer focusing on Prow.