### PR TITLE
[peribolos] only log caller when log level is raised

### DIFF
--- a/cmd/peribolos/main.go
+++ b/cmd/peribolos/main.go
@@ -100,6 +100,13 @@ func (o *options) parseArgs(flags *flag.FlagSet, args []string) error {
 		return err
 	}
 
+	level, err := logrus.ParseLevel(o.logLevel)
+	if err != nil {
+		return fmt.Errorf("--log-level invalid: %w", err)
+	}
+	logrus.SetLevel(level)
+	logrus.SetReportCaller(level >= logrus.DebugLevel)
+
 	if err := o.github.Validate(!o.confirm); err != nil {
 		return err
 	}
@@ -137,12 +144,6 @@ func (o *options) parseArgs(flags *flag.FlagSet, args []string) error {
 	if o.fixTeamRepos && !o.fixTeams {
 		return fmt.Errorf("--fix-team-repos requires --fix-teams")
 	}
-
-	level, err := logrus.ParseLevel(o.logLevel)
-	if err != nil {
-		return fmt.Errorf("--log-level invalid: %w", err)
-	}
-	logrus.SetLevel(level)
 
 	return nil
 }


### PR DESCRIPTION
Having the caller on the info level makes it impossible to disable the extra context information. That's unfortunate because as a user of Peribolos the additional `func` and `file` fields make the log harder to read than necessary.

I think a good compromise would be to only include the caller info on the debug level.