### PR TITLE
Include cluster name in authorization error messages

### DIFF
--- a/pkg/flagutil/kubernetes_cluster_clients.go
+++ b/pkg/flagutil/kubernetes_cluster_clients.go
@@ -396,13 +396,13 @@ func (o *KubernetesOptions) BuildClusterManagers(dryRun bool, requiredTestPodVer
 			authzClient, err := authorizationv1.NewForConfig(&config)
 			if err != nil {
 				lock.Lock()
-				errs = append(errs, fmt.Errorf("failed to construct authz client: %s", err))
+				errs = append(errs, fmt.Errorf("failed to construct authz client for cluster %s: %s", name, err))
 				lock.Unlock()
 				return
 			}
 			if err := CheckAuthorizations(authzClient.SelfSubjectAccessReviews(), options.Namespace, requiredTestPodVerbs); err != nil {
 				lock.Lock()
-				errs = append(errs, fmt.Errorf("failed pod resource authorization check: %w", err))
+				errs = append(errs, fmt.Errorf("failed pod resource authorization check for cluster %s: %w", name, err))
 				lock.Unlock()
 				return
 			}


### PR DESCRIPTION
Similar to this error: https://github.com/kubernetes-sigs/prow/compare/main...inteon:prow:error_include_clustername?expand=1#diff-7d688313b319388bc790c0799da5081d6648feaeaf7945b26e5b6a93752b044dR389, include the cluster name in the error message.

Currently the error message looks like this:
```json
{
   "component":"prow-controller-manager",
   "error":"failed pod resource authorization check: [missing permissions: unable to \"create\" pods, missing permissions: unable to \"delete\" pods, missing permissions: unable to \"list\" pods, missing permissions: unable to \"watch\" pods, missing permissions: unable to \"get\" pods, missing permissions: unable to \"patch\" pods]",
   "file":"sigs.k8s.io/prow/prow/cmd/prow-controller-manager/main.go:170",
   "func":"main.main",
   "level":"error",
   "msg":"Failed to construct build cluster managers. Please check that the kubeconfig secrets are correct, and that RBAC roles on the build cluster allow Prow's service account to list pods on it.",
   "severity":"error",
   "time":"2024-04-17T08:04:31Z"
}
```
This PR adds the cluster name to this error message.