### PR TITLE
Remove deprecated GitHub client functions

### DIFF
--- a/pkg/github/client.go
+++ b/pkg/github/client.go
@@ -202,7 +202,6 @@ type TeamClient interface {
 	ListTeamMembersBySlug(org, teamSlug, role string) ([]TeamMember, error)
 	ListTeamReposBySlug(org, teamSlug string) ([]Repo, error)
 	UpdateTeamRepoBySlug(org, teamSlug, repo string, permission TeamPermission) error
-	RemoveTeamRepo(id int, org, repo string) error
 	RemoveTeamRepoBySlug(org, teamSlug, repo string) error
 	ListTeamInvitations(org string, id int) ([]OrgInvitation, error)
 	ListTeamInvitationsBySlug(org, teamSlug string) ([]OrgInvitation, error)
@@ -3823,34 +3822,6 @@ func (c *client) UpdateTeamRepoBySlug(org, teamSlug, repo string, permission Tea
 		org:         org,
 		requestBody: &data,
 		exitCodes:   []int{204},
-	}, nil)
-	return err
-}
-
-// RemoveTeamRepo removes the team from the repo.
-//
-// https://docs.github.com/en/rest/reference/teams#remove-a-repository-from-a-team-legacy
-// Deprecated: please use RemoveTeamRepoBySlug
-func (c *client) RemoveTeamRepo(id int, org, repo string) error {
-	c.logger.WithField("methodName", "RemoveTeamRepo").
-		Warn("method is deprecated, and will result in multiple api calls to achieve result")
-	durationLogger := c.log("RemoveTeamRepo", id, org, repo)
-	defer durationLogger()
-
-	if c.fake || c.dry {
-		return nil
-	}
-
-	organization, err := c.GetOrg(org)
-	if err != nil {
-		return err
-	}
-
-	_, err = c.request(&request{
-		method:    http.MethodDelete,
-		path:      fmt.Sprintf("/organizations/%d/team/%d/repos/%s/%s", organization.Id, id, org, repo),
-		org:       org,
-		exitCodes: []int{204},
 	}, nil)
 	return err
 }

--- a/pkg/github/client.go
+++ b/pkg/github/client.go
@@ -194,7 +194,6 @@ type RepositoryClient interface {
 type TeamClient interface {
 	CreateTeam(org string, team Team) (*Team, error)
 	EditTeam(org string, t Team) (*Team, error)
-	DeleteTeam(org string, id int) error
 	DeleteTeamBySlug(org, teamSlug string) error
 	ListTeams(org string) ([]Team, error)
 	UpdateTeamMembership(org string, id int, user string, maintainer bool) (*TeamMembership, error)
@@ -3593,31 +3592,6 @@ func (c *client) EditTeam(org string, t Team) (*Team, error) {
 		exitCodes:   []int{200, 201},
 	}, &retTeam)
 	return &retTeam, err
-}
-
-// DeleteTeam removes team.ID from GitHub.
-//
-// See https://developer.github.com/v3/teams/#delete-team
-// Deprecated: please use DeleteTeamBySlug
-func (c *client) DeleteTeam(org string, id int) error {
-	c.logger.WithField("methodName", "DeleteTeam").
-		Warn("method is deprecated, and will result in multiple api calls to achieve result")
-	durationLogger := c.log("DeleteTeam", org, id)
-	defer durationLogger()
-
-	organization, err := c.GetOrg(org)
-	if err != nil {
-		return err
-	}
-
-	path := fmt.Sprintf("/organizations/%d/team/%d", organization.Id, id)
-	_, err = c.request(&request{
-		method:    http.MethodDelete,
-		path:      path,
-		org:       org,
-		exitCodes: []int{204},
-	}, nil)
-	return err
 }
 
 // DeleteTeamBySlug removes team.Slug from GitHub.

