### PR TITLE
Make image consistency errors more actionable.

### DIFF
--- a/prow/cmd/generic-autobumper/main.go
+++ b/prow/cmd/generic-autobumper/main.go
@@ -482,19 +482,19 @@ func parseUpstreamImageVersion(upstreamAddress, prefix string) (string, error) {
 func getVersionsAndCheckConsistency(prefixes []prefix, images map[string]string) (map[string][]string, error) {
 	// Key is tag, value is full image.
 	versions := map[string][]string{}
-	consistencyChecker := map[string]string{}
 	for _, prefix := range prefixes {
 		exceptions := sets.NewString(prefix.ConsistentImageExceptions...)
+		var consistencyVersion, consistencySourceImage string
 		for k, v := range images {
 			if strings.HasPrefix(k, prefix.Prefix) {
 				image := imageFromName(k)
-				found, ok := consistencyChecker[prefix.Prefix]
 				if prefix.ConsistentImages && !exceptions.Has(image) {
-					if ok && (found != v) {
-						return nil, fmt.Errorf("%s:%s not bumped consistently for prefix %s(%s), expected version: %s", k, v, prefix.Prefix, prefix.Name, found)
+					if consistencySourceImage != "" && (consistencyVersion != v) {
+						return nil, fmt.Errorf("%s -> %s not bumped consistently for prefix %s (%s), expected version %s based on bump of %s", k, v, prefix.Prefix, prefix.Name, consistencyVersion, consistencySourceImage)
 					}
-					if !ok {
-						consistencyChecker[prefix.Prefix] = v
+					if consistencySourceImage == "" {
+						consistencyVersion = v
+						consistencySourceImage = k
 					}
 				}
 


### PR DESCRIPTION
When there is an image consistency error, it would be helpful to know where the conflict came from.
For example, this error was difficult to debug: https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-test-infra-autobump-prow/1777837897014054912

> ```
> time="2024-04-09T23:16:30Z" level=fatal msg="failed to run the bumper tool" error="process function 0: gcr.io/k8s-prow/commenter:v20240405-c76de01869:v20240409-13cd3acf7e not bumped consistently for prefix gcr.io/k8s-prow/(Prow), expected version: v20240409-0bca2f141"
> ```

/assign @michelle192837 