### PR TITLE
build images using cloudbuild

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,9 @@
 # Prow
+[![Go Reference](https://pkg.go.dev/badge/sigs.k8s.io/prow.svg)](https://pkg.go.dev/sigs.k8s.io/prow)
+[![Go Report Card](https://goreportcard.com/badge/sigs.k8s.io/prow)](https://goreportcard.com/report/sigs.k8s.io/prow)
+[![LICENSE](https://img.shields.io/github/license/kubernetes-sigs/prow.svg)](https://github.com/kubernetes-sigs/prow/blob/main/LICENSE)
+[![Slack Status](https://img.shields.io/badge/slack-join_chat-white.svg?logo=slack&style=social)](https://kubernetes.slack.com/archives/CDECRSC5U)
+
 ![Prow Logo](./site/static/images/logo-horizontal.svg)
 
 The source code and statically generated docs for Prow live here. Historically Prow was developed in [kubernetes/test-infra](https://github.com/kubernetes/test-infra) along with other things, but the source code was moved here on April 9, 2024.

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,23 @@
+# See https://cloud.google.com/cloud-build/docs/build-config
+timeout: 3600s
+options:
+  substitution_option: ALLOW_LOOSE
+  machineType: 'E2_HIGHCPU_32'
+steps:
+  - name: us-central1-docker.pkg.dev/k8s-staging-test-infra/images/kubekins-e2e:latest-master
+    entrypoint: runner.sh
+    env:
+    - GIT_TAG=$_GIT_TAG
+    - BASE_REF=$_PULL_BASE_REF
+    - COMMIT=$_PULL_BASE_SHA
+    - REGISTRY=us-docker.pkg.dev/k8s-infra-prow/images
+    args:
+    - make 
+    - push-images
+# Unlike a typical image staging project, the images are being published to a privileged prod project
+# GCB is only configured to launch jobs with the specified service account.
+serviceAccount: image-builder@k8s-infra-prow.iam.gserviceaccount.com
+substitutions:
+  _GIT_TAG: "12345"
+  _PULL_BASE_REF: "main"
+  _PULL_BASE_SHA: 'abcdef'


### PR DESCRIPTION
Part of https://github.com/kubernetes-sigs/prow/issues/113 
Part of https://github.com/kubernetes/k8s.io/pull/6740

Right now, our postsubmit job [runs](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/post-push-prow/1781305980542259200) in a pod which breaks our trusted cluster build policies.

I tested this build at https://console.cloud.google.com/cloud-build/builds;region=global/ce637e5c-b605-490f-b104-589b7dca23c6?project=k8s-infra-ii-sandbox

@BenTheElder @ameukam 