--- a/pkg/github/client.go
+++ b/pkg/github/client.go
@@ -203,7 +203,6 @@ type TeamClient interface {
 	ListTeamReposBySlug(org, teamSlug string) ([]Repo, error)
 	UpdateTeamRepoBySlug(org, teamSlug, repo string, permission TeamPermission) error
 	RemoveTeamRepoBySlug(org, teamSlug, repo string) error
-	ListTeamInvitations(org string, id int) ([]OrgInvitation, error)
 	ListTeamInvitationsBySlug(org, teamSlug string) ([]OrgInvitation, error)
 	TeamHasMember(org string, teamID int, memberLogin string) (bool, error)
 	TeamBySlugHasMember(org string, teamSlug string, memberLogin string) (bool, error)
@@ -3844,44 +3843,6 @@ func (c *client) RemoveTeamRepoBySlug(org, teamSlug, repo string) error {
 		exitCodes: []int{204},
 	}, nil)
 	return err
-}
-
-// ListTeamInvitations gets a list of team members with pending invitations for the
-// given team id
-//
-// https://developer.github.com/v3/teams/members/#list-pending-team-invitations
-// Deprecated: please use ListTeamInvitationsBySlug
-func (c *client) ListTeamInvitations(org string, id int) ([]OrgInvitation, error) {
-	c.logger.WithField("methodName", "ListTeamInvitations").
-		Warn("method is deprecated, and will result in multiple api calls to achieve result")
-	durationLogger := c.log("ListTeamInvitations", org, id)
-	defer durationLogger()
-
-	if c.fake {
-		return nil, nil
-	}
-
-	organization, err := c.GetOrg(org)
-	if err != nil {
-		return nil, err
-	}
-	path := fmt.Sprintf("/organizations/%d/team/%d/invitations", organization.Id, id)
-	var ret []OrgInvitation
-	err = c.readPaginatedResults(
-		path,
-		acceptNone,
-		org,
-		func() interface{} {
-			return &[]OrgInvitation{}
-		},
-		func(obj interface{}) {
-			ret = append(ret, *(obj.(*[]OrgInvitation))...)
-		},
-	)
-	if err != nil {
-		return nil, err
-	}
-	return ret, nil
 }
 
 // ListTeamInvitationsBySlug gets a list of team members with pending invitations for the given team slug

--- a/pkg/github/client.go
+++ b/pkg/github/client.go
@@ -197,7 +197,6 @@ type TeamClient interface {
 	DeleteTeamBySlug(org, teamSlug string) error
 	ListTeams(org string) ([]Team, error)
 	UpdateTeamMembershipBySlug(org, teamSlug, user string, maintainer bool) (*TeamMembership, error)
-	RemoveTeamMembership(org string, id int, user string) error
 	RemoveTeamMembershipBySlug(org, teamSlug, user string) error
 	ListTeamMembers(org string, id int, role string) ([]TeamMember, error)
 	ListTeamMembersBySlug(org, teamSlug, role string) ([]TeamMember, error)
@@ -3669,34 +3668,6 @@ func (c *client) UpdateTeamMembershipBySlug(org, teamSlug, user string, maintain
 		exitCodes:   []int{200},
 	}, &tm)
 	return &tm, err
-}
-
-// RemoveTeamMembership removes the user from the team (but not the org).
-//
-// https://developer.github.com/v3/teams/members/#remove-team-member
-// Deprecated: please use RemoveTeamMembershipBySlug
-func (c *client) RemoveTeamMembership(org string, id int, user string) error {
-	c.logger.WithField("methodName", "RemoveTeamMembership").
-		Warn("method is deprecated, and will result in multiple api calls to achieve result")
-	durationLogger := c.log("RemoveTeamMembership", org, id, user)
-	defer durationLogger()
-
-	if c.fake {
-		return nil
-	}
-
-	organization, err := c.GetOrg(org)
-	if err != nil {
-		return err
-	}
-
-	_, err = c.request(&request{
-		method:    http.MethodDelete,
-		path:      fmt.Sprintf("/organizations/%d/team/%d/memberships/%s", organization.Id, id, user),
-		org:       org,
-		exitCodes: []int{204},
-	}, nil)
-	return err
 }
 
 // RemoveTeamMembershipBySlug removes the user from the team (but not the org).

