### PR TITLE
Update permissions list for branch protection

### DIFF
--- a/site/content/en/docs/getting-started-deploy.md
+++ b/site/content/en/docs/getting-started-deploy.md
@@ -20,7 +20,7 @@ app requests (both added and removed) require everyone to re-install it.
 Repository permissions:
 
 * Actions: Read-Only (Only needed when using the merge automation `tide`)
-* Administration: Read-Only (Required to fetch teams and collaborateurs)
+* Administration: Read-Only (Required to fetch teams and collaborators, Read & write needed when using branch protection automation)
 * Checks: Read-Only (Only needed when using the merge automation `tide`)
 * Contents: Read (Read & write needed when using the merge automation `tide`)
 * Issues: Read & write


### PR DESCRIPTION
If using `branchprotector` with the GitHub App, one needs to add read and write permissions for repo administration.
ref https://docs.github.com/en/rest/overview/permissions-required-for-github-apps?apiVersion=2022-11-28#repository-permissions-for-administration