### PR TITLE
Fix sync-prow.sh to avoid duplicating commit history.

### DIFF
--- a/hack/scripts/.gitignore
+++ b/hack/scripts/.gitignore
@@ -1,0 +1,2 @@
+old_prow/
+prow/


### PR DESCRIPTION
/assign @listx @simony-gke 

I used this script to generate this branch: https://github.com/cjwagner/prow/tree/sync
The branch will not merge cleanly so we'll need to refresh the sync and force push this to the main branch when we're ready. I don't think subsequent syncs will require a force push, but I am not certain.