### PR TITLE
Revive prowjob when node is terminated (enabled by default)

### DIFF
--- a/config/prow/cluster/prowjob-crd/prowjob_customresourcedefinition.yaml
+++ b/config/prow/cluster/prowjob-crd/prowjob_customresourcedefinition.yaml
@@ -1614,6 +1614,13 @@ spec:
                   If this field is unspecified or false, a new pod will be created to replace
                   the evicted one.
                 type: boolean
+              error_on_termination:
+                description: |-
+                  ErrorOnTermination indicates that the ProwJob should be completed and given
+                  the ErrorState status if the pod that is executing the job is terminated.
+                  If this field is unspecified or false, a new pod will be created to replace
+                  the terminated one.
+                type: boolean
               extra_refs:
                 description: |-
                   ExtraRefs are auxiliary repositories that

--- a/pkg/apis/prowjobs/v1/types.go
+++ b/pkg/apis/prowjobs/v1/types.go
@@ -182,6 +182,11 @@ type ProwJobSpec struct {
 	// If this field is unspecified or false, a new pod will be created to replace
 	// the evicted one.
 	ErrorOnEviction bool `json:"error_on_eviction,omitempty"`
+	// ErrorOnTermination indicates that the ProwJob should be completed and given
+	// the ErrorState status if the pod that is executing the job is terminated.
+	// If this field is unspecified or false, a new pod will be created to replace
+	// the terminated one.
+	ErrorOnTermination bool `json:"error_on_termination,omitempty"`
 
 	// PodSpec provides the basis for running the test under
 	// a Kubernetes agent

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1428,6 +1428,13 @@ func TestValidateAgent(t *testing.T) {
 			},
 			pass: true,
 		},
+		{
+			name: "error_on_termination allowed for kubernetes agent",
+			base: func(j *JobBase) {
+				j.ErrorOnTermination = true
+			},
+			pass: true,
+		},
 	}
 
 	for _, tc := range cases {
@@ -8431,6 +8438,9 @@ plank:
   pod_pending_timeout: 10m0s
   pod_running_timeout: 48h0m0s
   pod_unscheduled_timeout: 5m0s
+  termination_condition_reasons:
+  - DeletionByPodGC
+  - DeletionByGCPControllerManager
 pod_namespace: default
 prowjob_namespace: default
 push_gateway:
@@ -8517,6 +8527,9 @@ plank:
   pod_pending_timeout: 10m0s
   pod_running_timeout: 48h0m0s
   pod_unscheduled_timeout: 5m0s
+  termination_condition_reasons:
+  - DeletionByPodGC
+  - DeletionByGCPControllerManager
 pod_namespace: default
 prowjob_namespace: default
 push_gateway:
@@ -8596,6 +8609,9 @@ plank:
   pod_pending_timeout: 10m0s
   pod_running_timeout: 48h0m0s
   pod_unscheduled_timeout: 5m0s
+  termination_condition_reasons:
+  - DeletionByPodGC
+  - DeletionByGCPControllerManager
 pod_namespace: default
 prowjob_namespace: default
 push_gateway:
@@ -8680,6 +8696,9 @@ plank:
   pod_pending_timeout: 10m0s
   pod_running_timeout: 48h0m0s
   pod_unscheduled_timeout: 5m0s
+  termination_condition_reasons:
+  - DeletionByPodGC
+  - DeletionByGCPControllerManager
 pod_namespace: default
 prowjob_namespace: default
 push_gateway:

--- a/pkg/config/jobs.go
+++ b/pkg/config/jobs.go
@@ -123,6 +123,11 @@ type JobBase struct {
 	// If this field is unspecified or false, a new pod will be created to replace
 	// the evicted one.
 	ErrorOnEviction bool `json:"error_on_eviction,omitempty"`
+	// ErrorOnTermination indicates that the ProwJob should be completed and given
+	// the ErrorState status if the pod that is executing the job is terminated.
+	// If this field is unspecified or false, a new pod will be created to replace
+	// the terminated one.
+	ErrorOnTermination bool `json:"error_on_termination,omitempty"`
 	// SourcePath contains the path where this job is defined
 	SourcePath string `json:"-"`
 	// Spec is the Kubernetes pod spec used if Agent is kubernetes.

--- a/pkg/config/prow-config-documented.yaml
+++ b/pkg/config/prow-config-documented.yaml
@@ -1345,6 +1345,13 @@ plank:
     # Use `org/repo`, `org` or `*` as a key.
     report_templates:
         "": ""
+    # TerminationConditionReasons is a set of pod status condition reasons on which the
+    # controller will match to determine if the pod's node is being terminated. If a node is being
+    # terminated the controller will restart the prowjob, unless the ErrorOnTermination option
+    # is set on the prowjob or the MaxRevivals option is reached.
+    # Defaults to ["DeletionByPodGC", "DeletionByGCPControllerManager"].
+    termination_condition_reasons:
+        - ""
 # PodNamespace is the namespace in the cluster that prow
 # components will use for looking up Pods owned by ProwJobs.
 # The namespace needs to exist and will not be created by prow.

--- a/pkg/pjutil/pjutil.go
+++ b/pkg/pjutil/pjutil.go
@@ -228,12 +228,13 @@ func specFromJobBase(jb config.JobBase) prowapi.ProwJobSpec {
 		namespace = *jb.Namespace
 	}
 	return prowapi.ProwJobSpec{
-		Job:             jb.Name,
-		Agent:           prowapi.ProwJobAgent(jb.Agent),
-		Cluster:         jb.Cluster,
-		Namespace:       namespace,
-		MaxConcurrency:  jb.MaxConcurrency,
-		ErrorOnEviction: jb.ErrorOnEviction,
+		Job:                jb.Name,
+		Agent:              prowapi.ProwJobAgent(jb.Agent),
+		Cluster:            jb.Cluster,
+		Namespace:          namespace,
+		MaxConcurrency:     jb.MaxConcurrency,
+		ErrorOnEviction:    jb.ErrorOnEviction,
+		ErrorOnTermination: jb.ErrorOnTermination,
 
 		ExtraRefs:        DecorateExtraRefs(jb.ExtraRefs, jb),
 		DecorationConfig: jb.DecorationConfig,


### PR DESCRIPTION
Recreated pods when we detect they failed due to its node shutting down.
This saves us from having to rerun jobs that were terminated due to a spot instance shutdown.

## Current behavior

Now, when a node is terminated, the prowjob fails (PJ gets in the FailureState).

## New behavior

The prowjob is now deleted and recreated (revived) when the node is terminated.

If the pod is revived more than what is allowed through the MaxRevivals config value, the prowjob errors (PJ gets in the ErrorState).

Additionally, the ErrorOnTermination option can be used to error a prowjob directly when the pod is terminated (PJ gets in the ErrorState).

## Detecting node termination

The pod status that we see on pods terminated due to a spot instance shutdown look like this:
```yaml
status:
  message: Pod was terminated in response to imminent node shutdown.
  phase: Failed
  reason: Terminated
```
or
```yaml
status:
  conditions:
  - message: 'PodGC: node no longer exists'
    reason: DeletionByPodGC
    status: "True"
    type: DisruptionTarget
  phase: Failed
```
or
```yaml
status:
  conditions:
  - message: 'GCPControllerManager: node no longer exists'
    reason: DeletionByGCPControllerManager
    status: "True"
    type: DisruptionTarget
  phase: Failed
```

The TerminationConditionReasons option allows users to modify what pod condition reason values are used to detect that the node was being terminated (defaults to "DeletionByPodGC" and "DeletionByGCPControllerManager").
