### PR TITLE
Update prow instance url for TiDB

### DIFF
--- a/site/content/en/docs/overview/_index.md
+++ b/site/content/en/docs/overview/_index.md
@@ -113,7 +113,7 @@ Prow is used by the following organizations and projects:
 * [Loodse](https://public-prow.loodse.com/)
 * [Feast](https://github.com/gojek/feast)
 * [Falco](http://prow.falco.org)
-* [TiDB](https://prow.tidb.io)
+* [TiDB](https://prow.tidb.net)
 * [Amazon EKS Distro and Amazon EKS Anywhere](https://prow.eks.amazonaws.com/)
 * [KubeSphere](https://prow.kubesphere.io)
 * [OpenYurt](https://github.com/openyurtio/openyurt)


### PR DESCRIPTION
## I request to update it to new domain(prow.tidb.net)

I am a maintainer of Prow instance for TiDB and a member of [pingcap](https://github.com/pingcap) ORG.

> TiDB is a product of [PingCAP](https://www.pingcap.com).

The instance was migrated to new domain prow.tidb.net for one year. Now the old domain(prow.tidb.io) is offline.