### PR TITLE
Fix flake unit test TestAddWithParser

### DIFF
--- a/pkg/config/secret/reloader.go
+++ b/pkg/config/secret/reloader.go
@@ -69,13 +69,12 @@ func (p *parsingSecretReloader[T]) reloadSecret(reloadCensor func()) {
 			lastModTime = recentModTime
 		}
 
+		p.lock.Lock()
 		raw, parsed, err := loadSingleSecretWithParser(p.path, p.parsingFN)
 		if err != nil {
 			logger.WithField("secret-path", p.path).WithError(err).Error("Error loading secret.")
 			continue
 		}
-
-		p.lock.Lock()
 		p.rawValue = raw
 		p.parsed = parsed
 		p.lock.Unlock()


### PR DESCRIPTION
This PR is an attempt to fix https://github.com/kubernetes/test-infra/issues/31313.
As far as I was able to understand the test pulled out the value from the generator ([here](https://github.com/kubernetes/test-infra/blob/c76de018691234a5bfa8bb2c0e5586149c32db0a/prow/config/secret/agent_test.go#L159-L161)) before the agent had the time to update it ([here](https://github.com/kubernetes/test-infra/blob/c76de018691234a5bfa8bb2c0e5586149c32db0a/prow/config/secret/reloader.go#L78-L81)).
This solution might not be ideal still, due to the 10s time.Sleep but we need to go a pretty extensive refactor to make the test 100% deterministic.
Anyway, as far as I know the sleep has never been a problem so far, therefore we might be good this way.

The original PR is https://github.com/kubernetes/test-infra/pull/32385