--- a/pkg/github/client.go
+++ b/pkg/github/client.go
@@ -201,7 +201,6 @@ type TeamClient interface {
 	ListTeamMembers(org string, id int, role string) ([]TeamMember, error)
 	ListTeamMembersBySlug(org, teamSlug, role string) ([]TeamMember, error)
 	ListTeamReposBySlug(org, teamSlug string) ([]Repo, error)
-	UpdateTeamRepo(id int, org, repo string, permission TeamPermission) error
 	UpdateTeamRepoBySlug(org, teamSlug, repo string, permission TeamPermission) error
 	RemoveTeamRepo(id int, org, repo string) error
 	RemoveTeamRepoBySlug(org, teamSlug, repo string) error
@@ -3799,41 +3798,6 @@ func (c *client) ListTeamReposBySlug(org, teamSlug string) ([]Repo, error) {
 		return nil, err
 	}
 	return repos, nil
-}
-
-// UpdateTeamRepo adds the repo to the team with the provided role.
-//
-// https://developer.github.com/v3/teams/#add-or-update-team-repository
-// Deprecated: please use UpdateTeamRepoBySlug
-func (c *client) UpdateTeamRepo(id int, org, repo string, permission TeamPermission) error {
-	c.logger.WithField("methodName", "UpdateTeamRepo").
-		Warn("method is deprecated, and will result in multiple api calls to achieve result")
-	durationLogger := c.log("UpdateTeamRepo", id, org, repo, permission)
-	defer durationLogger()
-
-	if c.fake || c.dry {
-		return nil
-	}
-
-	organization, err := c.GetOrg(org)
-	if err != nil {
-		return err
-	}
-
-	data := struct {
-		Permission string `json:"permission"`
-	}{
-		Permission: string(permission),
-	}
-
-	_, err = c.request(&request{
-		method:      http.MethodPut,
-		path:        fmt.Sprintf("/organizations/%d/team/%d/repos/%s/%s", organization.Id, id, org, repo),
-		org:         org,
-		requestBody: &data,
-		exitCodes:   []int{204},
-	}, nil)
-	return err
 }
 
 // UpdateTeamRepoBySlug adds the repo to the team with the provided role.

--- a/pkg/github/client_test.go
+++ b/pkg/github/client_test.go
@@ -2895,43 +2895,6 @@ func TestAuthHeaderGetsSet(t *testing.T) {
 	}
 }
 
-func TestListTeamRepos(t *testing.T) {
-	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodGet {
-			t.Errorf("Bad method: %s", r.Method)
-		}
-
-		var result interface{}
-		switch r.URL.Path {
-		case "/organizations/1/team/1/repos":
-			result = []Repo{
-				{Name: "repo-bar", Permissions: RepoPermissions{Pull: true}},
-				{Name: "repo-invalid-permission-level"}}
-		case "/orgs/orgName":
-			result = Organization{Login: "orgName", Id: 1}
-		default:
-			t.Errorf("Bad request path: %s", r.URL.Path)
-			return
-		}
-
-		b, err := json.Marshal(result)
-		if err != nil {
-			t.Fatalf("Didn't expect error: %v", err)
-		}
-		fmt.Fprint(w, string(b))
-	}))
-	defer ts.Close()
-	c := getClient(ts.URL)
-	repos, err := c.ListTeamRepos("orgName", 1)
-	if err != nil {
-		t.Errorf("Didn't expect error: %v", err)
-	} else if len(repos) != 1 {
-		t.Errorf("Expected one repo, found %d: %v", len(repos), repos)
-	} else if repos[0].Name != "repo-bar" {
-		t.Errorf("Wrong repos: %v", repos)
-	}
-}
-
 func TestListTeamReposBySlug(t *testing.T) {
 	ts := simpleTestServer(t, "/orgs/orgName/teams/team-name/repos", []Repo{
 		{Name: "repo-bar", Permissions: RepoPermissions{Pull: true}},


### PR DESCRIPTION
This removes all deprecated functions in the GitHub client that are already unused. Some, like ListTeamMembers, are still required for deprecated configuration options, which I did not want to touch in this PR.