### PR TITLE
doc: Update `cmd`, `pkg`, & `test` paths (follow-up of #101)

### DIFF
--- a/site/content/en/docs/build-test-update.md
+++ b/site/content/en/docs/build-test-update.md
@@ -13,11 +13,11 @@ You can build, test, and deploy Prow’s binaries, container images, and cluster
 
 Build locally with:
 ```shell
-make -C prow build-images
+make build-images
 ```
 Push to remote with
 ```shell
-make -C prow push-images REGISTRY=<YOUR_REGISTRY>
+make push-images REGISTRY=<YOUR_REGISTRY>
 ```
 Unit test with:
 ```shell
@@ -25,12 +25,12 @@ make test
 ```
 Integration test with([more details](/docs/test/integration/)):
 ```shell
-./prow/test/integration/integration-test.sh
+./test/integration/integration-test.sh
 ```
 Individual packages and components can be built and tested like:
 ```shell
-go build ./prow/cmd/hook
-go test ./prow/plugins/lgtm
+go build ./cmd/hook
+go test ./pkg/plugins/lgtm
 ```
 (Note: `deck` depends on non-go static files, these were tested by integration
 tests, and for e2e test use [`runlocal`](https://github.com/kubernetes/test-infra/tree/master/prow/cmd/deck/runlocal) if desired.)
@@ -167,7 +167,7 @@ go run ./config:mkpj --job=JOB_NAME
 
 For your own prow instance:
 ```shell
-go run sigs.k8s.io/prow/pkg/cmd/mkpj --job=JOB_NAME --config-path=path/to/config.yaml
+go run sigs.k8s.io/prow/cmd/mkpj --job=JOB_NAME --config-path=path/to/config.yaml
 ```
 
 Alternatively, if you have jobs defined in a separate `job-config`, you can

--- a/site/content/en/docs/components/cli-tools/generic-autobumper.md
+++ b/site/content/en/docs/components/cli-tools/generic-autobumper.md
@@ -43,7 +43,7 @@ We need to fulfil those requirements to use this tool:
     to be used by this tool to push changes and create PRs against the remote repo.
 
 * a yaml config file that specifies the follwing information passed in with the flag -config=FILEPATH:
-* For info about what should go in the config look at [the documentation for the Options here](https://pkg.go.dev/sigs.k8s.io/prow/pkg/cmd/generic-autobumper/bumper#Options) and look at the example below.
+* For info about what should go in the config look at [the documentation for the Options here](https://pkg.go.dev/sigs.k8s.io/prow/cmd/generic-autobumper/bumper#Options) and look at the example below.
   
 e.g.,
 

--- a/site/content/en/docs/components/cli-tools/peribolos.md
+++ b/site/content/en/docs/components/cli-tools/peribolos.md
@@ -88,7 +88,7 @@ For more details please see GitHub documentation around [edit org], [update org 
 Peribolos can dump the current configuration to an org. For example you could dump the kubernetes org do the following:
 
 ```console
-$ go run ./prow/cmd/peribolos --dump kubernetes-sigs --github-token-path ~/github-token | tee ~/current.yaml
+$ go run ./cmd/peribolos --dump kubernetes-sigs --github-token-path ~/github-token | tee ~/current.yaml
 ...
 INFO: Build completed successfully, 1 total action
 ...
@@ -139,7 +139,7 @@ Open `~/current.yaml` and then delete any metadata you don't want peribolos to m
 Apply this config in dry-run mode to see what would happen (hopefully nothing since you just created it):
 
 ```console
-$ go run ./prow/cmd/peribolos --config-path ~/current.yaml --github-token-path ~/github-token # --confirm
+$ go run ./cmd/peribolos --config-path ~/current.yaml --github-token-path ~/github-token # --confirm
 
 {"client":"github","component":"peribolos","level":"info","msg":"GetOrg(kubernetes-sigs)","time":"2018-09-27T23:07:13Z"}
 {"client":"github","component":"peribolos","level":"info","msg":"ListOrgInvitations(kubernetes-sigs)","time":"2018-09-27T23:07:13Z"}
@@ -164,7 +164,7 @@ This flag is designed to protect against typos in the configuration which might 
 
 * `--confirm=false` - no github mutations will be made until this flag is true. It is safe to run the binary without this flag. It will print what it would do, without actually making any changes.
 
-See `go run ./prow/cmd/peribolos --help` for the full and current list of settings that can be configured with flags.
+See `go run ./cmd/peribolos --help` for the full and current list of settings that can be configured with flags.
 
 [`config.yaml`]: https://github.com/kubernetes/test-infra/tree/master/config/prow/config.yaml
 [edit team]: https://developer.github.com/v3/teams/#edit-team

--- a/site/content/en/docs/components/cli-tools/phaino.md
+++ b/site/content/en/docs/components/cli-tools/phaino.md
@@ -24,10 +24,10 @@ Usage:
 
 ```console
 # Use a job from deck
-go run ./prow/cmd/phaino $URL # or /path/to/prowjob.yaml
+go run ./cmd/phaino $URL # or /path/to/prowjob.yaml
 # Use mkpj to create the job
-go run ./prow/cmd/mkpj --config-path=/path/to/prow/config.yaml --job-config-path=/path/to/prow/job/configs --job=foo > /tmp/foo
-go run ./prow/cmd/phaino /tmp/foo
+go run ./cmd/mkpj --config-path=/path/to/prow/config.yaml --job-config-path=/path/to/prow/job/configs --job=foo > /tmp/foo
+go run ./cmd/phaino /tmp/foo
 ```
 
 Phaino is an interactive utility; it will prompt you for a local copy of any secrets or
@@ -86,7 +86,7 @@ it's desired to save the prompts, use the following tricks instead:
   --extra-envs=env1=val1,env2=val2
   ```
 
-See `go run ./prow/cmd/phaino --help` for full option list.
+See `go run ./cmd/phaino --help` for full option list.
 
 ### Usage examples
 
@@ -96,8 +96,8 @@ See `go run ./prow/cmd/phaino --help` for full option list.
 * Pick a job and click the rerun icon on the left
 * Copy the URL (something like `https://prow.k8s.io/rerun?prowjob=d08f1ca5-5d63-11e9-ab62-0a580a6c1281`)
 * Paste it as a phaino arg
-  * `go run ./prow/cmd/phaino https://prow.k8s.io/rerun?prowjob=d08f1ca5-5d63-11e9-ab62-0a580a6c1281`
-  * Alternatively `go run ./prow/cmd/phaino <(curl $URL)`
+  * `go run ./cmd/phaino https://prow.k8s.io/rerun?prowjob=d08f1ca5-5d63-11e9-ab62-0a580a6c1281`
+  * Alternatively `go run ./cmd/phaino <(curl $URL)`
 
 #### Configuration example
 
@@ -106,14 +106,14 @@ See `go run ./prow/cmd/phaino --help` for full option list.
 
       ```
       go run ./config:mkpj --job=pull-test-infra-bazel > /tmp/foo
-      go run ./prow/cmd/phaino /tmp/foo
+      go run ./cmd/phaino /tmp/foo
       ```
 
   * Other deployments will need to clone that rule and/or pass in extra flags:
 
       ```
-      go run ./prow/cmd/mkpj --config-path=/my/config.yaml --job=my-job
-      go run ./prow/cmd/phaino /tmp/foo
+      go run ./cmd/mkpj --config-path=/my/config.yaml --job=my-job
+      go run ./cmd/phaino /tmp/foo
       ```
 
 [ideas and forms]: https://en.wikipedia.org/wiki/Theory_of_forms#Forms

--- a/site/content/en/docs/components/cli-tools/phony.md
+++ b/site/content/en/docs/components/cli-tools/phony.md
@@ -15,7 +15,7 @@ To get an idea of `phony`'s behavior, start a local instance of `hook` with
 this:
 
 ```
-go run prow/cmd/hook/main.go \
+go run cmd/hook/main.go \
  --config-path=config/prow/config.yaml \
  --plugin-config=config/prow/plugins.yaml \
  --hmac-secret-file=path/to/hmac \

--- a/site/content/en/docs/components/core/deck/_index.md
+++ b/site/content/en/docs/components/core/deck/_index.md
@@ -7,7 +7,7 @@ description: >
 
 ## Running Deck locally
 
-Deck can be run locally by executing `./prow/cmd/deck/runlocal`. The scripts starts Deck via
+Deck can be run locally by executing `./cmd/deck/runlocal`. The scripts starts Deck via
 Bazel using:
 
 * pre-generated data (extracted from a running Prow instance)
@@ -23,7 +23,7 @@ VSCode or Intellij.
 
 ```bash
 # Prepare assets
-make -C prow build-tarball PROW_IMAGE=prow/cmd/deck
+make build-tarball PROW_IMAGE=cmd/deck
 mkdir -p /tmp/deck
 tar -xvf ./_bin/deck.tar -C /tmp/deck 
 cd /tmp/deck

--- a/site/content/en/docs/components/core/prow-controller-manager.md
+++ b/site/content/en/docs/components/core/prow-controller-manager.md
@@ -25,7 +25,7 @@ Only one of them may have more than zero replicas at the same time.
 
 ### Usage
 ```bash
-$ go run ./prow/cmd/prow-controller-manager --help
+$ go run ./cmd/prow-controller-manager --help
 ```
 
 ### Configuration

--- a/site/content/en/docs/components/deprecated/cm2kc.md
+++ b/site/content/en/docs/components/deprecated/cm2kc.md
@@ -12,7 +12,7 @@ description: >
 ## Usage
 
 ```shell
-go run ./prow/cmd/cm2kc <options>
+go run ./cmd/cm2kc <options>
 ```
 
 The following is a list of supported options for `cm2kc`:
@@ -36,7 +36,7 @@ The following command will:
 ```shell
 kubectl --context=my-context get secrets build-cluster -o jsonpath='{.data.cluster}' |
   base64 -d |
-  go run ./prow/cmd/cm2kc |
+  go run ./cmd/cm2kc |
   kubectl --context=my-context create secret generic kubeconfig --from-file=config=/dev/stdin
 ```
 
@@ -64,7 +64,7 @@ build:
 Execute `cm2kc` specifying an `--input` path to the *clustermap* file and an `--output` path to the desired location of the generated *kubeconfig* file:
 
 ```shell
-go run ./prow/cmd/cm2kc --input=/path/to/clustermap.yaml --output=/path/to/kubeconfig.yaml
+go run ./cmd/cm2kc --input=/path/to/clustermap.yaml --output=/path/to/kubeconfig.yaml
 ```
 
 The following *kubeconfig* file will be created at the specified `--output` path:  

--- a/site/content/en/docs/components/deprecated/plank.md
+++ b/site/content/en/docs/components/deprecated/plank.md
@@ -10,7 +10,7 @@ Plank is the controller that manages the job execution and lifecycle for jobs ru
 ### Usage
 
 ```bash
-go run ./prow/cmd/prow-controller-manager --help
+go run ./cmd/prow-controller-manager --help
 ```
 
 ### Configuration

--- a/site/content/en/docs/components/optional/branchprotector.md
+++ b/site/content/en/docs/components/optional/branchprotector.md
@@ -164,18 +164,18 @@ So in the example above:
 
 ### Run unit tests
 
-`go test ./prow/cmd/branchprotector`
+`go test ./cmd/branchprotector`
 
 ### Run locally
 
-`go run ./prow/cmd/branchprotector --help`, which will tell you about the
+`go run ./cmd/branchprotector --help`, which will tell you about the
 current flags.
 
 Do a dry run (which will not make any changes to github) with
 something like the following command:
 
 ```sh
-go run ./prow/cmd/branchprotector \
+go run ./cmd/branchprotector \
   --config-path=/path/to/config.yaml \
   --github-token-path=/path/to/my-github-token
 ```
@@ -188,11 +188,21 @@ This will say how the binary will actually change github if you add a
 Run things like the following:
 
 ```sh
-# Build image locally
-make -C prow push-single-image PROW_IMAGE=prow/cmd/branchprotector REGISTRY=<YOUR_REGISTRY>
+# Build image locally and push it to <YOUR_REGISTRY>
+make push-single-image PROW_IMAGE=cmd/branchprotector REGISTRY=<YOUR_REGISTRY>
 ```
 
-This will build an image with your local changes, push it to `<YOUR_REGISTRY>`
+This will build an image with your local changes, and push it to `<YOUR_REGISTRY>`.
+
+Or, if you just want to build an image but not to push, run the following:
+
+
+```sh
+# Build image locally
+make build-single-image PROW_IMAGE=cmd/branchprotector
+```
+
+This will build an image with your local changes, without pushing it to anywhere.
 
 ### Deploy cronjob to production
 

--- a/site/content/en/docs/components/optional/hmac.md
+++ b/site/content/en/docs/components/optional/hmac.md
@@ -26,7 +26,7 @@ There are two ways to run this tool:
 1. Run it on local:
 
 ```sh
-go run ./prow/cmd/hmac \
+go run ./cmd/hmac \
   --config-path=/path/to/prow/config \
   --github-token-path=/path/to/oauth/secret \
   --kubeconfig=/path/to/kubeconfig \

--- a/site/content/en/docs/components/optional/tot/fallbackcheck.md
+++ b/site/content/en/docs/components/optional/tot/fallbackcheck.md
@@ -15,7 +15,7 @@ It ignores jobs that have no GCS buckets.
 ## Install
 
 ```shell
-go get sigs.k8s.io/prow/pkg/cmd/tot/fallbackcheck
+go get sigs.k8s.io/prow/cmd/tot/fallbackcheck
 ```
 
 ## Run

--- a/site/content/en/docs/getting-started-deploy.md
+++ b/site/content/en/docs/getting-started-deploy.md
@@ -399,7 +399,7 @@ presubmits:
 Again, run the following to test the files, replacing the paths as necessary:
 
 ```sh
-$ go run ./prow/cmd/checkconfig --plugin-config=path/to/plugins.yaml --config-path=path/to/config.yaml
+$ go run ./cmd/checkconfig --plugin-config=path/to/plugins.yaml --config-path=path/to/config.yaml
 ```
 
 Now run the following to update the configmap.

--- a/site/content/en/docs/spyglass/write-a-lens.md
+++ b/site/content/en/docs/spyglass/write-a-lens.md
@@ -73,7 +73,7 @@ import (
 )
 ```
 
-Finally, you can then test it by running `./prow/cmd/deck/runlocal` and loading a spyglass page.
+Finally, you can then test it by running `./cmd/deck/runlocal` and loading a spyglass page.
 
 ## Lens frontend
 

--- a/site/content/en/docs/test/integration/_index.md
+++ b/site/content/en/docs/test/integration/_index.md
@@ -8,32 +8,32 @@ description: >
 ## Run all integration tests
 
 ```bash
-./prow/test/integration/integration-test.sh
+./test/integration/integration-test.sh
 ```
 
 ## Run a specific integration test
 
 ```bash
-./prow/test/integration/integration-test.sh -run=TestIWantToRun
+./test/integration/integration-test.sh -run=TestIWantToRun
 ```
 
 ## Cleanup
 
 ```bash
-./prow/test/integration/teardown.sh -all
+./test/integration/teardown.sh -all
 ```
 
 # Adding new integration tests
 
 ## New component
 
-Assume we want to add `most-awesome-component` (source code in `prow/cmd/most-awesome-component`).
+Assume we want to add `most-awesome-component` (source code in `cmd/most-awesome-component`).
 
 1. Add `most-awesome-component` to the `PROW_COMPONENTS`, `PROW_IMAGES`, and
    `PROW_IMAGES_TO_COMPONENTS` variables in [lib.sh](https://github.com/kubernetes/test-infra/tree/master/prow/test/integration/lib.sh).
 
    - Add the line `most-awesome-component` to `PROW_COMPONENTS`.
-   - Add the line `[most-awesome-component]=prow/cmd/most-awesome-component` to `PROW_IMAGES`.
+   - Add the line `[most-awesome-component]=cmd/most-awesome-component` to `PROW_IMAGES`.
    - Add the line `[most-awesome-component]=most-awesome-component` to `PROW_IMAGES_TO_COMPONENTS`.
    - Explanation: `PROW_COMPONENTS` lists which components are deployed into the
      cluster, `PROW_IMAGES` describes where the source code is located for each
@@ -42,7 +42,7 @@ Assume we want to add `most-awesome-component` (source code in `prow/cmd/most-aw
      framework knows what to redeploy depending on what image has changed). As an
      example, the `deck` and `deck-tenanted` components (in `PROW_COMPONENTS`)
      both use the `deck` image (defined in `PROW_IMAGES_TO_COMPONENTS`), so they
-     are both redeployed every time you change something in `prow/cmd/deck`
+     are both redeployed every time you change something in `cmd/deck`
      (defined in `PROW_IMAGES`).
 
 2. Set up Kubernetes Deployment and Service configurations inside the
@@ -67,13 +67,13 @@ tests in `most-awesome-component_test.go`
 ## Check that your new test is working
 
 1. Add or edit new tests (e.g., `func TestMostAwesomeComponent(t *testing.T) {...}`) in `most-awesome-component_test.go`.
-2. Run `./prow/test/integration/integration-test.sh -run=TestMostAwesomeComponent` to bring up the test cluster and to only test
+2. Run `./test/integration/integration-test.sh -run=TestMostAwesomeComponent` to bring up the test cluster and to only test
    your new test named `TestMostAwesomeComponent`.
 3. If you need to make changes to `most-awesome-component_test.go` (and not the
-   component itself), run `./prow/test/integration/integration-test.sh -run=TestMostAwesomeComponent -no-setup`. The `-no-setup` will ensure that
+   component itself), run `./test/integration/integration-test.sh -run=TestMostAwesomeComponent -no-setup`. The `-no-setup` will ensure that
    the test framework avoid redeploying the test cluster.
    - If you **do** need to make changes to the Prow component, run
-     `./prow/test/integration/integration-test.sh -run=TestMostAwesomeComponent -build=most-awesome-component` so that `prow/cmd/most-awesome-component` is
+     `./test/integration/integration-test.sh -run=TestMostAwesomeComponent -build=most-awesome-component` so that `cmd/most-awesome-component` is
      recompiled and redeployed into the cluster before running
      `TestMostAwesomeComponent`.
 


### PR DESCRIPTION
The PR #101 has moved `cmd`, `pkg`, & `test` directories which was in `prow/`, to the root of the repo.

This PR is a follow-up of #101, updating `cmd`, `pkg`, & `test` paths in docs.

Note: Outdated URLs will be updated in other PR (#103).