### PR TITLE
Add missing build dependencies from test-infra for deck image build

### DIFF
--- a/hack/build/ensure-node_modules.sh
+++ b/hack/build/ensure-node_modules.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# this script ensures node_modules is up to date with yarn in docker
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)"
+
+cache() {
+    local action="$1"
+    cd "${REPO_ROOT}/hack/tools"
+    go build -o "${REPO_ROOT}/_bin/gcs-cacher" github.com/sethvargo/gcs-cacher
+
+    "${REPO_ROOT}/_bin/gcs-cacher" \
+        -bucket "k8s-prow-build-cache" \
+        -$action "yarn-deps-$(md5sum ${REPO_ROOT}/yarn.lock  | awk '{ print $1 }')" \
+        -dir "${REPO_ROOT}/node_modules" \
+        -allow-failure
+}
+
+# Download cache if running in CI
+if [[ "${CI:-}" == "true" ]]; then
+    cache restore
+fi
+
+cd "${REPO_ROOT}"
+hack/run-in-node-container.sh \
+    yarn install
+
+# Optional creates cache if this is supplied
+if [[ "${CREATE_TYPESCRIPT_CACHE:-}" == "true" ]]; then
+    cache cache
+fi

--- a/hack/run-in-node-container.sh
+++ b/hack/run-in-node-container.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script runs $@ in a node container
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+cd "${REPO_ROOT}"
+
+NODE_IMAGE='node:18-bullseye-slim'
+
+DOCKER=(docker)
+
+if [[ -n "${NO_DOCKER:-}" ]]; then
+  DOCKER=(echo docker)
+elif ! (command -v docker >/dev/null); then
+  echo "WARNING: docker not installed; please install docker or try setting NO_DOCKER=true" >&2
+  exit 1
+fi
+
+# We are running as the current host user/group so the files produced are
+# owned appropriately on the host.
+# With rootless mode, this happens without the need for a --user option.
+# https://www.redhat.com/sysadmin/user-flag-rootless-containers
+# Docker includes the "rootless" keyword in its "system info" output,
+# whereas podman includes "rootless: (true|false)".
+DOCKER_USER=""
+if ! "${DOCKER[@]}" system info | grep -q "rootless\(: true\)\?$"; then
+    DOCKER_USER="--user $(id -u):$(id -g)"
+fi
+
+# NOTE: yarn tries to read configs under $HOME and fails if it can't,
+# we don't need these configs but we need it to not fail.
+# We set HOME to somewhere read/write-able by any user, since our uid will not
+# exist in /etc/passwd in the node image and yarn will try to read from / and
+# fail instead if we don't.
+"${DOCKER[@]}" run \
+    --rm -i \
+    ${DOCKER_USER} \
+    -e HOME=/tmp \
+    -v "${REPO_ROOT:?}:${REPO_ROOT:?}" -w "${REPO_ROOT}" \
+    --security-opt="label=disable" \
+    "${NODE_IMAGE}" \
+    "$@"
+if [[ -n "${NO_DOCKER:-}" ]]; then
+  (
+    set -o xtrace
+    "$@"
+  )
+fi

--- a/hack/ts.rollup_bundle.min.minify_options.json
+++ b/hack/ts.rollup_bundle.min.minify_options.json
@@ -1,0 +1,11 @@
+{
+    "compress": {
+        "keep_fnames": true,
+        "passes": 3,
+        "pure_getters": true,
+        "reduce_funcs": true,
+        "reduce_vars": true,
+        "sequences": true
+    },
+    "mangle": true
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,38 @@
+{
+  "dependencies": {
+    "code-prettify": "^0.1.0",
+    "color": "^3.1.2",
+    "dialog-polyfill": "^0.5.0",
+    "moment": "^2.22.2",
+    "pako": "^1.0.10"
+  },
+  "bazel-update-info": {
+    "WORKSPACE": "NB: set frozen_lockfile = False"
+  },
+  "devDependencies": {
+    "@bazel/bazelisk": "^1.5.0",
+    "@bazel/jasmine": "3.1.0",
+    "@bazel/rollup": "^3.1.0",
+    "@bazel/terser": "^3.1.0",
+    "@bazel/typescript": "^3.1.0",
+    "@rollup/plugin-commonjs": "14.0.0",
+    "@rollup/plugin-json": "4.1.0",
+    "@rollup/plugin-node-resolve": "8.4.0",
+    "@types/color": "^3.0.0",
+    "@types/google.visualization": "^0.0.43",
+    "@types/gtag.js": "^0.0.0",
+    "@types/jasmine": "~3.3.13",
+    "@types/pako": "^1.0.1",
+    "@typescript-eslint/eslint-plugin": "^5.31.0",
+    "@typescript-eslint/parser": "^5.31.0",
+    "eslint": "^8.20.0",
+    "eslint-plugin-jsdoc": "^39.3.3",
+    "eslint-plugin-prefer-arrow": "^1.2.3",
+    "jasmine": "~3.4.0",
+    "rollup": "2.77.2",
+    "rollup-plugin-amd": "4.0.0",
+    "rollup-plugin-terser": "5.1.3",
+    "terser": "5.14.2",
+    "typescript": "^3.7.5"
+  }
+}

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,17 @@
+import { nodeResolve } from '@rollup/plugin-node-resolve';
+import commonjs from '@rollup/plugin-commonjs';
+
+const inputFile = process.env.ROLLUP_ENTRYPOINT;
+const outputFile = process.env.ROLLUP_OUT_FILE;
+
+export default {
+  context: "window",
+  input: inputFile,
+  output: [
+    {
+      file: outputFile,
+      format: 'esm'
+    }
+  ],
+  plugins: [nodeResolve(), commonjs()]
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,37 @@
+{
+  "compilerOptions": {
+    "lib": ["dom", "es6", "ScriptHost", "es2015.core", "dom.iterable", "es2016.array.include"],
+    "target": "es2015",
+    "module": "esnext",
+    "downlevelIteration": true,
+    "skipDefaultLibCheck": true,
+    "moduleResolution": "node",
+    "preserveConstEnums": false,
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "jsx": "react",
+    "noErrorTruncation": false,
+    "noEmitOnError": false,
+    "declaration": false,
+    "stripInternal": true,
+    "inlineSourceMap": true,
+    "inlineSources": true,
+    "sourceMap": false,
+    "allowSyntheticDefaultImports": true,
+    "baseUrl": ".",
+    "rootDir": ".",
+    "rootDirs": [
+        "."
+    ],
+    "paths": {
+      "*": [
+        "node_modules/*",
+        "node_modules/@types/*"
+      ]
+    },
+    "typeRoots": [
+      "node_modules/@types"
+    ],
+    "types": []
+  }
+}


### PR DESCRIPTION
The configs in top level folder and hack/ are hidden dependencies for gather-static.sh (in prow/cmd/deck, which is called by prowimagebuilder) and ts_rollup.

Tested prow/cmd/deck can be successfully built with these changes.