### PR TITLE
Fix typos throughout the repository

### DIFF
--- a/cmd/branchprotector/protect_test.go
+++ b/cmd/branchprotector/protect_test.go
@@ -1178,7 +1178,7 @@ branch-protection:
         unauthorized-app:
           restrictions:
             apps:
-            - nocontent-app  
+            - nocontent-app
         unauthorized-collaborator:
           restrictions:
             users:
@@ -2504,7 +2504,7 @@ func TestValidateRequest(t *testing.T) {
 			errs: []error{fmt.Errorf("the following apps are not authorized for %s/%s: [%s]", "org", "repo", "bar")},
 		},
 		{
-			name: "restrict to unathorized collaborator results in error",
+			name: "restrict to unauthorized collaborator results in error",
 			request: &github.BranchProtectionRequest{
 				Restrictions: &github.RestrictionsRequest{
 					Users: &[]string{"foo"},

--- a/cmd/checkconfig/main.go
+++ b/cmd/checkconfig/main.go
@@ -413,7 +413,8 @@ func validate(o options) error {
 		}
 	}
 
-	if o.warningEnabled(validateSupplementalProwConfigOrgRepoHierarchy) {
+	// include the deprecated spelling to keep backwards-compatibility
+	if o.warningEnabled(validateSupplementalProwConfigOrgRepoHierarchy) || o.warningEnabled("validate-supplemental-prow-config-hirarchy") {
 		if err := validateAdditionalProwConfigIsInOrgRepoDirectoryStructure(os.DirFS("./"), o.config.SupplementalProwConfigDirs.Strings(), o.pluginsConfig.SupplementalPluginsConfigDirs.Strings(), o.config.SupplementalProwConfigsFileNameSuffix, o.pluginsConfig.SupplementalPluginsConfigsFileNameSuffix); err != nil {
 			errs = append(errs, err)
 		}

--- a/cmd/checkconfig/main.go
+++ b/cmd/checkconfig/main.go
@@ -100,29 +100,29 @@ func (o *options) warningEnabled(warning string) bool {
 }
 
 const (
-	mismatchedTideWarning                         = "mismatched-tide"
-	mismatchedTideLenientWarning                  = "mismatched-tide-lenient"
-	tideStrictBranchWarning                       = "tide-strict-branch"
-	tideContextPolicy                             = "tide-context-policy"
-	nonDecoratedJobsWarning                       = "non-decorated-jobs"
-	validDecorationConfigWarning                  = "valid-decoration-config"
-	jobNameLengthWarning                          = "long-job-names"
-	jobRefsDuplicationWarning                     = "duplicate-job-refs"
-	needsOkToTestWarning                          = "needs-ok-to-test"
-	managedWebhooksWarning                        = "managed-webhooks"
-	validateOwnersWarning                         = "validate-owners"
-	missingTriggerWarning                         = "missing-trigger"
-	validateURLsWarning                           = "validate-urls"
-	unknownFieldsWarning                          = "unknown-fields"
-	unknownFieldsAllWarning                       = "unknown-fields-all" // Superset of "unknown-fields" that includes validating job config.
-	verifyOwnersFilePresence                      = "verify-owners-presence"
-	validateClusterFieldWarning                   = "validate-cluster-field"
-	validateSupplementalProwConfigOrgRepoHirarchy = "validate-supplemental-prow-config-hirarchy"
-	validateUnmanagedBranchConfigHasNoSubconfig   = "validate-unmanaged-branchconfig-has-no-subconfig"
-	validateGitHubAppInstallationWarning          = "validate-github-app-installation"
-	validateLabelWarning                          = "validate-label"
-	requiredJobAnnotationsWarning                 = "required-job-annotations"
-	periodicDefaultCloneWarning                   = "periodic-default-clone-config"
+	mismatchedTideWarning                          = "mismatched-tide"
+	mismatchedTideLenientWarning                   = "mismatched-tide-lenient"
+	tideStrictBranchWarning                        = "tide-strict-branch"
+	tideContextPolicy                              = "tide-context-policy"
+	nonDecoratedJobsWarning                        = "non-decorated-jobs"
+	validDecorationConfigWarning                   = "valid-decoration-config"
+	jobNameLengthWarning                           = "long-job-names"
+	jobRefsDuplicationWarning                      = "duplicate-job-refs"
+	needsOkToTestWarning                           = "needs-ok-to-test"
+	managedWebhooksWarning                         = "managed-webhooks"
+	validateOwnersWarning                          = "validate-owners"
+	missingTriggerWarning                          = "missing-trigger"
+	validateURLsWarning                            = "validate-urls"
+	unknownFieldsWarning                           = "unknown-fields"
+	unknownFieldsAllWarning                        = "unknown-fields-all" // Superset of "unknown-fields" that includes validating job config.
+	verifyOwnersFilePresence                       = "verify-owners-presence"
+	validateClusterFieldWarning                    = "validate-cluster-field"
+	validateSupplementalProwConfigOrgRepoHierarchy = "validate-supplemental-prow-config-hierarchy"
+	validateUnmanagedBranchConfigHasNoSubconfig    = "validate-unmanaged-branchconfig-has-no-subconfig"
+	validateGitHubAppInstallationWarning           = "validate-github-app-installation"
+	validateLabelWarning                           = "validate-label"
+	requiredJobAnnotationsWarning                  = "required-job-annotations"
+	periodicDefaultCloneWarning                    = "periodic-default-clone-config"
 
 	defaultHourlyTokens = 3000
 	defaultAllowedBurst = 100
@@ -143,7 +143,7 @@ var defaultWarnings = []string{
 	validateURLsWarning,
 	unknownFieldsWarning,
 	validateClusterFieldWarning,
-	validateSupplementalProwConfigOrgRepoHirarchy,
+	validateSupplementalProwConfigOrgRepoHierarchy,
 	validateUnmanagedBranchConfigHasNoSubconfig,
 	validateLabelWarning,
 	requiredJobAnnotationsWarning,
@@ -413,7 +413,7 @@ func validate(o options) error {
 		}
 	}
 
-	if o.warningEnabled(validateSupplementalProwConfigOrgRepoHirarchy) {
+	if o.warningEnabled(validateSupplementalProwConfigOrgRepoHierarchy) {
 		if err := validateAdditionalProwConfigIsInOrgRepoDirectoryStructure(os.DirFS("./"), o.config.SupplementalProwConfigDirs.Strings(), o.pluginsConfig.SupplementalPluginsConfigDirs.Strings(), o.config.SupplementalProwConfigsFileNameSuffix, o.pluginsConfig.SupplementalPluginsConfigsFileNameSuffix); err != nil {
 			errs = append(errs, err)
 		}
@@ -1099,7 +1099,7 @@ func verifyLabelPlugin(label plugins.Label) error {
 	restrictedAndAdditionalLabels := make(map[string][]string)
 	for orgRepo, restrictedLabels := range label.RestrictedLabels {
 		for _, restrictedLabel := range restrictedLabels {
-			if label.IsRestrictedLabelInAdditionalLables(restrictedLabel.Label) {
+			if label.IsRestrictedLabelInAdditionalLabels(restrictedLabel.Label) {
 				restrictedAndAdditionalLabels[restrictedLabel.Label] = append(restrictedAndAdditionalLabels[restrictedLabel.Label], orgRepo)
 			}
 			if restrictedLabel.Label == "" {
@@ -1257,7 +1257,7 @@ func validateCluster(cfg *config.Config, opener io.Opener) error {
 			}
 			statuses = map[string]plank.ClusterStatus{}
 			if err := json.Unmarshal(b, &statuses); err != nil {
-				return fmt.Errorf("error unmarshaling build cluster status file: %w", err)
+				return fmt.Errorf("error unmarshalling build cluster status file: %w", err)
 			}
 		}
 	}

--- a/cmd/checkconfig/main_test.go
+++ b/cmd/checkconfig/main_test.go
@@ -1583,7 +1583,7 @@ func TestValidateInRepoConfig(t *testing.T) {
 			name:         "unknown field prowYAML fails strict validation",
 			strict:       true,
 			prowYAMLData: []byte(`presubmits: [{"name": "hans", "never_run": "true", "spec": {"containers": [{}]}}]`),
-			expectedErr:  "error unmarshalling JSON: while decoding JSON: json: unknown field \"never_run\"",
+			expectedErr:  "error unmarshaling JSON: while decoding JSON: json: unknown field \"never_run\"",
 		},
 	}
 
@@ -2032,7 +2032,7 @@ plugins:
 				root + "/my-org/cfg.yaml":     invalidConfig,
 				root + "/my-org/plugins.yaml": invalidConfig,
 			}),
-			expectedErrorMessage: `[failed to unmarshal root/my-org/cfg.yaml into *config.Config: error unmarshalling JSON: while decoding JSON: json: cannot unmarshal array into Go value of type config.Config, failed to unmarshal root/my-org/plugins.yaml into *plugins.Configuration: error unmarshalling JSON: while decoding JSON: json: cannot unmarshal array into Go value of type plugins.Configuration]`,
+			expectedErrorMessage: `[failed to unmarshal root/my-org/cfg.yaml into *config.Config: error unmarshaling JSON: while decoding JSON: json: cannot unmarshal array into Go value of type config.Config, failed to unmarshal root/my-org/plugins.yaml into *plugins.Configuration: error unmarshaling JSON: while decoding JSON: json: cannot unmarshal array into Go value of type plugins.Configuration]`,
 		},
 		{
 			name: "Repo config at org level",
@@ -2063,7 +2063,7 @@ plugins:
 				root + "/my-org/my-repo/cfg.yaml":     invalidConfig,
 				root + "/my-org/my-repo/plugins.yaml": invalidConfig,
 			}),
-			expectedErrorMessage: `[failed to unmarshal root/my-org/my-repo/cfg.yaml into *config.Config: error unmarshalling JSON: while decoding JSON: json: cannot unmarshal array into Go value of type config.Config, failed to unmarshal root/my-org/my-repo/plugins.yaml into *plugins.Configuration: error unmarshalling JSON: while decoding JSON: json: cannot unmarshal array into Go value of type plugins.Configuration]`,
+			expectedErrorMessage: `[failed to unmarshal root/my-org/my-repo/cfg.yaml into *config.Config: error unmarshaling JSON: while decoding JSON: json: cannot unmarshal array into Go value of type config.Config, failed to unmarshal root/my-org/my-repo/plugins.yaml into *plugins.Configuration: error unmarshaling JSON: while decoding JSON: json: cannot unmarshal array into Go value of type plugins.Configuration]`,
 		},
 		{
 			name: "Org config at repo level",

--- a/cmd/checkconfig/main_test.go
+++ b/cmd/checkconfig/main_test.go
@@ -452,7 +452,7 @@ triggers:
 			expectedErr: "repoz",
 		},
 		// Options like DisallowUnknownFields can not be passed when using
-		// a custon json.Unmarshaler like we do here for defaulting:
+		// a custom json.Unmarshaler like we do here for defaulting:
 		// https://github.com/golang/go/issues/41144
 		//		{
 		//			name:     "invalid map entry",
@@ -1583,7 +1583,7 @@ func TestValidateInRepoConfig(t *testing.T) {
 			name:         "unknown field prowYAML fails strict validation",
 			strict:       true,
 			prowYAMLData: []byte(`presubmits: [{"name": "hans", "never_run": "true", "spec": {"containers": [{}]}}]`),
-			expectedErr:  "error unmarshaling JSON: while decoding JSON: json: unknown field \"never_run\"",
+			expectedErr:  "error unmarshalling JSON: while decoding JSON: json: unknown field \"never_run\"",
 		},
 	}
 
@@ -2032,7 +2032,7 @@ plugins:
 				root + "/my-org/cfg.yaml":     invalidConfig,
 				root + "/my-org/plugins.yaml": invalidConfig,
 			}),
-			expectedErrorMessage: `[failed to unmarshal root/my-org/cfg.yaml into *config.Config: error unmarshaling JSON: while decoding JSON: json: cannot unmarshal array into Go value of type config.Config, failed to unmarshal root/my-org/plugins.yaml into *plugins.Configuration: error unmarshaling JSON: while decoding JSON: json: cannot unmarshal array into Go value of type plugins.Configuration]`,
+			expectedErrorMessage: `[failed to unmarshal root/my-org/cfg.yaml into *config.Config: error unmarshalling JSON: while decoding JSON: json: cannot unmarshal array into Go value of type config.Config, failed to unmarshal root/my-org/plugins.yaml into *plugins.Configuration: error unmarshalling JSON: while decoding JSON: json: cannot unmarshal array into Go value of type plugins.Configuration]`,
 		},
 		{
 			name: "Repo config at org level",
@@ -2063,7 +2063,7 @@ plugins:
 				root + "/my-org/my-repo/cfg.yaml":     invalidConfig,
 				root + "/my-org/my-repo/plugins.yaml": invalidConfig,
 			}),
-			expectedErrorMessage: `[failed to unmarshal root/my-org/my-repo/cfg.yaml into *config.Config: error unmarshaling JSON: while decoding JSON: json: cannot unmarshal array into Go value of type config.Config, failed to unmarshal root/my-org/my-repo/plugins.yaml into *plugins.Configuration: error unmarshaling JSON: while decoding JSON: json: cannot unmarshal array into Go value of type plugins.Configuration]`,
+			expectedErrorMessage: `[failed to unmarshal root/my-org/my-repo/cfg.yaml into *config.Config: error unmarshalling JSON: while decoding JSON: json: cannot unmarshal array into Go value of type config.Config, failed to unmarshal root/my-org/my-repo/plugins.yaml into *plugins.Configuration: error unmarshalling JSON: while decoding JSON: json: cannot unmarshal array into Go value of type plugins.Configuration]`,
 		},
 		{
 			name: "Org config at repo level",

--- a/cmd/deck/main.go
+++ b/cmd/deck/main.go
@@ -218,7 +218,7 @@ func init() {
 	prometheus.MustRegister(httpResponseSize)
 }
 
-var simplifier = simplifypath.NewSimplifier(l("", // shadow element mimicing the root
+var simplifier = simplifypath.NewSimplifier(l("", // shadow element mimicking the root
 	l(""),
 	l("badge.svg"),
 	l("command-help"),
@@ -1609,8 +1609,8 @@ func defaultLensRemoteConfig(lfc *config.LensFileConfig) error {
 	}
 
 	if lfc.RemoteConfig.Endpoint == "" {
-		// Must not have a slash in between, DyanmicPathForLens already returns a slash-prefixed path
-		lfc.RemoteConfig.Endpoint = fmt.Sprintf("http://%s%s", spyglassLocalLensListenerAddr, common.DyanmicPathForLens(lfc.Lens.Name))
+		// Must not have a slash in between, DynamicPathForLens already returns a slash-prefixed path
+		lfc.RemoteConfig.Endpoint = fmt.Sprintf("http://%s%s", spyglassLocalLensListenerAddr, common.DynamicPathForLens(lfc.Lens.Name))
 	}
 
 	if lfc.RemoteConfig.Title == "" {

--- a/cmd/deck/main_test.go
+++ b/cmd/deck/main_test.go
@@ -350,7 +350,7 @@ func TestHandleProwJobs(t *testing.T) {
 	}
 	var res prowjobItems
 	if err := json.Unmarshal(body, &res); err != nil {
-		t.Fatalf("Error unmarshaling: %v", err)
+		t.Fatalf("Error unmarshalling: %v", err)
 	}
 	if res.Items[0].Annotations != nil {
 		t.Errorf("Failed to omit annotations correctly, expected: nil, got %v", res.Items[0].Annotations)
@@ -416,7 +416,7 @@ func TestProwJob(t *testing.T) {
 	}
 	var res prowapi.ProwJob
 	if err := yaml.Unmarshal(body, &res); err != nil {
-		t.Fatalf("Error unmarshaling: %v", err)
+		t.Fatalf("Error unmarshalling: %v", err)
 	}
 	if res.Spec.Job != "whoa" {
 		t.Errorf("Wrong job, expected \"whoa\", got \"%s\"", res.Spec.Job)
@@ -494,7 +494,7 @@ func TestTide(t *testing.T) {
 	}
 	res := tidePools{}
 	if err := json.Unmarshal(body, &res); err != nil {
-		t.Fatalf("Error unmarshaling: %v", err)
+		t.Fatalf("Error unmarshalling: %v", err)
 	}
 	if len(res.Pools) != 1 {
 		t.Fatalf("Wrong number of pools. Got %d, expected 1 in %v", len(res.Pools), res.Pools)
@@ -557,7 +557,7 @@ func TestTideHistory(t *testing.T) {
 	}
 	var res tideHistory
 	if err := json.Unmarshal(body, &res); err != nil {
-		t.Fatalf("Error unmarshaling: %v", err)
+		t.Fatalf("Error unmarshalling: %v", err)
 	}
 	if !reflect.DeepEqual(res.History, testHist) {
 		t.Fatalf("Expected /tide-history.js:\n%#v\n,but got:\n%#v\n", testHist, res.History)
@@ -603,7 +603,7 @@ func TestHelp(t *testing.T) {
 		}
 		var res pluginhelp.Help
 		if err := yaml.Unmarshal(body, &res); err != nil {
-			t.Fatalf("Error unmarshaling: %v", err)
+			t.Fatalf("Error unmarshalling: %v", err)
 		}
 		if !reflect.DeepEqual(help, res) {
 			t.Errorf("Invalid plugin help. Got %v, expected %v", res, help)
@@ -798,7 +798,7 @@ func TestHandleConfig(t *testing.T) {
 	}
 	dataC, err := yaml.Marshal(c)
 	if err != nil {
-		t.Fatalf("Error unmarshaling: %v", err)
+		t.Fatalf("Error unmarshalling: %v", err)
 	}
 
 	testcases := []struct {
@@ -914,7 +914,7 @@ func TestHandlePluginConfig(t *testing.T) {
 	}
 	var res plugins.Configuration
 	if err := yaml.Unmarshal(body, &res); err != nil {
-		t.Fatalf("Error unmarshaling: %v", err)
+		t.Fatalf("Error unmarshalling: %v", err)
 	}
 	if !reflect.DeepEqual(c, res) {
 		t.Errorf("Invalid config. Got %v, expected %v", res, c)
@@ -961,7 +961,7 @@ func verifyCfgHasRemoteForLens(lensName string) func(*config.Config, error) erro
 			if lens.RemoteConfig.ParsedEndpoint == nil {
 				return errors.New("parsedEndpoint was nil")
 			}
-			if expected := common.DyanmicPathForLens(lensName); lens.RemoteConfig.ParsedEndpoint.Path != expected {
+			if expected := common.DynamicPathForLens(lensName); lens.RemoteConfig.ParsedEndpoint.Path != expected {
 				return fmt.Errorf("expected parsedEndpoint.Path to be %q, was %q", expected, lens.RemoteConfig.ParsedEndpoint.Path)
 			}
 			if lens.RemoteConfig.ParsedEndpoint.Scheme != "http" {

--- a/cmd/deck/rerun_test.go
+++ b/cmd/deck/rerun_test.go
@@ -302,7 +302,7 @@ func TestRerun(t *testing.T) {
 				}
 				var res prowapi.ProwJob
 				if err := yaml.Unmarshal(body, &res); err != nil {
-					t.Fatalf("Error unmarshaling: %v", err)
+					t.Fatalf("Error unmarshalling: %v", err)
 				}
 				if res.Spec.Job != "whoa" {
 					t.Errorf("Wrong job, expected \"whoa\", got \"%s\"", res.Spec.Job)
@@ -644,7 +644,7 @@ func TestLatestRerun(t *testing.T) {
 				}
 				var res prowapi.ProwJob
 				if err := yaml.Unmarshal(body, &res); err != nil {
-					t.Fatalf("Error unmarshaling: %v", err)
+					t.Fatalf("Error unmarshalling: %v", err)
 				}
 				// These two fields are undeterministic so there are being set to the default
 				res.Status.StartTime = metav1.Time{}

--- a/cmd/external-plugins/needs-rebase/plugin/plugin.go
+++ b/cmd/external-plugins/needs-rebase/plugin/plugin.go
@@ -339,7 +339,7 @@ type searchQuery struct {
 	} `graphql:"search(type: ISSUE, first: 100, after: $searchCursor, query: $query)"`
 }
 
-// constructQueries constructs the v4 queries for the peridic scan.
+// constructQueries constructs the v4 queries for the periodic scan.
 // It returns a map[org][]query.
 func constructQueries(log *logrus.Entry, now time.Time, orgs, repos []string, usesGitHubAppsAuth bool) map[string][]string {
 	result := map[string][]string{}

--- a/cmd/gangway/main.go
+++ b/cmd/gangway/main.go
@@ -93,9 +93,9 @@ func (o *options) validate() error {
 	return utilerrors.NewAggregate(errs)
 }
 
-// interruptableServer is a wrapper type around the gRPC server, so that we can
+// interruptibleServer is a wrapper type around the gRPC server, so that we can
 // pass it along to our own interrupts package.
-type interruptableServer struct {
+type interruptibleServer struct {
 	grpcServer *grpc.Server
 	listener   net.Listener
 	port       int
@@ -107,7 +107,7 @@ type interruptableServer struct {
 // context cancels us), we forcefully kill the server by calling Stop(). Stop()
 // interrupts GracefulStop() (see
 // https://pkg.go.dev/google.golang.org/grpc#Server.Stop).
-func (s *interruptableServer) Shutdown(ctx context.Context) error {
+func (s *interruptibleServer) Shutdown(ctx context.Context) error {
 
 	gracefulStopFinished := make(chan struct{})
 
@@ -125,7 +125,7 @@ func (s *interruptableServer) Shutdown(ctx context.Context) error {
 	}
 }
 
-func (s *interruptableServer) ListenAndServe() error {
+func (s *interruptibleServer) ListenAndServe() error {
 	logrus.Infof("serving gRPC on port %d", s.port)
 	return s.grpcServer.Serve(s.listener)
 }
@@ -217,7 +217,7 @@ func main() {
 	// clients that don't have the generated stubs baked in, such as grpcurl.
 	reflection.Register(grpcServer)
 
-	s := &interruptableServer{
+	s := &interruptibleServer{
 		grpcServer: grpcServer,
 		listener:   lis,
 		port:       o.port,

--- a/cmd/generic-autobumper/bumper/bumper.go
+++ b/cmd/generic-autobumper/bumper/bumper.go
@@ -522,7 +522,7 @@ func gitCommit(name, email, message string, stdout, stderr io.Writer, signoff bo
 
 // MinimalGitPush pushes the content of the local repository to the remote, checking to make
 // sure that there are real changes that need updating by diffing the tree refs, ensuring that
-// no metadata-only pushes occur, as those re-trigger tests, remove LGTM, and cause churn whithout
+// no metadata-only pushes occur, as those re-trigger tests, remove LGTM, and cause churn without
 // changing the content being proposed in the PR.
 func MinimalGitPush(remote, remoteBranch string, stdout, stderr io.Writer, dryrun bool, opts ...CallOption) error {
 	if err := Call(stdout, stderr, gitCmd, []string{"remote", "add", forkRemoteName, remote}, opts...); err != nil {
@@ -594,7 +594,7 @@ func getTreeRef(stderr io.Writer, refname string, opts ...CallOption) (string, e
 	}
 	fields := strings.Fields(revParseStdout.String())
 	if n := len(fields); n < 1 {
-		return "", errors.New("got no otput when trying to rev-parse")
+		return "", errors.New("got no output when trying to rev-parse")
 	}
 	return fields[0], nil
 }

--- a/cmd/generic-autobumper/bumper/bumper_test.go
+++ b/cmd/generic-autobumper/bumper/bumper_test.go
@@ -253,7 +253,7 @@ func TestGetAssignment(t *testing.T) {
 		expectResKeyword     string
 	}{
 		{
-			description:      "AssignTo takes precedence over oncall setings",
+			description:      "AssignTo takes precedence over oncall settings",
 			assignTo:         "some-user",
 			expectResKeyword: "/cc @some-user",
 		},
@@ -280,11 +280,11 @@ func TestCDToRootDir(t *testing.T) {
 		"testdata/dir": {"extra-file"},
 	} {
 		if err := os.MkdirAll(path.Join(tmpDir, dir), 0755); err != nil {
-			t.Fatalf("Faile creating dir %q: %v", dir, err)
+			t.Fatalf("Failed creating dir %q: %v", dir, err)
 		}
 		for _, f := range fps {
 			if _, err := os.Create(path.Join(tmpDir, dir, f)); err != nil {
-				t.Fatalf("Faile creating file %q: %v", f, err)
+				t.Fatalf("Failed creating file %q: %v", f, err)
 			}
 		}
 	}

--- a/cmd/generic-autobumper/helper.go
+++ b/cmd/generic-autobumper/helper.go
@@ -87,7 +87,7 @@ func isUnderPath(name string, paths []string) bool {
 }
 
 // isBumpedPrefix takes a prefix and a map of new tags resulted from bumping
-// : the images using those tags and itterates over the map to find if the
+// : the images using those tags and iterates over the map to find if the
 // prefix is found. If it is, this means it has been bumped.
 func isBumpedPrefix(prefix prefix, versions map[string][]string) (string, bool) {
 	for tag, imageList := range versions {

--- a/cmd/generic-autobumper/main.go
+++ b/cmd/generic-autobumper/main.go
@@ -115,7 +115,7 @@ func generatePRBody(images map[string]string, prefixes []prefix) (body string) {
 // options is the options for autobumper operations.
 type options struct {
 	// The URL where upstream image references are located. Only required if Target Version is "upstream" or "upstreamStaging". Use "https://raw.githubusercontent.com/{ORG}/{REPO}"
-	// Images will be bumped based off images located at the address using this URL and the refConfigFile or stagingRefConigFile for each Prefix.
+	// Images will be bumped based off images located at the address using this URL and the refConfigFile or stagingRefConfigFile for each Prefix.
 	UpstreamURLBase string `yaml:"upstreamURLBase"`
 	// The config paths to be included in this bump, in which only .yaml files will be considered. By default all files are included.
 	IncludedConfigPaths []string `yaml:"includedConfigPaths"`

--- a/cmd/generic-autobumper/main_test.go
+++ b/cmd/generic-autobumper/main_test.go
@@ -352,11 +352,11 @@ func TestUpdateReferences(t *testing.T) {
 		"testdata/dir":         {"extra-file"},
 	} {
 		if err := os.MkdirAll(path.Join(tmpDir, dir), 0755); err != nil {
-			t.Fatalf("Faile creating dir %q: %v", dir, err)
+			t.Fatalf("Failed creating dir %q: %v", dir, err)
 		}
 		for _, f := range fps {
 			if _, err := os.Create(path.Join(tmpDir, dir, f)); err != nil {
-				t.Fatalf("Faile creating file %q: %v", f, err)
+				t.Fatalf("Failed creating file %q: %v", f, err)
 			}
 		}
 	}

--- a/cmd/gerrit/main_test.go
+++ b/cmd/gerrit/main_test.go
@@ -40,7 +40,7 @@ func TestFlags(t *testing.T) {
 			name: "minimal flags work",
 		},
 		{
-			name: "expicitly set --dry-run=false",
+			name: "explicitly set --dry-run=false",
 			args: map[string]string{
 				"--dry-run": "false",
 			},

--- a/cmd/ghproxy/ghproxy_test.go
+++ b/cmd/ghproxy/ghproxy_test.go
@@ -96,17 +96,17 @@ func TestDiskCachePruning(t *testing.T) {
 
 	numberPartitions, err := getNumberOfCachePartitions(cacheDir)
 	if err != nil {
-		t.Fatalf("failed to get number of cache paritions: %v", err)
+		t.Fatalf("failed to get number of cache partitions: %v", err)
 	}
 	if numberPartitions != 2 {
-		t.Fatalf("expected two cache paritions, one for the app and one for the app installation, got %d", numberPartitions)
+		t.Fatalf("expected two cache partitions, one for the app and one for the app installation, got %d", numberPartitions)
 	}
 
 	ghcache.Prune(cacheDir, func() time.Time { return now.Add(expiryDuration).Add(time.Second) })
 
 	numberPartitions, err = getNumberOfCachePartitions(cacheDir)
 	if err != nil {
-		t.Fatalf("failed to get number of cache paritions: %v", err)
+		t.Fatalf("failed to get number of cache partitions: %v", err)
 	}
 	if numberPartitions != 1 {
 		t.Errorf("expected one cache partition for the app as the one for the installation should be cleaned up, got  %d", numberPartitions)
@@ -118,7 +118,7 @@ func getNumberOfCachePartitions(cacheDir string) (int, error) {
 	for _, suffix := range []string{"temp", "data"} {
 		entries, err := os.ReadDir(path.Join(cacheDir, suffix))
 		if err != nil {
-			return result, fmt.Errorf("faield to list: %w", err)
+			return result, fmt.Errorf("failed to list: %w", err)
 		}
 		if result == 0 {
 			result = len(entries)

--- a/cmd/hook/main_test.go
+++ b/cmd/hook/main_test.go
@@ -51,7 +51,7 @@ func Test_gatherOptions(t *testing.T) {
 			},
 		},
 		{
-			name: "expicitly set --dry-run=false",
+			name: "explicitly set --dry-run=false",
 			args: map[string]string{
 				"--dry-run": "false",
 			},

--- a/cmd/horologium/main_test.go
+++ b/cmd/horologium/main_test.go
@@ -383,7 +383,7 @@ func TestFlags(t *testing.T) {
 			},
 		},
 		{
-			name: "expicitly set --dry-run=false",
+			name: "explicitly set --dry-run=false",
 			args: map[string]string{
 				"--dry-run": "false",
 			},

--- a/cmd/peribolos/main_test.go
+++ b/cmd/peribolos/main_test.go
@@ -3006,7 +3006,7 @@ func TestValidateRepos(t *testing.T) {
 			expectError: true,
 		},
 		{
-			description: "finds name confict between previous and current names",
+			description: "finds name conflict between previous and current names",
 			config: map[string]org.Repo{
 				"repo":     {Previously: []string{"conflict"}},
 				"conflict": {Description: &description},
@@ -3014,7 +3014,7 @@ func TestValidateRepos(t *testing.T) {
 			expectError: true,
 		},
 		{
-			description: "finds name confict between two previous names",
+			description: "finds name conflict between two previous names",
 			config: map[string]org.Repo{
 				"repo":         {Previously: []string{"conflict"}},
 				"another-repo": {Previously: []string{"conflict"}},

--- a/cmd/pipeline/controller.go
+++ b/cmd/pipeline/controller.go
@@ -86,7 +86,7 @@ type controllerOptions struct {
 	rl              workqueue.RateLimitingInterface
 }
 
-// pjNamespace retruns the prow namespace from configuration
+// pjNamespace returns the prow namespace from configuration
 func (c *controller) pjNamespace() string {
 	return c.config().ProwJobNamespace
 }

--- a/cmd/sinker/main_test.go
+++ b/cmd/sinker/main_test.go
@@ -745,8 +745,8 @@ func TestClean(t *testing.T) {
 		t.Fatalf("failed to get remaining prowjobs: %v", err)
 	}
 	actuallyDeletedProwJobs := sets.Set[string]{}
-	for _, initalProwJob := range prowJobs {
-		actuallyDeletedProwJobs.Insert(initalProwJob.(metav1.Object).GetName())
+	for _, initialProwJob := range prowJobs {
+		actuallyDeletedProwJobs.Insert(initialProwJob.(metav1.Object).GetName())
 	}
 	for _, remainingProwJob := range remainingProwJobs.Items {
 		actuallyDeletedProwJobs.Delete(remainingProwJob.Name)

--- a/cmd/tide/main_test.go
+++ b/cmd/tide/main_test.go
@@ -56,7 +56,7 @@ func Test_gatherOptions(t *testing.T) {
 			},
 		},
 		{
-			name: "expicitly set --dry-run=false",
+			name: "explicitly set --dry-run=false",
 			args: map[string]string{
 				"--dry-run": "false",
 			},

--- a/cmd/webhook-server/helpers.go
+++ b/cmd/webhook-server/helpers.go
@@ -462,7 +462,7 @@ func (wa *webhookAgent) fetchClusters(d time.Duration, ctx context.Context, stat
 					}
 					var tempMap map[string]plank.ClusterStatus
 					if err := json.Unmarshal(b, &tempMap); err != nil {
-						return fmt.Errorf("error unmarshaling build cluster status file: %w", err)
+						return fmt.Errorf("error unmarshalling build cluster status file: %w", err)
 					}
 					wa.mu.Lock()
 					wa.statuses = tempMap

--- a/config/prow/cluster/prowjob-crd/prowjob_customresourcedefinition.yaml
+++ b/config/prow/cluster/prowjob-crd/prowjob_customresourcedefinition.yaml
@@ -693,7 +693,7 @@ spec:
                   defining max concurrency. When several jobs from the same queue
                   try to run at the same time, the number of them that is actually
                   started is limited by JobQueueCapacities (part of Plank's config).
-                  If this field is left undefined inifinite concurrency is assumed.
+                  If this field is left undefined infinite concurrency is assumed.
                   This behaviour may be superseded by MaxConcurrency field, if it
                   is set to a constraining value.
                 type: string

--- a/hack/make-rules/go-run/arbitrary.sh
+++ b/hack/make-rules/go-run/arbitrary.sh
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# arbitrary.sh runs arbitry go command, ensures go version is from .go-version
+# arbitrary.sh runs arbitrary go command, ensures go version is from .go-version
 # Usage: ./arbitrary.sh <go args>
 # Example: ./arbitrary.sh build prow/cmd/crier
 

--- a/hack/third_party/gimme/gimme
+++ b/hack/third_party/gimme/gimme
@@ -429,10 +429,10 @@ _try_existing() {
 		# newer envs have existing semi-colon at end of line, because newer gimme
 		# puts them there; envs created before that change lack those semi-colons
 		# and should gain them, to make it easier for people using eval without
-		# double-quoting the command substition.
+		# double-quoting the command substitution.
 		sed -e 's/\([^;]\)$/\1;/' <"${existing_env}"
-		# gimme is the corner-case where GOROOT _should_ be overriden, since if the
-		# ancilliary tooling's system-internal DefaultGoroot exists, and GOROOT is
+		# gimme is the corner-case where GOROOT _should_ be overridden, since if the
+		# ancillary tooling's system-internal DefaultGoroot exists, and GOROOT is
 		# unset, then it will be used and the wrong golang will be picked up.
 		# Lots of old installs won't have GOROOT; munge it from $PATH
 		if grep -qs '^unset GOROOT' -- "${existing_env}"; then

--- a/pkg/apis/prowjobs/v1/types.go
+++ b/pkg/apis/prowjobs/v1/types.go
@@ -225,7 +225,7 @@ type ProwJobSpec struct {
 	// max concurrency. When several jobs from the same queue try to run
 	// at the same time, the number of them that is actually started is
 	// limited by JobQueueCapacities (part of Plank's config). If
-	// this field is left undefined inifinite concurrency is assumed.
+	// this field is left undefined infinite concurrency is assumed.
 	// This behaviour may be superseded by MaxConcurrency field, if it
 	// is set to a constraining value.
 	JobQueueName string `json:"job_queue_name,omitempty"`

--- a/pkg/apis/prowjobs/v1/types_test.go
+++ b/pkg/apis/prowjobs/v1/types_test.go
@@ -340,7 +340,7 @@ func TestDecorationDefaultingDoesntOverwrite(t *testing.T) {
 			},
 		},
 		{
-			name: "ingnore interrupts set",
+			name: "ignore interrupts set",
 			provided: &DecorationConfig{
 				UploadIgnoresInterrupts: &truth,
 			},
@@ -350,7 +350,7 @@ func TestDecorationDefaultingDoesntOverwrite(t *testing.T) {
 			},
 		},
 		{
-			name: "do not ingnore interrupts ",
+			name: "do not ignore interrupts ",
 			provided: &DecorationConfig{
 				UploadIgnoresInterrupts: &lies,
 			},

--- a/pkg/bugzilla/client.go
+++ b/pkg/bugzilla/client.go
@@ -632,7 +632,7 @@ func cloneBugStruct(bug *Bug, subcomponents map[string][]string, comments []Comm
 }
 
 // clone handles the bz client calls for the bug cloning process and allows us to share the implementation
-// between the real and fake client to prevent bugs from accidental discrepencies between the two.
+// between the real and fake client to prevent bugs from accidental discrepancies between the two.
 func clone(c Client, bug *Bug, mutations []func(bug *BugCreate)) (int, error) {
 	subcomponents, err := c.GetSubComponentsOnBug(bug.ID)
 	if err != nil {

--- a/pkg/config/cache_test.go
+++ b/pkg/config/cache_test.go
@@ -212,7 +212,7 @@ func TestGetProwYAMLCached(t *testing.T) {
 			// If the InRepoConfig is disabled for this repo, then the returned
 			// value should be an empty &ProwYAML{}. Also, the cache miss should
 			// not result in adding this entry into the cache (because the value
-			// will be a meaninless empty &ProwYAML{}).
+			// will be a meaningless empty &ProwYAML{}).
 			name:                "CacheMiss/InRepoConfigDisabled",
 			valConstructor:      goodValConstructor,
 			cacheInitialState:   nil,
@@ -685,7 +685,7 @@ func TestGetProwYAMLCachedAndDefaulted(t *testing.T) {
 				postsubmits: []Postsubmit{postsubmitBefore},
 			},
 			// For this test case, we do not change the
-			// DefualtDecorationConfigEntry at all, so we don't expect any
+			// DefaultDecorationConfigEntry at all, so we don't expect any
 			// changes.
 			configAfter: makeConfig(envBefore, []*DefaultDecorationConfigEntry{
 				{

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -224,7 +224,7 @@ type ProwConfig struct {
 	// Each entry in the slice specifies Repo and CLuster regexp filter fields to
 	// match against the jobs and a corresponding ProwJobDefault . All entries that
 	// match a job are used. Later matching entries override the fields of earlier
-	// matching entires.
+	// matching entries.
 	ProwJobDefaultEntries []*ProwJobDefaultEntry `json:"prowjob_default_entries,omitempty"`
 
 	// DisabledClusters holds a list of disabled build cluster names. The same context names will be ignored while
@@ -608,7 +608,7 @@ type Controller struct {
 	// Use `org/repo`, `org` or `*` as a key.
 	ReportTemplateStrings map[string]string `json:"report_templates,omitempty"`
 
-	// ReportTemplates is a mapping of templates that is compliled at load
+	// ReportTemplates is a mapping of templates that is compiled at load
 	// time from ReportTemplateStrings.
 	ReportTemplates map[string]*template.Template `json:"-"`
 
@@ -1908,7 +1908,7 @@ func yamlToConfig(path string, nc interface{}, opts ...yaml.JSONOpt) error {
 		return fmt.Errorf("error reading %s: %w", path, err)
 	}
 	if err := yaml.Unmarshal(b, nc, opts...); err != nil {
-		return fmt.Errorf("error unmarshaling %s: %w", path, err)
+		return fmt.Errorf("error unmarshalling %s: %w", path, err)
 	}
 	var jc *JobConfig
 	switch v := nc.(type) {
@@ -3302,7 +3302,7 @@ func SetPostsubmitRegexes(ps []Postsubmit) error {
 	return nil
 }
 
-// OrgRepo supercedes org/repo string handling.
+// OrgRepo supersedes org/repo string handling.
 type OrgRepo struct {
 	Org  string
 	Repo string

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -4536,10 +4536,10 @@ func TestPlankJobURLPrefix(t *testing.T) {
 				},
 			},
 			prowjob: &prowapi.ProwJob{Spec: prowapi.ProwJobSpec{
-				DecorationConfig: &prowapi.DecorationConfig{GCSConfiguration: &prowapi.GCSConfiguration{JobURLPrefix: "https://overriden"}},
+				DecorationConfig: &prowapi.DecorationConfig{GCSConfiguration: &prowapi.GCSConfiguration{JobURLPrefix: "https://overridden"}},
 				Refs:             &prowapi.Refs{Org: "my-alternate-org", Repo: "my-repo"},
 			}},
-			expectedJobURLPrefix: "https://overriden",
+			expectedJobURLPrefix: "https://overridden",
 		},
 		{
 			name: "Matching org and not matching repo returns JobURLPrefix from org",
@@ -4944,7 +4944,7 @@ func TestValidateTriggering(t *testing.T) {
 			errExpected: true,
 		},
 		{
-			name: "Triger unset, rerun command set, err",
+			name: "Trigger unset, rerun command set, err",
 			presubmit: Presubmit{
 				RerunCommand: "my-rerun-command",
 				Reporter: Reporter{
@@ -5464,7 +5464,7 @@ default_decoration_config_entries:
 			t.Parallel()
 			p := Plank{}
 			if err := yaml.Unmarshal([]byte(tc.raw), &p); err != nil {
-				t.Errorf("error unmarshaling: %v", err)
+				t.Errorf("error unmarshalling: %v", err)
 			}
 			if err := p.FinalizeDefaultDecorationConfigs(); err != nil && !tc.expectErr {
 				t.Errorf("unexpected error finalizing DefaultDecorationConfigs: %v", err)
@@ -8965,7 +8965,7 @@ func TestHasConfigFor(t *testing.T) {
 				actualIsGlobal, actualOrgs, actualRepos := fuzzedAndManipulatedConfig.HasConfigFor()
 
 				if expectIsGlobal != actualIsGlobal {
-					t.Errorf("exepcted isGlobal: %t, got: %t", expectIsGlobal, actualIsGlobal)
+					t.Errorf("expected isGlobal: %t, got: %t", expectIsGlobal, actualIsGlobal)
 				}
 
 				if diff := cmp.Diff(expectOrgs, actualOrgs); diff != "" {

--- a/pkg/config/gangway.go
+++ b/pkg/config/gangway.go
@@ -128,7 +128,7 @@ func (allowedApiClient *AllowedApiClient) GetApiClientCloudVendor() (ApiClientCl
 //
 // Each supported client type (e.g., GCP) has custom logic around the HTTP
 // metadata headers to know what kind of headers to look for. Different cloud
-// vendors will have different HTTP metdata headers, although technically
+// vendors will have different HTTP metadata headers, although technically
 // nothing stops users from injecting these headers manually on their own.
 func (c *Config) IdentifyAllowedClient(md *metadata.MD) (*AllowedApiClient, error) {
 	if md == nil {

--- a/pkg/config/inrepoconfig.go
+++ b/pkg/config/inrepoconfig.go
@@ -174,7 +174,7 @@ func prowYAMLGetter(
 		return nil, err
 	}
 
-	// TODO(mpherman): This is to hopefully mittigate issue with gerrit merges. Need to come up with a solution that checks
+	// TODO(mpherman): This is to hopefully mitigate issue with gerrit merges. Need to come up with a solution that checks
 	// each CLs merge strategy as they can differ. ifNecessary is just the gerrit default
 	var mergeMethod types.PullRequestMergeType
 	if gerritsource.IsGerritOrg(identifier) {

--- a/pkg/config/inrepoconfig_test.go
+++ b/pkg/config/inrepoconfig_test.go
@@ -291,7 +291,7 @@ func testDefaultProwYAMLGetter(clients localgit.Clients, t *testing.T) {
 			},
 		},
 		{
-			name: "Yaml unmarshaling is not strict",
+			name: "Yaml unmarshalling is not strict",
 			baseContent: map[string][]byte{
 				".prow.yaml": []byte(`postsubmits: [{"name": "hans", "undef_attr": true, "spec": {"containers": [{}]}}]`),
 			},

--- a/pkg/config/org/org.go
+++ b/pkg/config/org/org.go
@@ -93,7 +93,7 @@ type TeamMetadata struct {
 	Privacy     *Privacy `json:"privacy,omitempty"`
 }
 
-// Team declares metadata as well as its poeple.
+// Team declares metadata as well as its people.
 type Team struct {
 	TeamMetadata
 	Members     []string        `json:"members,omitempty"`

--- a/pkg/config/prow-config-documented.yaml
+++ b/pkg/config/prow-config-documented.yaml
@@ -1037,7 +1037,7 @@ pod_namespace: ' '
 # Each entry in the slice specifies Repo and CLuster regexp filter fields to
 # match against the jobs and a corresponding ProwJobDefault . All entries that
 # match a job are used. Later matching entries override the fields of earlier
-# matching entires.
+# matching entries.
 prowjob_default_entries:
     - # Cluster matches against the cluster alias of the build cluster that the
       # ProwJob is configured to run on. Recall that ProwJobs default to running on

--- a/pkg/config/tide_test.go
+++ b/pkg/config/tide_test.go
@@ -1517,7 +1517,7 @@ func TestConfigGetTideContextPolicy(t *testing.T) {
 			},
 		},
 		{
-			name: "both static and inrepoconfig jobs are consired",
+			name: "both static and inrepoconfig jobs are considered",
 			config: Config{
 				JobConfig: JobConfig{
 					PresubmitsStatic: map[string][]Presubmit{

--- a/pkg/crier/controller.go
+++ b/pkg/crier/controller.go
@@ -159,7 +159,7 @@ func (r *reconciler) reconcile(ctx context.Context, log *logrus.Entry, req recon
 	for _, pjob := range pjs {
 		if err := criercommonlib.UpdateReportStateWithRetries(ctx, pjob, log, r.pjclientset, r.reporter.GetName()); err != nil {
 			log.WithError(err).Error("Failed to update report state on prowjob")
-			// The error above is alreay logged, so it would be duplicated
+			// The error above is already logged, so it would be duplicated
 			// effort to combine all errors to return, only capture the last
 			// error should be sufficient.
 			lastErr = err

--- a/pkg/crier/controller_test.go
+++ b/pkg/crier/controller_test.go
@@ -194,7 +194,7 @@ func TestReconcile(t *testing.T) {
 			expectReport: false,
 		},
 		{
-			name:         "doesn't report nonexistant job",
+			name:         "doesn't report nonexistent job",
 			shouldReport: true,
 			expectReport: false,
 		},

--- a/pkg/crier/reporters/criercommonlib/shardedlock.go
+++ b/pkg/crier/reporters/criercommonlib/shardedlock.go
@@ -38,7 +38,7 @@ func NewSimplePull(org, repo string, number int) *SimplePull {
 
 // ShardedLock contains sharding information based on PRs
 type ShardedLock struct {
-	// semaphore is chosed over mutex, as Acquire from semaphore respects
+	// semaphore is chosen over mutex, as Acquire from semaphore respects
 	// context timeout while mutex doesn't
 	mapLock *semaphore.Weighted
 	locks   map[SimplePull]*semaphore.Weighted
@@ -52,7 +52,7 @@ func NewShardedLock() *ShardedLock {
 	}
 }
 
-// GetLock aquires the lock for a PR
+// GetLock acquires the lock for a PR
 func (s *ShardedLock) GetLock(ctx context.Context, key SimplePull) (*semaphore.Weighted, error) {
 	if err := s.mapLock.Acquire(ctx, 1); err != nil {
 		return nil, err

--- a/pkg/crier/reporters/gerrit/reporter.go
+++ b/pkg/crier/reporters/gerrit/reporter.go
@@ -62,7 +62,7 @@ const (
 
 	// lgtm means all presubmits passed, but need someone else to approve before merge (looks good to me).
 	lgtm = "+1"
-	// lbtm means some presubmits failed, perfer not merge (looks bad to me).
+	// lbtm means some presubmits failed, prefer not merge (looks bad to me).
 	lbtm = "-1"
 	// lztm is the minimum score for a postsubmit.
 	lztm = "0"

--- a/pkg/crier/reporters/gerrit/reporter_test.go
+++ b/pkg/crier/reporters/gerrit/reporter_test.go
@@ -88,7 +88,7 @@ func (f *fgc) SetReview(instance, id, revision, message string, labels map[strin
 	return nil
 }
 
-func (f *fgc) GetChange(instance, id string, addtionalFields ...string) (*gerrit.ChangeInfo, error) {
+func (f *fgc) GetChange(instance, id string, additionalFields ...string) (*gerrit.ChangeInfo, error) {
 	if f.changes == nil {
 		return nil, errors.New("fake client changes is not initialized")
 	}

--- a/pkg/flagutil/github_enablement.go
+++ b/pkg/flagutil/github_enablement.go
@@ -81,7 +81,7 @@ func (o *GitHubEnablementOptions) EnablementChecker() func(org, repo string) boo
 	enabledOrgs := o.enabledOrgs.StringSet()
 	enabledRepos := o.enabledRepos.StringSet()
 	disabledOrgs := o.disabledOrgs.StringSet()
-	diabledRepos := o.disabledRepos.StringSet()
+	disabledRepos := o.disabledRepos.StringSet()
 	return func(org, repo string) bool {
 		if len(enabledOrgs) > 0 || len(enabledRepos) > 0 {
 			if !enabledOrgs.Has(org) && !enabledRepos.Has(org+"/"+repo) {
@@ -89,6 +89,6 @@ func (o *GitHubEnablementOptions) EnablementChecker() func(org, repo string) boo
 			}
 		}
 
-		return !disabledOrgs.Has(org) && !diabledRepos.Has(org+"/"+repo)
+		return !disabledOrgs.Has(org) && !disabledRepos.Has(org+"/"+repo)
 	}
 }

--- a/pkg/flagutil/github_enablement_test.go
+++ b/pkg/flagutil/github_enablement_test.go
@@ -92,7 +92,7 @@ func TestEnablementChecker(t *testing.T) {
 		expectAllowed           bool
 	}{
 		{
-			name:          "Defalt allows everything",
+			name:          "Default allows everything",
 			expectAllowed: true,
 		},
 		{

--- a/pkg/gerrit/adapter/adapter.go
+++ b/pkg/gerrit/adapter/adapter.go
@@ -384,13 +384,13 @@ func (c *Controller) Sync() {
 	// First time seeing these projects, spin up worker threads for them.
 	staggerPosition := 0
 	for instance, projects := range needsWorker {
-		staggerIncement := c.config().Gerrit.TickInterval.Duration / time.Duration(needsWorkerCount[instance])
+		staggerIncrement := c.config().Gerrit.TickInterval.Duration / time.Duration(needsWorkerCount[instance])
 		for _, project := range projects {
 			c.projectsWithWorker[id(instance, project)] = true
 			logrus.WithFields(logrus.Fields{"instance": instance, "repo": project}).Info("Starting worker for project.")
 			go func(instance, project string, staggerPosition int) {
 				// Stagger new worker threads across the loop period to reduce load on the Gerrit API and Git server.
-				napTime := staggerIncement * time.Duration(staggerPosition)
+				napTime := staggerIncrement * time.Duration(staggerPosition)
 				time.Sleep(napTime)
 
 				// Now start the repo worker thread.

--- a/pkg/gerrit/adapter/adapter_test.go
+++ b/pkg/gerrit/adapter/adapter_test.go
@@ -634,7 +634,7 @@ func TestTriggerJobs(t *testing.T) {
 		wantPjs        []*prowapi.ProwJob
 	}{
 		{
-			name: "no presubmit Prow jobs automatically triggered from WorkInProgess change",
+			name: "no presubmit Prow jobs automatically triggered from WorkInProgress change",
 			change: client.ChangeInfo{
 				CurrentRevision: "1",
 				Project:         "test-infra",
@@ -3249,7 +3249,7 @@ func TestTriggerJobs(t *testing.T) {
 					if prowjob, ok := action.Object.(*prowapi.ProwJob); ok {
 						// Comparing the entire prowjob struct is not necessary
 						// in this test, so construct only ProwJob structs with
-						// only necessary informations.
+						// only necessary information.
 						gotProwjobs = append(gotProwjobs, &prowapi.ProwJob{
 							ObjectMeta: metav1.ObjectMeta{
 								Labels:      prowjob.Labels,

--- a/pkg/gerrit/client/client.go
+++ b/pkg/gerrit/client/client.go
@@ -417,7 +417,7 @@ func (c *Client) QueryChangesForProject(instance, project string, lastUpdate tim
 	return changes, nil
 }
 
-func (c *Client) GetChange(instance, id string, addtionalFields ...string) (*ChangeInfo, error) {
+func (c *Client) GetChange(instance, id string, additionalFields ...string) (*ChangeInfo, error) {
 	c.lock.RLock()
 	h, ok := c.handlers[instance]
 	c.lock.RUnlock()
@@ -425,7 +425,7 @@ func (c *Client) GetChange(instance, id string, addtionalFields ...string) (*Cha
 		return nil, fmt.Errorf("not activated gerrit instance: %s", instance)
 	}
 
-	info, resp, err := h.changeService.GetChange(id, &gerrit.ChangeOptions{AdditionalFields: addtionalFields})
+	info, resp, err := h.changeService.GetChange(id, &gerrit.ChangeOptions{AdditionalFields: additionalFields})
 
 	if err != nil {
 		return nil, fmt.Errorf("error getting current change: %w", responseBodyError(err, resp))

--- a/pkg/gerrit/client/client_test.go
+++ b/pkg/gerrit/client/client_test.go
@@ -136,7 +136,7 @@ func TestApplyGlobalConfigOnce(t *testing.T) {
 			},
 		},
 		{
-			name: "empty-addtionalfunc",
+			name: "empty-additionalfunc",
 			orgRepoConfigGetter: func() *config.GerritOrgRepoConfigs {
 				return cfg.Gerrit.OrgReposConfig
 			},
@@ -146,7 +146,7 @@ func TestApplyGlobalConfigOnce(t *testing.T) {
 			},
 		},
 		{
-			name: "nil-addtionalfunc",
+			name: "nil-additionalfunc",
 			orgRepoConfigGetter: func() *config.GerritOrgRepoConfigs {
 				return cfg.Gerrit.OrgReposConfig
 			},

--- a/pkg/gerrit/source/source.go
+++ b/pkg/gerrit/source/source.go
@@ -75,7 +75,7 @@ func ensuresHTTPSPrefix(in string) string {
 	return fmt.Sprintf("%s%s", scheme, strings.Trim(TrimHTTPSPrefix(in), "/"))
 }
 
-// TrimHTTPSPrefix trims https:// and http:// from input, also remvoes all
+// TrimHTTPSPrefix trims https:// and http:// from input, also removes all
 // trailing slashes from the end.
 func TrimHTTPSPrefix(in string) string {
 	in = strings.TrimPrefix(in, "https://")
@@ -83,7 +83,7 @@ func TrimHTTPSPrefix(in string) string {
 	return strings.TrimRight(in, "/")
 }
 
-// orgRepo returns <org>/<repo>, removes all extra slashs.
+// orgRepo returns <org>/<repo>, removes all extra slashes.
 func orgRepo(org, repo string) string {
 	org = strings.Trim(org, "/")
 	repo = strings.Trim(repo, "/")

--- a/pkg/ghcache/ghcache.go
+++ b/pkg/ghcache/ghcache.go
@@ -149,19 +149,27 @@ var pendingOutboundConnectionsGauge = prometheus.NewGauge(prometheus.GaugeOpts{
 	Help: "How many pending requests are waiting to be sent to GitHub servers.",
 })
 
-var cachePartitionsCounter = prometheus.NewCounterVec(
+var deprecatedCachePartitionsCounter = prometheus.NewCounterVec(
 	prometheus.CounterOpts{
 		Name: "ghcache_cache_parititions",
+		Help: "Which cache partitions exist (deprecated: use ghcache_cache_partitions instead).",
+	},
+	[]string{"token_hash"},
+)
+
+var cachePartitionsCounter = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Name: "ghcache_cache_partitions",
 		Help: "Which cache partitions exist.",
 	},
 	[]string{"token_hash"},
 )
 
 func init() {
-
 	prometheus.MustRegister(outboundConcurrencyGauge)
 	prometheus.MustRegister(pendingOutboundConnectionsGauge)
 	prometheus.MustRegister(cachePartitionsCounter)
+	prometheus.MustRegister(deprecatedCachePartitionsCounter)
 }
 
 func cacheResponseMode(headers http.Header) CacheResponseMode {
@@ -456,10 +464,10 @@ func Prune(baseDir string, now func() time.Time) {
 			if metadata.ExpiresAt.After(now()) {
 				continue
 			}
-			paritionPath := filepath.Dir(metadataPath)
-			logrus.WithField("path", paritionPath).WithField("expiresAt", metadata.ExpiresAt.String()).Info("Cleaning up expired cache parition")
-			if err := os.RemoveAll(paritionPath); err != nil {
-				logrus.WithError(err).WithField("path", paritionPath).Error("failed to delete expired cache parition")
+			partitionPath := filepath.Dir(metadataPath)
+			logrus.WithField("path", partitionPath).WithField("expiresAt", metadata.ExpiresAt.String()).Info("Cleaning up expired cache partition")
+			if err := os.RemoveAll(partitionPath); err != nil {
+				logrus.WithError(err).WithField("path", partitionPath).Error("failed to delete expired cache partition")
 			}
 		}
 	}

--- a/pkg/ghcache/partitioner.go
+++ b/pkg/ghcache/partitioner.go
@@ -74,8 +74,9 @@ func (prt *partitioningRoundTripper) RoundTrip(r *http.Request) (*http.Response,
 	prt.lock.Lock()
 	roundTripper, found := prt.roundTrippers[cachePartition]
 	if !found {
-		logrus.WithField("cache-parition-key", cachePartition).Info("Creating a new cache for partition")
+		logrus.WithField("cache-partition-key", cachePartition).Info("Creating a new cache for partition")
 		cachePartitionsCounter.WithLabelValues(cachePartition).Add(1)
+		deprecatedCachePartitionsCounter.WithLabelValues(cachePartition).Add(1)
 		prt.roundTrippers[cachePartition] = prt.roundTripperCreator(cachePartition, expiresAt)
 		roundTripper = prt.roundTrippers[cachePartition]
 	}

--- a/pkg/git/git_test.go
+++ b/pkg/git/git_test.go
@@ -555,6 +555,6 @@ func testShowRef(clients localgit.Clients, t *testing.T) {
 		t.Fatalf("ShowRef: %v", err)
 	}
 	if res != reference {
-		t.Errorf("expeted result to be %s, was %s", reference, res)
+		t.Errorf("expected result to be %s, was %s", reference, res)
 	}
 }

--- a/pkg/git/v2/client_factory.go
+++ b/pkg/git/v2/client_factory.go
@@ -218,7 +218,7 @@ func defaultClientFactoryOpts(cfo *ClientFactoryOpts) {
 // sshRemoteResolverFactory, and if CookieFilePath is provided then returns
 // gerritResolverFactory(Assuming that git http.cookiefile is used only by
 // Gerrit, this function needs to be updated if it turned out that this
-// assumtpion is not correct.)
+// assumption is not correct.)
 func NewClientFactory(opts ...ClientFactoryOpt) (ClientFactory, error) {
 	o := ClientFactoryOpts{}
 	defaultClientFactoryOpts(&o)

--- a/pkg/git/v2/remote.go
+++ b/pkg/git/v2/remote.go
@@ -105,7 +105,7 @@ func (f *httpResolverFactory) CentralRemote(org, repo string) RemoteResolver {
 // for the repository that can be published to.
 func (f *httpResolverFactory) PublishRemote(_, centralRepo string) ForkRemoteResolver {
 	return func(forkName string) (string, error) {
-		// For the publsh remote we use:
+		// For the publish remote we use:
 		// - the user login rather than the central org
 		// - the forkName rather than the central repo name, if specified.
 		repo := centralRepo

--- a/pkg/github/app_auth_roundtripper_integration_test.go
+++ b/pkg/github/app_auth_roundtripper_integration_test.go
@@ -51,7 +51,7 @@ func TestGetOrg(t *testing.T) {
 		"http://localhost:8888",
 	)
 	if err != nil {
-		t.Fatalf("failed to constuct client: %v", err)
+		t.Fatalf("failed to construct client: %v", err)
 	}
 
 	if _, err := client.GetOrg(org); err != nil {

--- a/pkg/github/app_auth_roundtripper_test.go
+++ b/pkg/github/app_auth_roundtripper_test.go
@@ -182,7 +182,7 @@ func TestAppsAuth(t *testing.T) {
 			},
 		},
 		{
-			name:          "App installation auth success, installations and token is requsted",
+			name:          "App installation auth success, installations and token is requested",
 			cachedAppSlug: utilpointer.String("ci-app"),
 			doRequest: func(c Client) error {
 				_, err := c.GetOrg("org")
@@ -228,7 +228,7 @@ func TestAppsAuth(t *testing.T) {
 			},
 		},
 		{
-			name: "App installation auth success, slug, installations and token is requsted",
+			name: "App installation auth success, slug, installations and token is requested",
 			doRequest: func(c Client) error {
 				_, err := c.GetOrg("org")
 				return err
@@ -285,7 +285,7 @@ func TestAppsAuth(t *testing.T) {
 			},
 		},
 		{
-			name:          "App installation auth with custom base url with path is successful, slug, installations and token are requsted",
+			name:          "App installation auth with custom base url with path is successful, slug, installations and token are requested",
 			githubBaseURL: "https://corp.internal/api/v3",
 			doRequest: func(c Client) error {
 				_, err := c.GetOrg("org")

--- a/pkg/github/client.go
+++ b/pkg/github/client.go
@@ -2070,7 +2070,7 @@ func (c *client) GetFailedActionRunsByHeadBranch(org, repo, branchName, headSHA 
 	prRuns := []WorkflowRun{}
 
 	// keep only the runs matching the current PR headSHA
-	for _, run := range runs.WorflowRuns {
+	for _, run := range runs.WorkflowRuns {
 		if run.HeadSha == headSHA {
 			prRuns = append(prRuns, run)
 		}
@@ -4488,7 +4488,7 @@ func (c *client) GetColumnProjectCards(org string, columnID int) ([]ProjectCard,
 	var cards []ProjectCard
 	err := c.readPaginatedResults(
 		path,
-		// projects api requies the accept header to be set this way
+		// projects api requires the accept header to be set this way
 		"application/vnd.github.inertia-preview+json",
 		org,
 		func() interface{} {

--- a/pkg/github/ghmetrics/ghmetrics.go
+++ b/pkg/github/ghmetrics/ghmetrics.go
@@ -42,7 +42,7 @@ var ghTokenUntilResetGaugeVec = prometheus.NewGaugeVec(
 var ghTokenUsageGaugeVec = prometheus.NewGaugeVec(
 	prometheus.GaugeOpts{
 		Name: "github_token_usage",
-		Help: "How many GitHub token requets are remaining for the current hour.",
+		Help: "How many GitHub token requests are remaining for the current hour.",
 	},
 	[]string{"token_hash", "api_version", "ratelimit_resource"},
 )
@@ -166,7 +166,7 @@ func timestampStringToTime(tstamp string) time.Time {
 	return time.Unix(timestamp, 0)
 }
 
-// userAgentWithouVersion formats a user agent without the version to reduce label cardinality
+// userAgentWithoutVersion formats a user agent without the version to reduce label cardinality
 func userAgentWithoutVersion(userAgent string) string {
 	if !strings.Contains(userAgent, "/") {
 		return userAgent

--- a/pkg/github/ghmetrics/ghpath.go
+++ b/pkg/github/ghmetrics/ghpath.go
@@ -104,7 +104,7 @@ func organizationTree() []simplifypath.Node {
 	}
 }
 
-var simplifier = simplifypath.NewSimplifier(l("", // shadow element mimicing the root
+var simplifier = simplifypath.NewSimplifier(l("", // shadow element mimicking the root
 	l(""),
 	l("app", l("installations", v("id", l("access_tokens")))),
 	l("repos",

--- a/pkg/github/types.go
+++ b/pkg/github/types.go
@@ -393,8 +393,8 @@ type RepoRequest struct {
 }
 
 type WorkflowRuns struct {
-	Count       int           `json:"total_count,omitempty"`
-	WorflowRuns []WorkflowRun `json:"workflow_runs"`
+	Count        int           `json:"total_count,omitempty"`
+	WorkflowRuns []WorkflowRun `json:"workflow_runs"`
 }
 
 // RepoCreateRequest contains metadata used in requests to create a repo.

--- a/pkg/io/opener.go
+++ b/pkg/io/opener.go
@@ -92,7 +92,7 @@ type Opener interface {
 	Attributes(ctx context.Context, path string) (Attributes, error)
 	SignedURL(ctx context.Context, path string, opts SignedURLOptions) (string, error)
 	Iterator(ctx context.Context, prefix, delimiter string) (ObjectIterator, error)
-	UpdateAtributes(context.Context, string, ObjectAttrsToUpdate) (*Attributes, error)
+	UpdateAttributes(context.Context, string, ObjectAttrsToUpdate) (*Attributes, error)
 }
 
 type opener struct {
@@ -365,7 +365,7 @@ func (o *opener) Attributes(ctx context.Context, path string) (Attributes, error
 	}, nil
 }
 
-func (o *opener) UpdateAtributes(ctx context.Context, path string, attrs ObjectAttrsToUpdate) (*Attributes, error) {
+func (o *opener) UpdateAttributes(ctx context.Context, path string, attrs ObjectAttrsToUpdate) (*Attributes, error) {
 	if !strings.HasPrefix(path, providers.GS+"://") {
 		return nil, fmt.Errorf("unsupported provider: %q", path)
 	}

--- a/pkg/jenkins/jenkins.go
+++ b/pkg/jenkins/jenkins.go
@@ -82,7 +82,7 @@ type Action struct {
 type Parameter struct {
 	Name string `json:"name"`
 	// This needs to be an interface so we won't clobber
-	// json unmarshaling when the Jenkins job has more
+	// json unmarshalling when the Jenkins job has more
 	// parameter types than strings.
 	Value interface{} `json:"value"`
 }
@@ -440,7 +440,7 @@ func getJobName(spec *prowapi.ProwJobSpec) string {
 	return jobName
 }
 
-// getJobInfoPath builds an approriate path to use for this Jenkins Job to get the job information
+// getJobInfoPath builds an appropriate path to use for this Jenkins Job to get the job information
 func getJobInfoPath(spec *prowapi.ProwJobSpec) string {
 	jenkinsJobName := getJobName(spec)
 	jenkinsPath := fmt.Sprintf("/job/%s/api/json", jenkinsJobName)

--- a/pkg/jira/fakejira/fake.go
+++ b/pkg/jira/fakejira/fake.go
@@ -65,7 +65,7 @@ func (f *FakeClient) GetIssue(id string) (*jira.Issue, error) {
 func (f *FakeClient) GetRemoteLinks(id string) ([]jira.RemoteLink, error) {
 	issue, err := f.GetIssue(id)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to get issue when chekcing from remote links: %+v", err)
+		return nil, fmt.Errorf("Failed to get issue when checking from remote links: %+v", err)
 	}
 	return append(f.ExistingLinks[issue.ID], f.ExistingLinks[issue.Key]...), nil
 }

--- a/pkg/jira/jira.go
+++ b/pkg/jira/jira.go
@@ -40,7 +40,7 @@ const (
 	StatusNew            = "NEW"
 	StatusBacklog        = "BACKLOG"
 	StatusAssigned       = "ASSIGNED"
-	StatusInProgess      = "IN PROGRESS"
+	StatusInProgress     = "IN PROGRESS"
 	StatusModified       = "MODIFIED"
 	StatusPost           = "POST"
 	StatusOnDev          = "ON_DEV"

--- a/pkg/jira/metrics.go
+++ b/pkg/jira/metrics.go
@@ -36,7 +36,7 @@ var requestResults = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 }, []string{methodField, pathField, statusField})
 
 func pathSimplifier() simplifypath.Simplifier {
-	return simplifypath.NewSimplifier(simplifypath.L("", // shadow element mimicing the root
+	return simplifypath.NewSimplifier(simplifypath.L("", // shadow element mimicking the root
 		simplifypath.L("rest",
 			simplifypath.L("api",
 				simplifypath.L("2",

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -59,6 +59,6 @@ func TestExposeMetrics(t *testing.T) {
 		t.Fatalf("failed getting metrics: %v", err)
 	}
 	if resp.StatusCode != http.StatusOK {
-		t.Errorf("resonse status was not 200 but %d", resp.StatusCode)
+		t.Errorf("response status was not %d but %d", http.StatusOK, resp.StatusCode)
 	}
 }

--- a/pkg/pjutil/filter_test.go
+++ b/pkg/pjutil/filter_test.go
@@ -368,7 +368,7 @@ func TestFilterPresubmits(t *testing.T) {
 			expectErr: false,
 		},
 		{
-			name: "everything matches and some that are forces to run supercede some that are skipped due to shared contexts",
+			name: "everything matches and some that are forces to run supersede some that are skipped due to shared contexts",
 			filter: &ArbitraryFilter{
 				override: func(p config.Presubmit) (shouldRun bool, forcedToRun bool, defaultBehavior bool) {
 					return true, p.Name == "should-trigger", p.Name == "should-trigger"

--- a/pkg/pjutil/health.go
+++ b/pkg/pjutil/health.go
@@ -51,15 +51,15 @@ func NewHealthOnPort(port int) *Health {
 	}
 }
 
-type ReadynessCheck func() bool
+type ReadinessCheck func() bool
 
 // ServeReady starts serving the readiness endpoint
-func (h *Health) ServeReady(readynessChecks ...ReadynessCheck) {
+func (h *Health) ServeReady(readinessChecks ...ReadinessCheck) {
 	h.healthMux.HandleFunc("/healthz/ready", func(w http.ResponseWriter, r *http.Request) {
-		for _, readynessCheck := range readynessChecks {
-			if !readynessCheck() {
+		for _, readinessCheck := range readinessChecks {
+			if !readinessCheck() {
 				w.WriteHeader(http.StatusServiceUnavailable)
-				fmt.Fprint(w, "ReadynessCheck failed")
+				fmt.Fprint(w, "ReadinessCheck failed")
 				return
 			}
 		}

--- a/pkg/plank/controller_test.go
+++ b/pkg/plank/controller_test.go
@@ -2082,7 +2082,7 @@ func TestMaxConcurrencyWithNewlyTriggeredJobs(t *testing.T) {
 	}
 }
 
-func TestMaxConcurency(t *testing.T) {
+func TestMaxConcurrency(t *testing.T) {
 	type pendingJob struct {
 		Duplicates int
 		JobQueue   string
@@ -2099,7 +2099,7 @@ func TestMaxConcurency(t *testing.T) {
 	}
 	testCases := []testCase{
 		{
-			Name:           "Max concurency 0 always runs",
+			Name:           "Max concurrency 0 always runs",
 			ProwJob:        prowapi.ProwJob{Spec: prowapi.ProwJobSpec{MaxConcurrency: 0}},
 			ExpectedResult: true,
 		},
@@ -2116,7 +2116,7 @@ func TestMaxConcurency(t *testing.T) {
 			ExpectedResult: false,
 		},
 		{
-			Name: "Num pending plus older instances equals max concurency",
+			Name: "Num pending plus older instances equals max concurrency",
 			ProwJob: prowapi.ProwJob{
 				ObjectMeta: metav1.ObjectMeta{
 					CreationTimestamp: metav1.Now(),
@@ -2139,7 +2139,7 @@ func TestMaxConcurency(t *testing.T) {
 			ExpectedResult: false,
 		},
 		{
-			Name: "Num pending plus older instances exceeds max concurency",
+			Name: "Num pending plus older instances exceeds max concurrency",
 			ProwJob: prowapi.ProwJob{
 				ObjectMeta: metav1.ObjectMeta{
 					CreationTimestamp: metav1.Now(),

--- a/pkg/plank/reconciler.go
+++ b/pkg/plank/reconciler.go
@@ -115,10 +115,10 @@ func add(
 	totURL string,
 	additionalSelector string,
 	overwriteReconcile reconcile.Func,
-	predicateCallack func(bool),
+	predicateCallback func(bool),
 	numWorkers int,
 ) error {
-	predicate, err := predicates(additionalSelector, predicateCallack)
+	predicate, err := predicates(additionalSelector, predicateCallback)
 	if err != nil {
 		return fmt.Errorf("failed to construct predicate: %w", err)
 	}

--- a/pkg/plank/reconciler_test.go
+++ b/pkg/plank/reconciler_test.go
@@ -200,10 +200,10 @@ func TestAdd(t *testing.T) {
 					t.Errorf("failed to start build mgr: %v", err)
 				}
 			}()
-			if err := singnalOrTimout(prowJobInformerStarted); err != nil {
+			if err := signalOrTimeout(prowJobInformerStarted); err != nil {
 				t.Fatalf("failure waiting for prowJobInformer: %v", err)
 			}
-			if err := singnalOrTimout(podInformerStarted); err != nil {
+			if err := signalOrTimeout(podInformerStarted); err != nil {
 				t.Fatalf("failure waiting for podInformer: %v", err)
 			}
 
@@ -280,7 +280,7 @@ func (ehsi *eventHandlerSignalingInformer) AddEventHandler(handler toolscache.Re
 	return reg, err
 }
 
-func singnalOrTimout(signal <-chan struct{}) error {
+func signalOrTimeout(signal <-chan struct{}) error {
 	select {
 	case <-signal:
 		return nil

--- a/pkg/pluginhelp/externalplugins/externalplugins.go
+++ b/pkg/pluginhelp/externalplugins/externalplugins.go
@@ -62,7 +62,7 @@ func ServeExternalPluginHelp(mux *http.ServeMux, log *logrus.Entry, provider Ext
 			}
 			var enabledRepos []config.OrgRepo
 			if err := json.Unmarshal(b, &enabledRepos); err != nil {
-				serverError("unmarshaling request body", err)
+				serverError("unmarshalling request body", err)
 				return
 			}
 			if provider == nil {

--- a/pkg/plugins/approve/approvers/owners_test.go
+++ b/pkg/plugins/approve/approvers/owners_test.go
@@ -463,7 +463,7 @@ func TestGetAllPotentialApprovers(t *testing.T) {
 			expectedApprovers: sets.List(setToLower(aApprovers)),
 		},
 		{
-			testName:          "Two Leafs",
+			testName:          "Two Leaves",
 			filenames:         []string{"a/d/test.go", "b/test.go"},
 			expectedApprovers: sets.List(setToLower(dApprovers.Union(bApprovers))),
 		},

--- a/pkg/plugins/blunderbuss/blunderbuss.go
+++ b/pkg/plugins/blunderbuss/blunderbuss.go
@@ -295,19 +295,19 @@ func getReviewers(rc reviewersClient, ghc githubClient, log *logrus.Entry, autho
 		// record required reviewers if any
 		requiredReviewers.Insert(rc.RequiredReviewers(file.Filename).UnsortedList()...)
 
-		fileUnusedLeafs := layeredsets.NewString(sets.List(rc.LeafReviewers(file.Filename))...).Difference(reviewers.Set()).Difference(authorSet)
-		if fileUnusedLeafs.Len() == 0 {
+		fileUnusedLeaves := layeredsets.NewString(sets.List(rc.LeafReviewers(file.Filename))...).Difference(reviewers.Set()).Difference(authorSet)
+		if fileUnusedLeaves.Len() == 0 {
 			continue
 		}
-		leafReviewers = leafReviewers.Union(fileUnusedLeafs)
-		if r := findReviewer(ghc, log, useStatusAvailability, &busyReviewers, &fileUnusedLeafs); r != "" {
+		leafReviewers = leafReviewers.Union(fileUnusedLeaves)
+		if r := findReviewer(ghc, log, useStatusAvailability, &busyReviewers, &fileUnusedLeaves); r != "" {
 			reviewers.Insert(0, r)
 		}
 	}
 	// now ensure that we request review from at least minReviewers reviewers. Favor leaf reviewers.
-	unusedLeafs := leafReviewers.Difference(reviewers.Set())
-	for reviewers.Len() < minReviewers && unusedLeafs.Len() > 0 {
-		if r := findReviewer(ghc, log, useStatusAvailability, &busyReviewers, &unusedLeafs); r != "" {
+	unusedLeaves := leafReviewers.Difference(reviewers.Set())
+	for reviewers.Len() < minReviewers && unusedLeaves.Len() > 0 {
+		if r := findReviewer(ghc, log, useStatusAvailability, &busyReviewers, &unusedLeaves); r != "" {
 			reviewers.Insert(1, r)
 		}
 	}

--- a/pkg/plugins/bugzilla/bugzilla_test.go
+++ b/pkg/plugins/bugzilla/bugzilla_test.go
@@ -1391,7 +1391,7 @@ Instructions for interacting with me using PR comments are available [here](http
 			expectedBug: &bugzilla.Bug{},
 		},
 		{
-			name:   "closed PR with multiple exernal links removes link, does not change bug state, and comments",
+			name:   "closed PR with multiple external links removes link, does not change bug state, and comments",
 			merged: false,
 			closed: true,
 			bugs:   []bugzilla.Bug{{ID: 123, Status: "POST", Severity: "urgent"}},

--- a/pkg/plugins/config.go
+++ b/pkg/plugins/config.go
@@ -418,7 +418,7 @@ func (l Label) RestrictedLabelsFor(org, repo string) map[string]RestrictedLabel 
 	return result
 }
 
-func (l Label) IsRestrictedLabelInAdditionalLables(restricted string) bool {
+func (l Label) IsRestrictedLabelInAdditionalLabels(restricted string) bool {
 	for _, additional := range l.AdditionalLabels {
 		if restricted == additional {
 			return true

--- a/pkg/plugins/config_test.go
+++ b/pkg/plugins/config_test.go
@@ -1722,7 +1722,7 @@ func TestPluginsMergeFrom(t *testing.T) {
 			}
 
 			if diff := cmp.Diff(tc.expected, tc.to); diff != "" {
-				t.Errorf("expexcted config differs from actual: %s", diff)
+				t.Errorf("expected config differs from actual: %s", diff)
 			}
 		})
 	}
@@ -2043,7 +2043,7 @@ func TestBugzillaMergeFrom(t *testing.T) {
 			}
 
 			if diff := cmp.Diff(tc.expected, tc.to); diff != "" {
-				t.Errorf("expexcted config differs from actual: %s", diff)
+				t.Errorf("expected config differs from actual: %s", diff)
 			}
 		})
 	}
@@ -2233,7 +2233,7 @@ func TestHasConfigFor(t *testing.T) {
 				actualIsGlobal, actualOrgs, actualRepos := fuzzedAndManipulatedConfig.HasConfigFor()
 
 				if expectIsGlobal != actualIsGlobal {
-					t.Errorf("exepcted isGlobal: %t, got: %t", expectIsGlobal, actualIsGlobal)
+					t.Errorf("expected isGlobal: %t, got: %t", expectIsGlobal, actualIsGlobal)
 				}
 
 				if diff := cmp.Diff(expectOrgs, actualOrgs); diff != "" {

--- a/pkg/plugins/jira/jira_test.go
+++ b/pkg/plugins/jira/jira_test.go
@@ -558,7 +558,7 @@ func TestFilterOutDisabledJiraProjects(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			output := filterOutDisabledJiraProjects(tc.candidates, tc.jiraConfig)
 			if diff := cmp.Diff(tc.expectedOutput, output); diff != "" {
-				t.Fatalf("actual output differes from expected output: %s", diff)
+				t.Fatalf("actual output differs from expected output: %s", diff)
 			}
 		})
 	}

--- a/pkg/plugins/lgtm/lgtm.go
+++ b/pkg/plugins/lgtm/lgtm.go
@@ -219,7 +219,7 @@ func handlePullRequestReview(gc githubClient, config *plugins.Configuration, own
 		htmlURL:     e.Review.HTMLURL,
 	}
 
-	// Only react to reviews that are being submitted (not editted or dismissed).
+	// Only react to reviews that are being submitted (not edited or dismissed).
 	if e.Action != github.ReviewActionSubmitted {
 		return nil
 	}

--- a/pkg/plugins/lgtm/lgtm_test.go
+++ b/pkg/plugins/lgtm/lgtm_test.go
@@ -581,7 +581,7 @@ func TestLGTMCommentWithLGTMNoti(t *testing.T) {
 		}
 		botUser, err := fc.BotUser()
 		if err != nil {
-			t.Fatalf("For case %s, could not get Bot nam", tc.name)
+			t.Fatalf("For case %s, could not get Bot name", tc.name)
 		}
 		ic := github.IssueComment{
 			User: github.User{

--- a/pkg/plugins/lifecycle/lifecycle_test.go
+++ b/pkg/plugins/lifecycle/lifecycle_test.go
@@ -261,7 +261,7 @@ func TestAddLifecycleLabels(t *testing.T) {
 			Action: github.GenericCommentActionCreated,
 			IsPR:   tc.isPR,
 		}
-		err := handle(fc, logrus.WithField("plugin", "fake-lifecyle"), e)
+		err := handle(fc, logrus.WithField("plugin", "fake-lifecycle"), e)
 		switch {
 		case err != nil:
 			t.Errorf("%s: unexpected error: %v", tc.name, err)

--- a/pkg/plugins/override/override.go
+++ b/pkg/plugins/override/override.go
@@ -527,7 +527,7 @@ If you are trying to override a checkrun that has a space in it, you must put a 
 		done.Insert(status.Context)
 	}
 
-	// We want to interate over the checkrunContexts, create a new checkrun with the same name as the context and mark it as successful.
+	// We want to iterate over the checkrunContexts, create a new checkrun with the same name as the context and mark it as successful.
 	// Tide has logic to pick the best checkrun result
 	// Checkruns have been converted to contexts and deduped
 	if oc.UsesAppAuth() {

--- a/pkg/plugins/override/override_test.go
+++ b/pkg/plugins/override/override_test.go
@@ -43,7 +43,7 @@ const (
 	fakeRepo    = "fake-repo"
 	fakePR      = 33
 	fakeSHA     = "deadbeef"
-	faseBaseRef = "fake-branch"
+	fakeBaseRef = "fake-branch"
 	fakeBaseSHA = "fffffff"
 	adminUser   = "admin-user"
 )
@@ -187,7 +187,7 @@ func (c *fakeClient) GetPullRequest(org, repo string, number int) (*github.PullR
 	}
 	var pr github.PullRequest
 	pr.Head.SHA = fakeSHA
-	pr.Base.Ref = faseBaseRef
+	pr.Base.Ref = fakeBaseRef
 	return &pr, nil
 }
 
@@ -249,7 +249,7 @@ func (c *fakeClient) GetBranchProtection(org, repo, branch string) (*github.Bran
 		return nil, fmt.Errorf("bad org: %s", org)
 	case repo != fakeRepo:
 		return nil, fmt.Errorf("bad repo: %s", repo)
-	case branch != faseBaseRef:
+	case branch != fakeBaseRef:
 		return nil, fmt.Errorf("bad branch: %s", branch)
 	}
 
@@ -523,7 +523,7 @@ func TestHandle(t *testing.T) {
 			usesAppsAuth: false,
 		},
 		{
-			name:    "override nonexistant checkrun",
+			name:    "override nonexistent checkrun",
 			comment: "/override foobar",
 			checkruns: &github.CheckRunList{
 				CheckRuns: []github.CheckRun{

--- a/pkg/plugins/plugins.go
+++ b/pkg/plugins/plugins.go
@@ -67,7 +67,7 @@ var (
 	CommentMap, _ = genyaml.NewCommentMap(nil)
 
 	//go:embed config.go
-	embededConfigGoFileContent []byte
+	embeddedConfigGoFileContent []byte
 )
 
 func init() {
@@ -79,7 +79,7 @@ func init() {
 		return
 	}
 
-	if cm, err := genyaml.NewCommentMap(map[string][]byte{"prow/plugins/config.go": embededConfigGoFileContent}); err == nil {
+	if cm, err := genyaml.NewCommentMap(map[string][]byte{"prow/plugins/config.go": embeddedConfigGoFileContent}); err == nil {
 		CommentMap = cm
 	} else {
 		logrus.WithError(err).Error("Failed to initialize commentMap")

--- a/pkg/plugins/plugins_test.go
+++ b/pkg/plugins/plugins_test.go
@@ -28,8 +28,8 @@ import (
 )
 
 func TestEnsureEmbed(t *testing.T) {
-	if len(embededConfigGoFileContent) == 0 {
-		t.Error("EmbededConfigGoFileContent is empty.")
+	if len(embeddedConfigGoFileContent) == 0 {
+		t.Error("EmbeddedConfigGoFileContent is empty.")
 	}
 }
 

--- a/pkg/plugins/stage/stage_test.go
+++ b/pkg/plugins/stage/stage_test.go
@@ -207,7 +207,7 @@ func TestStageLabels(t *testing.T) {
 			Body:   tc.body,
 			Action: github.GenericCommentActionCreated,
 		}
-		err := handle(fc, logrus.WithField("plugin", "fake-lifecyle"), e)
+		err := handle(fc, logrus.WithField("plugin", "fake-lifecycle"), e)
 		switch {
 		case err != nil:
 			t.Errorf("%s: unexpected error: %v", tc.name, err)

--- a/pkg/plugins/testfreeze/checker/checker_test.go
+++ b/pkg/plugins/testfreeze/checker/checker_test.go
@@ -51,7 +51,7 @@ func TestInTestFreeze(t *testing.T) {
 		assert  func(*Result, error)
 	}{
 		{
-			name: "success no test freez",
+			name: "success no test freeze",
 			prepare: func(mock *checkerfakes.FakeChecker) {
 				mock.ListRefsReturns([]*plumbing.Reference{
 					tag("wrong"),       // unable to parse this tag, but don't error
@@ -104,7 +104,7 @@ func TestInTestFreeze(t *testing.T) {
 			},
 		},
 		{
-			name: "error no latest releae branch found",
+			name: "error no latest release branch found",
 			prepare: func(mock *checkerfakes.FakeChecker) {
 				mock.ListRefsReturns([]*plumbing.Reference{
 					tag("1.22.0"),

--- a/pkg/plugins/trigger/generic-comment.go
+++ b/pkg/plugins/trigger/generic-comment.go
@@ -142,7 +142,7 @@ func handleGenericComment(c Client, trigger plugins.Trigger, gc github.GenericCo
 	if trigger.TriggerGitHubWorkflows && (pjutil.RetestRe.MatchString(gc.Body) || pjutil.TestAllRe.MatchString(gc.Body)) {
 		headSHA, err := refGetter.HeadSHA()
 		if err != nil {
-			c.Logger.Warnf("headSHA unvailable, failed github actions for pr will not be triggered: %v", pr)
+			c.Logger.Warnf("headSHA unavailable, failed github actions for pr will not be triggered: %v", pr)
 		} else {
 			failedRuns, err := c.GitHubClient.GetFailedActionRunsByHeadBranch(org, repo, pr.Head.Ref, headSHA)
 			if err != nil {

--- a/pkg/plugins/trigger/pull-request_test.go
+++ b/pkg/plugins/trigger/pull-request_test.go
@@ -210,7 +210,7 @@ func TestHandlePullRequest(t *testing.T) {
 			prIsDraft:   true,
 		},
 		{
-			name: "Trusted user switch PR from draft to normal shoud build",
+			name: "Trusted user switch PR from draft to normal should build",
 
 			Author:      "t",
 			ShouldBuild: true,
@@ -523,14 +523,14 @@ func TestHandlePullRequest(t *testing.T) {
 				}
 
 				if pj.Status.State != prowapi.AbortedState {
-					t.Errorf("exptected job %s to be aborted, found state: %v", tc.jobToAbort.Name, pj.Status.State)
+					t.Errorf("expected job %s to be aborted, found state: %v", tc.jobToAbort.Name, pj.Status.State)
 				}
 				if pj.Complete() {
-					t.Errorf("exptected job %s to not be set to complete.", tc.jobToAbort.Name)
+					t.Errorf("expected job %s to not be set to complete.", tc.jobToAbort.Name)
 				}
 			}
 			if cmp.Diff(tc.issueLabelsAdded, g.IssueLabelsAdded) != "" {
-				t.Errorf("exptected added issue labels %v to match %v", tc.issueLabelsAdded, g.IssueLabelsAdded)
+				t.Errorf("expected added issue labels %v to match %v", tc.issueLabelsAdded, g.IssueLabelsAdded)
 			}
 		})
 	}
@@ -617,7 +617,7 @@ func TestAbortAllJobs(t *testing.T) {
 			}
 
 			if err := abortAllJobs(client, pr); err != nil {
-				t.Fatalf("error caling abortAllJobs: %v", err)
+				t.Fatalf("error calling abortAllJobs: %v", err)
 			}
 
 			pj, err := pjClient.ProwV1().ProwJobs("").Get(context.Background(), pj().Name, metav1.GetOptions{})

--- a/pkg/plugins/trigger/trigger.go
+++ b/pkg/plugins/trigger/trigger.go
@@ -361,7 +361,7 @@ func getPostsubmits(log *logrus.Entry, gc git.ClientFactory, cfg *config.Config,
 	return postsubmits
 }
 
-// createWithRetry will retry the cration of a ProwJob. The Name must be set, otherwise we might end up creating it multiple times
+// createWithRetry will retry the creation of a ProwJob. The Name must be set, otherwise we might end up creating it multiple times
 // if one Create request errors but succeeds under the hood.
 func createWithRetry(ctx context.Context, client prowJobClient, pj *prowapi.ProwJob, millisecondOverride ...time.Duration) error {
 	millisecond := time.Millisecond

--- a/pkg/plugins/trigger/trigger_test.go
+++ b/pkg/plugins/trigger/trigger_test.go
@@ -660,7 +660,7 @@ func TestCreateWithRetry(t *testing.T) {
 
 			result, err := fakeProwJobClient.ProwV1().ProwJobs("").List(context.Background(), metav1.ListOptions{})
 			if err != nil {
-				t.Fatalf("faile to list prowjobs: %v", err)
+				t.Fatalf("failed to list prowjobs: %v", err)
 			}
 
 			if len(result.Items) != 1 {

--- a/pkg/plugins/verify-owners/verify-owners.go
+++ b/pkg/plugins/verify-owners/verify-owners.go
@@ -501,7 +501,7 @@ func nonTrustedUsersInOwners(ghc githubClient, log *logrus.Entry, triggerConfig 
 	return nonTrustedUsers, nil
 }
 
-// checkIfTrustedUser looks for newly addded owners by checking if they are in the patch
+// checkIfTrustedUser looks for newly added owners by checking if they are in the patch
 // and then checks if the owner is a trusted user.
 // returns a map from user to reasons for not being trusted
 func checkIfTrustedUser(ghc githubClient, log *logrus.Entry, triggerConfig plugins.Trigger, owner, patch, fileName, org, repo string, nonTrustedUsers map[string]nonTrustedReasons, trustedUsers sets.Set[string], repoAliases repoowners.RepoAliases) (map[string]nonTrustedReasons, error) {

--- a/pkg/prstatus/prstatus_test.go
+++ b/pkg/prstatus/prstatus_test.go
@@ -134,7 +134,7 @@ func TestHandlePrStatusWithoutLogin(t *testing.T) {
 	}
 	var dataReturned UserData
 	if err := yaml.Unmarshal(body, &dataReturned); err != nil {
-		t.Errorf("Error with unmarshaling response: %v", err)
+		t.Errorf("Error with unmarshalling response: %v", err)
 	}
 	if !reflect.DeepEqual(dataReturned, mockData) {
 		t.Errorf("Invalid user data. Got %v, expected %v", dataReturned, mockData)
@@ -170,7 +170,7 @@ func TestHandlePrStatusWithInvalidToken(t *testing.T) {
 
 	var dataReturned UserData
 	if err := yaml.Unmarshal(body, &dataReturned); err != nil {
-		t.Errorf("Error with unmarshaling response: %v", err)
+		t.Errorf("Error with unmarshalling response: %v", err)
 	}
 
 	expectedData := UserData{Login: false}
@@ -324,7 +324,7 @@ func TestHandlePrStatusWithLogin(t *testing.T) {
 			}
 			var dataReturned UserData
 			if err := yaml.Unmarshal(body, &dataReturned); err != nil {
-				t.Errorf("Error with unmarshaling response: %v", err)
+				t.Errorf("Error with unmarshalling response: %v", err)
 			}
 			if !reflect.DeepEqual(dataReturned, testcase.expectedData) {
 				t.Fatalf("Invalid user data. Got %v, expected %v.", dataReturned, testcase.expectedData)

--- a/pkg/scheduler/reconciler.go
+++ b/pkg/scheduler/reconciler.go
@@ -78,7 +78,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 	var result strategy.Result
 	var err error
-	// So far only k8s and tekton use the cluster field in a meaninful way. Hence
+	// So far only k8s and tekton use the cluster field in a meaningful way. Hence
 	// if we're reconciling a job having a different agent (or no agent at all) applying
 	// the passthrough strategy may be the safest approach.
 	if pj.Spec.Agent == prowv1.KubernetesAgent || pj.Spec.Agent == prowv1.TektonAgent {

--- a/pkg/scheduler/strategy/default.go
+++ b/pkg/scheduler/strategy/default.go
@@ -35,7 +35,7 @@ type Interface interface {
 }
 
 // Get gets a scheduling strategy in accordance to configuration. It defaults
-// to Passthrough stategy if none has been configured.
+// to Passthrough strategy if none has been configured.
 func Get(cfg *config.Config) Interface {
 	if cfg.Scheduler.Failover != nil {
 		return NewFailover(*cfg.Scheduler.Failover)

--- a/pkg/sidecar/run.go
+++ b/pkg/sidecar/run.go
@@ -125,7 +125,7 @@ func (o Options) Run(ctx context.Context, logFile *os.File) (int, error) {
 				buildLogs := logReadersFuncs(entries)
 				metadata := combineMetadata(entries)
 
-				//Peform best-effort upload
+				// perform best-effort upload
 				err := o.doUpload(ctx, spec, false, true, metadata, buildLogs, logFile, &once)
 				if err != nil {
 					logrus.WithError(err).Error("Failed to perform best-effort upload")
@@ -216,7 +216,7 @@ func combineMetadata(entries []wrapper.Options) map[string]interface{} {
 	return metadata
 }
 
-// preUpload peforms steps required before actual upload
+// preUpload performs steps required before actual upload
 func (o Options) preUpload() {
 	if o.DeprecatedWrapperOptions != nil {
 		// This only fires if the prowjob controller and sidecar are at different commits

--- a/pkg/simplifypath/simplify.go
+++ b/pkg/simplifypath/simplify.go
@@ -58,7 +58,7 @@ type Node struct {
 	Greedy bool
 }
 
-// PathFragment Interface for tree leafs to help resolve paths
+// PathFragment Interface for tree leaves to help resolve paths
 type PathFragment interface {
 	Matches(part string) bool
 	Represent() string

--- a/pkg/simplifypath/simplify_test.go
+++ b/pkg/simplifypath/simplify_test.go
@@ -57,7 +57,7 @@ func TestVariable(t *testing.T) {
 }
 
 func TestSimplify(t *testing.T) {
-	s := NewSimplifier(L("", // shadow element mimicing the root
+	s := NewSimplifier(L("", // shadow element mimicking the root
 		L(""),
 		L("repos",
 			V("owner",

--- a/pkg/spyglass/lenses/buildlog/lens.go
+++ b/pkg/spyglass/lenses/buildlog/lens.go
@@ -94,7 +94,7 @@ func (lens Lens) Header(artifacts []api.Artifact, resourceDir string, config jso
 }
 
 // defaultErrRE matches keywords and glog error messages.
-// It is only used if higlight_regexes is not specified in the lens config.
+// It is only used if highlight_regexes is not specified in the lens config.
 var defaultErrRE = regexp.MustCompile(`timed out|ERROR:|(FAIL|Failure \[)\b|panic\b|^E\d{4} \d\d:\d\d:\d\d\.\d\d\d]`)
 
 func init() {

--- a/pkg/spyglass/lenses/buildlog/lens_test.go
+++ b/pkg/spyglass/lenses/buildlog/lens_test.go
@@ -51,7 +51,7 @@ func TestGetConfig(t *testing.T) {
 			want: def,
 		},
 		{
-			name: "configure highligher",
+			name: "configure highlighter",
 			raw:  `{"highlighter": {"endpoint": "service", "pin": true}}`,
 			want: func() parsedConfig {
 				d := def
@@ -986,7 +986,7 @@ func TestAnalyzeArtifact(t *testing.T) {
 			err:  true,
 		},
 		{
-			name: "unparseable link",
+			name: "unparsable link",
 			high: &highlightConfig{},
 			art: &fake.Artifact{
 				Link: pstr("bad::%\x00:://" + pkgio.GSAnonHost),

--- a/pkg/spyglass/lenses/common/bindata.go
+++ b/pkg/spyglass/lenses/common/bindata.go
@@ -91,8 +91,8 @@ func staticSpyglassLensHtml() (*asset, error) {
 // It returns an error if the asset could not be found or
 // could not be loaded.
 func Asset(name string) ([]byte, error) {
-	cannonicalName := strings.Replace(name, "\\", "/", -1)
-	if f, ok := _bindata[cannonicalName]; ok {
+	canonicalName := strings.Replace(name, "\\", "/", -1)
+	if f, ok := _bindata[canonicalName]; ok {
 		a, err := f()
 		if err != nil {
 			return nil, fmt.Errorf("Asset %s can't read by error: %v", name, err)
@@ -117,8 +117,8 @@ func MustAsset(name string) []byte {
 // It returns an error if the asset could not be found or
 // could not be loaded.
 func AssetInfo(name string) (os.FileInfo, error) {
-	cannonicalName := strings.Replace(name, "\\", "/", -1)
-	if f, ok := _bindata[cannonicalName]; ok {
+	canonicalName := strings.Replace(name, "\\", "/", -1)
+	if f, ok := _bindata[canonicalName]; ok {
 		a, err := f()
 		if err != nil {
 			return nil, fmt.Errorf("AssetInfo %s can't read by error: %w", name, err)
@@ -160,8 +160,8 @@ var _bindata = map[string]func() (*asset, error){
 func AssetDir(name string) ([]string, error) {
 	node := _bintree
 	if len(name) != 0 {
-		cannonicalName := strings.Replace(name, "\\", "/", -1)
-		pathList := strings.Split(cannonicalName, "/")
+		canonicalName := strings.Replace(name, "\\", "/", -1)
+		pathList := strings.Split(canonicalName, "/")
 		for _, p := range pathList {
 			node = node.Children[p]
 			if node == nil {
@@ -233,6 +233,6 @@ func RestoreAssets(dir, name string) error {
 }
 
 func _filePath(dir, name string) string {
-	cannonicalName := strings.Replace(name, "\\", "/", -1)
-	return filepath.Join(append([]string{dir}, strings.Split(cannonicalName, "/")...)...)
+	canonicalName := strings.Replace(name, "\\", "/", -1)
+	return filepath.Join(append([]string{dir}, strings.Split(canonicalName, "/")...)...)
 }

--- a/pkg/spyglass/lenses/common/common.go
+++ b/pkg/spyglass/lenses/common/common.go
@@ -71,7 +71,7 @@ func NewLensServer(
 			ConfigGetter:           cfg,
 			LensOpt:                lens.Config,
 		}
-		mux.Handle(DyanmicPathForLens(lens.Config.LensName), newLensHandler(lens.Lens, opt))
+		mux.Handle(DynamicPathForLens(lens.Config.LensName), newLensHandler(lens.Lens, opt))
 	}
 	mux.Handle("/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		logrus.WithField("path", r.URL.Path).Error("LensServer got request on unhandled path")
@@ -312,6 +312,6 @@ func KeyToJob(src string) (jobName string, buildID string, err error) {
 
 const prefixSpyglassDynamicHandlers = "dynamic"
 
-func DyanmicPathForLens(lensName string) string {
+func DynamicPathForLens(lensName string) string {
 	return fmt.Sprintf("/%s/%s", prefixSpyglassDynamicHandlers, lensName)
 }

--- a/pkg/spyglass/lenses/links/links_test.go
+++ b/pkg/spyglass/lenses/links/links_test.go
@@ -155,7 +155,7 @@ func TestParseLinkFile(t *testing.T) {
 		},
 		{
 			jobPath:  "artifacts/debugging-links.link.json",
-			content:  []byte(`some unparseable json file contents`),
+			content:  []byte(`some unparsable json file contents`),
 			hasError: true,
 		},
 	}

--- a/pkg/spyglass/lenses/metadata/lens.go
+++ b/pkg/spyglass/lenses/metadata/lens.go
@@ -106,7 +106,7 @@ func (lens Lens) Body(artifacts []api.Artifact, resourceDir string, data string,
 		case prowv1.StartedStatusFile:
 			if len(read) > 0 {
 				if err = json.Unmarshal(read, &started); err != nil {
-					logrus.WithError(err).Error("Error unmarshaling started.json")
+					logrus.WithError(err).Error("Error unmarshalling started.json")
 				}
 				metadataViewData.StartTime = time.Unix(started.Timestamp, 0)
 			} else {
@@ -115,7 +115,7 @@ func (lens Lens) Body(artifacts []api.Artifact, resourceDir string, data string,
 		case prowv1.FinishedStatusFile:
 			if len(read) > 0 {
 				if err = json.Unmarshal(read, &finished); err != nil {
-					logrus.WithError(err).Error("Error unmarshaling finished.json")
+					logrus.WithError(err).Error("Error unmarshalling finished.json")
 				}
 				metadataViewData.Finished = true
 				if finished.Timestamp != nil {

--- a/pkg/spyglass/storageartifact_fetcher.go
+++ b/pkg/spyglass/storageartifact_fetcher.go
@@ -195,7 +195,7 @@ func (h *storageArtifactHandle) Attrs(ctx context.Context) (pkgio.Attributes, er
 }
 
 func (h *storageArtifactHandle) UpdateAttrs(ctx context.Context, attrs pkgio.ObjectAttrsToUpdate) (*pkgio.Attributes, error) {
-	return h.UpdateAtributes(ctx, h.Name, attrs)
+	return h.UpdateAttributes(ctx, h.Name, attrs)
 }
 
 // Artifact constructs a GCS artifact from the given GCS bucket and key. Uses the golang GCS library

--- a/pkg/statusreconciler/status_test.go
+++ b/pkg/statusreconciler/status_test.go
@@ -223,7 +223,7 @@ func TestSave(t *testing.T) {
 
 				var got config.Config
 				if err := yaml.Unmarshal(buf, &got); err != nil {
-					t.Fatalf("%s: unexpected error unmarshaling status file contents %v", tc.name, err)
+					t.Fatalf("%s: unexpected error unmarshalling status file contents %v", tc.name, err)
 				}
 				verify(t, tc.name, got, tc.expectedNamespace, tc.expectedPresubmits)
 			}

--- a/pkg/tide/gerrit_test.go
+++ b/pkg/tide/gerrit_test.go
@@ -51,7 +51,7 @@ func newFakeGerritClient() *fakeGerritClient {
 	}
 }
 
-func (f *fakeGerritClient) QueryChangesForProject(instance, project string, lastUpdate time.Time, rateLimit int, addtionalFilters ...string) ([]gerrit.ChangeInfo, error) {
+func (f *fakeGerritClient) QueryChangesForProject(instance, project string, lastUpdate time.Time, rateLimit int, additionalFilters ...string) ([]gerrit.ChangeInfo, error) {
 	if f.changes == nil || f.changes[instance] == nil || f.changes[instance][project] == nil {
 		return nil, errors.New("queries project doesn't exist")
 	}
@@ -59,7 +59,7 @@ func (f *fakeGerritClient) QueryChangesForProject(instance, project string, last
 	return f.changes[instance][project], nil
 }
 
-func (f *fakeGerritClient) GetChange(instance, id string, addtionalFields ...string) (*gerrit.ChangeInfo, error) {
+func (f *fakeGerritClient) GetChange(instance, id string, additionalFields ...string) (*gerrit.ChangeInfo, error) {
 	if f.changes == nil || f.changes[instance] == nil {
 		return nil, errors.New("instance not exist")
 	}

--- a/pkg/tide/history/history.go
+++ b/pkg/tide/history/history.go
@@ -122,7 +122,7 @@ type Record struct {
 	TenantIDs []string       `json:"tenantids"`
 }
 
-// New creates a new History struct with the specificed recordLog size limit.
+// New creates a new History struct with the specified recordLog size limit.
 func New(maxRecordsPerKey int, opener io.Opener, path string) (*History, error) {
 	hist := &History{
 		logs:         map[string]*recordLog{},

--- a/pkg/tide/status.go
+++ b/pkg/tide/status.go
@@ -306,18 +306,18 @@ func (sc *statusController) expectedStatus(log *logrus.Entry, queryMap *config.Q
 			return github.StatusError, fmt.Sprintf(statusNotInPool, fmt.Sprintf(" Merging is blocked by issue%s %s.", s, strings.Join(numbers, ", "))), nil
 		}
 
-		// hasFullfilledQuery is a weird state, it means that the PR is not in the pool but should be. It happens when all requirements were fulfilled
+		// hasFulfilledQuery is a weird state, it means that the PR is not in the pool but should be. It happens when all requirements were fulfilled
 		// at the time the status controller queried GitHub but not at the time the sync controller queried GitHub.
 		// We just fall through to check if there are missing jobs to avoid wasting api tokens by sending it to pending and then to success in the next
 		// sync or status controller iteration.
-		var hasFullfilledQuery bool
+		var hasFulfilledQuery bool
 
 		minDiffCount := -1
 		var minDiff string
 		for _, q := range queryMap.ForRepo(repo) {
 			diff, diffCount := requirementDiff(pr, &q, cc)
 			if diffCount == 0 {
-				hasFullfilledQuery = true
+				hasFulfilledQuery = true
 				break
 			} else if sc.config().Tide.DisplayAllQueriesInStatus {
 				if diffCount >= 2000 {
@@ -337,7 +337,7 @@ func (sc *statusController) expectedStatus(log *logrus.Entry, queryMap *config.Q
 			minDiff = " No Tide query for branch " + crc.BaseRefName + " found."
 		}
 
-		if !hasFullfilledQuery {
+		if !hasFulfilledQuery {
 			return github.StatusPending, fmt.Sprintf(statusNotInPool, minDiff), nil
 		}
 	}

--- a/pkg/tide/tide.go
+++ b/pkg/tide/tide.go
@@ -1255,7 +1255,7 @@ func prowJobListHasProwJobWithMatchingHeadSHA(pjs *prowapi.ProwJobList, headSHA 
 func setTideStatusSuccess(pr CodeReviewCommon, ghc githubClient, cfg *config.Config, log *logrus.Entry) error {
 	// Do not waste api tokens and risk hitting the 2.5k context limit by setting it to success if it is
 	// already set to success.
-	if prHasSuccessfullTideStatusContext(pr) {
+	if prHasSuccessfulTideStatusContext(pr) {
 		return nil
 	}
 	return ghc.CreateStatus(
@@ -1269,10 +1269,10 @@ func setTideStatusSuccess(pr CodeReviewCommon, ghc githubClient, cfg *config.Con
 		})
 }
 
-// prHasSuccessfullTideStatusContext is used only by setTideStatusSuccess.
+// prHasSuccessfulTideStatusContext is used only by setTideStatusSuccess.
 //
 // Used only by setTideStatusSuccess, referenced only by GitHubProvider.
-func prHasSuccessfullTideStatusContext(pr CodeReviewCommon) bool {
+func prHasSuccessfulTideStatusContext(pr CodeReviewCommon) bool {
 	commits := pr.GitHubCommits()
 	if commits == nil {
 		return false
@@ -2232,7 +2232,7 @@ func mapKeyWithHighestvalue(m map[string]int) string {
 // no state, failure, pending and success.
 func getBetterSimpleState(a, b simpleState) simpleState {
 	if a == "" || a == failureState || b == successState {
-		// b can't be worse than no state or failure and a can't be beter than success
+		// b can't be worse than no state or failure and a can't be better than success
 		return b
 	}
 

--- a/pkg/tide/tide_test.go
+++ b/pkg/tide/tide_test.go
@@ -4082,7 +4082,7 @@ func newFakeManager(t *testing.T, ctx context.Context, objs ...runtime.Object) t
 func prowYAMLGetterForHeadRefs(headRefsToLookFor []string, ps []config.Presubmit) config.ProwYAMLGetter {
 	return func(_ *config.Config, _ git.ClientFactory, _, _, _ string, headRefs ...string) (*config.ProwYAML, error) {
 		if len(headRefsToLookFor) != len(headRefs) {
-			return nil, fmt.Errorf("expcted %d headrefs, got %d", len(headRefsToLookFor), len(headRefs))
+			return nil, fmt.Errorf("expected %d headrefs, got %d", len(headRefsToLookFor), len(headRefs))
 		}
 		var presubmits []config.Presubmit
 		if sets.New[string](headRefsToLookFor...).Equal(sets.New[string](headRefs...)) {

--- a/site/content/en/docs/announcements.md
+++ b/site/content/en/docs/announcements.md
@@ -9,6 +9,10 @@ description: >
 
 New features added to each component:
 
+- *April 20, 2024* The `ghcache_cache_parititions` Prometheus metric has been deprecated in favor
+    of `ghcache_cache_partitions`. Besides spelling both metrics are identical.
+- *April 20, 2024* The `validate-supplemental-prow-config-hirarchy` check in `checkconfig` has been
+    renamed to `validate-supplemental-prow-config-hierarchy`; the old name is now deprecated.
 - *October 20, 2023* The [update to Inrepoconfig
     handling](https://github.com/kubernetes/test-infra/pull/30400) will break
     users if they have symlinks inside `.prow/` that point to targets elsewhere

--- a/site/content/en/docs/components/cli-tools/generic-autobumper.md
+++ b/site/content/en/docs/components/cli-tools/generic-autobumper.md
@@ -2,7 +2,7 @@
 title: "generic-autobumper"
 weight: 10
 description: >
-  
+
 ---
 
 This tool automates the version upgrading of images such as the [prow.k8s.io](https://prow.k8s.io) Prow deployment.
@@ -42,9 +42,9 @@ We need to fulfil those requirements to use this tool:
 * a [GitHub token](https://help.github.com/en/articles/creating-a-personal-access-token-for-the-command-line) which has permissions
     to be used by this tool to push changes and create PRs against the remote repo.
 
-* a yaml config file that specifies the follwing information passed in with the flag -config=FILEPATH:
+* a yaml config file that specifies the following information passed in with the flag -config=FILEPATH:
 * For info about what should go in the config look at [the documentation for the Options here](https://pkg.go.dev/sigs.k8s.io/prow/cmd/generic-autobumper/bumper#Options) and look at the example below.
-  
+
 e.g.,
 
 ```yaml

--- a/site/content/en/docs/jobs.md
+++ b/site/content/en/docs/jobs.md
@@ -2,7 +2,7 @@
 title: "ProwJobs"
 weight: 160
 description: >
-  
+
 ---
 
 For a brief overview of how Prow runs jobs take a look at ["Life of a Prow Job"](/docs/life-of-a-prow-job/).
@@ -146,7 +146,7 @@ And to use the preset, add corresponding label in prow job definition like:
     preset-foo-bar: "true"
 ```
 
-Alternatively, annonymous presets can be applied to all jobs, the config looks
+Alternatively, anonymous presets can be applied to all jobs, the config looks
 like:
 
 ```yaml

--- a/site/content/en/docs/more-prow.md
+++ b/site/content/en/docs/more-prow.md
@@ -2,7 +2,7 @@
 title: "Getting more out of Prow"
 weight: 100
 description: >
-  
+
 ---
 
 If you want more functionality from your Prow instance this guide is for you. It primarily links to other resources that catalogue existing components and features.
@@ -24,7 +24,7 @@ changed (based on a `run_if_changed` or `skip_if_only_changed` regexp). In
 order to `kubectl apply` to the cluster, the job will need to supply credentials
 (e.g. a kubeconfig file or
 [GCP service account key-file](https://github.com/kubernetes-sigs/prow/blob/main/pkg/gcloud-deployer-service-account.sh)). Since
-this job requires priviledged credentials to deploy to the cluster, it is
+this job requires privileged credentials to deploy to the cluster, it is
 important that it is run in a separate build cluster that is isolated from all
 presubmit jobs. See the
 [documentation about separate build clusters](/docs/scaling/#separate-build-clusters)
@@ -56,4 +56,4 @@ If your Prow instance operates on a lot of GitHub repos or runs lots of jobs you
 
 ## Private Front end
 
-If you want to create a private Deck instnace that contains a subset of prowjobs, you should review the ["Private Deck"](/docs/private-deck/) guide.
+If you want to create a private Deck instance that contains a subset of prowjobs, you should review the ["Private Deck"](/docs/private-deck/) guide.

--- a/site/content/en/docs/private-deck.md
+++ b/site/content/en/docs/private-deck.md
@@ -2,7 +2,7 @@
 title: "Setting up Private Deck"
 weight: 170
 description: >
-  
+
 ---
 
 ## 1) [User] Create a PR to Set up TenantIDs for prowjobs and Repos
@@ -22,7 +22,7 @@ prowjob_default_entries:
       tenant_id: 'private'
 
 ```
-This configuration is used both to apply tenantIDs to prowjobs, but is also used by Deck to filter out Tide information from orgRepos with tenantIDs that do not match. So even if you can lable all your prowjobs using cluster, make sure that all of your repos are given a tenantID as well.
+This configuration is used both to apply tenantIDs to prowjobs, but is also used by Deck to filter out Tide information from orgRepos with tenantIDs that do not match. So even if you can label all your prowjobs using cluster, make sure that all of your repos are given a tenantID as well.
 
 Once the PR is created, Prow operators should review the PR to make sure that no other tenantIDs were affected by the change.
 
@@ -54,16 +54,16 @@ gcloud iam service-accounts add-iam-policy-binding \
 Once the service account is created, grant the service account Viewer access to the GCS bucket where test results are located.
 ## 3) [Operator] (Optional) Create a New OauthApp for Authentication
 
-If you want to make the new Deck instance private, create a new oauth app using the Prowbot github account. 
+If you want to make the new Deck instance private, create a new oauth app using the Prowbot github account.
 
-You can follow this [Documentation](https://docs.github.com/en/developers/apps/building-oauth-apps/creating-an-oauth-app) to create the app: 
+You can follow this [Documentation](https://docs.github.com/en/developers/apps/building-oauth-apps/creating-an-oauth-app) to create the app:
 ### Creating oauth Secrets
 
 You will need to create two secrets populated with information from the oauth app
 
 github-oauth-config:
 ```
-data: 
+data:
   secret: {
     "client_id":"...",
     "client_secret":"...",
@@ -76,7 +76,7 @@ data:
 
 oauth-config
 ```
-data: 
+data:
   clientID: ...
   clientSecret: ...
   cookieSecret: ...
@@ -92,7 +92,7 @@ When creating the new Deck Deployment, make sure to update the following fields:
 - Update TenantID on new Deployment
     - Add `- --tenant-id=NEW_ID` under args in the Deck deployment spec
     - You can add this flag multiple times to allow multiple tenantIDs
-- (Optional) Add a volume mount for the oauth app and update the oauth-config 
+- (Optional) Add a volume mount for the oauth app and update the oauth-config
     - Here is an example of oauth2-proxy being used with github account validation. The oauth and oauth-config secrets are made in step 3.
 
     ```
@@ -145,7 +145,7 @@ When creating the new Deck Deployment, make sure to update the following fields:
         - name: OAUTH2_PROXY_REDIRECT_URL
           value: https://prow.infra.cft.dev/oauth2/callback
     ```
-    
+
     ```
     volumes:
     ...
@@ -171,7 +171,7 @@ In order to use the new Deployment you will need to:
  - [Here](https://github.com/GoogleCloudPlatform/oss-test-infra/blob/e1f836416d1b3cd2cebc81454eb7f5f1febbc468/prow/oss/cluster/cluster.yaml#L128) is an example
 
  ## 6 [User] Update status check links
- 
+
  In the prow config, add the new domain to target_urls and job_url_prefix_config like so:
 
  ```yaml

--- a/site/content/en/docs/prow-secrets.md
+++ b/site/content/en/docs/prow-secrets.md
@@ -2,7 +2,7 @@
 title: "Prow Secrets Management"
 weight: 140
 description: >
-  
+
 ---
 
 Secrets in prow service/build clusters are managed with [Kubernetes External
@@ -90,6 +90,6 @@ data:
 The `Secret` will be updated automatically when the secret value in gsm changed
 or the `ExternalSecret` is changed. when `ExternalSecret` CR is deleted from the
 cluster, the secret will be also be deleted by kubernetes external secret.
-(Note: deleting the `ExternelSecret` CR config from source control doesn't
+(Note: deleting the `ExternalSecret` CR config from source control doesn't
 result in deletion of corresponding `ExternalSecret` CR from the cluster as the
 postsubmit action only does `kubectl apply`).

--- a/site/content/en/docs/spyglass/_index.md
+++ b/site/content/en/docs/spyglass/_index.md
@@ -2,7 +2,7 @@
 title: "Spyglass"
 weight: 180
 description: >
-  
+
 ---
 
 # Spyglass
@@ -113,7 +113,7 @@ deck:
         config:
           runner_configs: # Would only work if `prowjob.json` is configured below
             "<BUILD_CLUSTER_ALIAS>":
-              pod_link_template: "https://<YOUR_CLOUD_PROVIDER_URL>/{{ .Name }}" # Name is directly from the Pod truct.
+              pod_link_template: "https://<YOUR_CLOUD_PROVIDER_URL>/{{ .Name }}" # Name is directly from the Pod struct.
             # Example:
             # "default":
             #    pod_link_template: "https://console.cloud.google.com/kubernetes/pod/us-central1-f/prow/test-pods/{{ .Name }}/details?project=k8s-prow-builds"

--- a/site/content/en/docs/spyglass/architecture.md
+++ b/site/content/en/docs/spyglass/architecture.md
@@ -2,7 +2,7 @@
 title: "Spyglass Architecture"
 weight: 10
 description: >
-  
+
 ---
 
 Spyglass is split into two major parts: the Spyglass core, and a set of independent lenses.
@@ -18,7 +18,7 @@ the following responsibilities:
 - Looking up artifacts for a given job and mapping those to lenses
 - Generating a page that loads the required lenses
 - Framing lenses with their boilerplate
-- Faciliating communication between the lens frontends and backends
+- Facilitating communication between the lens frontends and backends
 
 ## Spyglass Lenses
 

--- a/test/integration/cmd/fakegerritserver/main.go
+++ b/test/integration/cmd/fakegerritserver/main.go
@@ -154,7 +154,7 @@ func addChangeHandler(fgc *fakegerrit.FakeGerrit) func(*http.Request) (interface
 		project := vars["project"]
 		change := gerrit.ChangeInfo{}
 		if err := unmarshal(r, &change); err != nil {
-			logrus.Infof("Error unmarshaling: %v", err)
+			logrus.Infof("Error unmarshalling: %v", err)
 			return "", http.StatusInternalServerError, err
 		}
 		fgc.AddChange(project, &change)
@@ -167,7 +167,7 @@ func addAccountHandler(fgc *fakegerrit.FakeGerrit) func(*http.Request) (interfac
 	return func(r *http.Request) (interface{}, int, error) {
 		account := gerrit.AccountInfo{}
 		if err := unmarshal(r, &account); err != nil {
-			logrus.Infof("Error unmarshaling: %v", err)
+			logrus.Infof("Error unmarshalling: %v", err)
 			return "", http.StatusInternalServerError, err
 		}
 		fgc.AddAccount(&account)
@@ -196,7 +196,7 @@ func addBranchHandler(fgc *fakegerrit.FakeGerrit) func(*http.Request) (interface
 		project := vars["project"]
 		branch := gerrit.BranchInfo{}
 		if err := unmarshal(r, &branch); err != nil {
-			logrus.Infof("Error unmarshaling: %v", err)
+			logrus.Infof("Error unmarshalling: %v", err)
 			return "", http.StatusInternalServerError, err
 		}
 		fgc.AddBranch(project, branchName, &branch)

--- a/test/integration/integration-test.sh
+++ b/test/integration/integration-test.sh
@@ -78,7 +78,7 @@ Options:
         comma-separated string. Also results in only redeploying certain entries
         in PROW_COMPONENTS, by way of PROW_IMAGES_TO_COMPONENTS in lib.sh.
 
-        The value "ALL" for this falg is an alias for all images (PROW_IMAGES in
+        The value "ALL" for this flag is an alias for all images (PROW_IMAGES in
         lib.sh).
 
         By default, "-build=ALL" is assumed, so that users do not have to

--- a/test/integration/setup-prow-components.sh
+++ b/test/integration/setup-prow-components.sh
@@ -66,7 +66,7 @@ Options:
         service that needs frequent recompilation. The images are a
         comma-separated string.
 
-        The value "ALL" for this falg is an alias for all images (PROW_IMAGES in
+        The value "ALL" for this flag is an alias for all images (PROW_IMAGES in
         lib.sh).
 
     -delete='':

--- a/test/integration/test/deck_test.go
+++ b/test/integration/test/deck_test.go
@@ -387,7 +387,7 @@ func TestRerun(t *testing.T) {
 	// Now we are waiting on Horologium to create the first prow job so that we
 	// can rerun from.
 	// Horologium itself is pretty good at handling the configmap update, but
-	// not kubelet, accoriding to
+	// not kubelet, according to
 	// https://github.com/kubernetes/kubernetes/issues/30189 kubelet syncs
 	// configmap updates on existing pods every minute, which is a long wait.
 	// The proposed fix in the issue was updating the deployment, which imo

--- a/test/integration/test/gerrit_test.go
+++ b/test/integration/test/gerrit_test.go
@@ -63,7 +63,7 @@ func TestGerrit(t *testing.T) {
 			expectedMessages: []string{"/test all", "Triggered 1 prow jobs (0 suppressed reporting): \n  * Name: hello-world-presubmit"},
 		},
 		{
-			name: "no presubmit Prow jobs automatically triggered from WorkInProgess change",
+			name: "no presubmit Prow jobs automatically triggered from WorkInProgress change",
 			change: client.ChangeInfo{
 				CurrentRevision: "1",
 				ChangeID:        "2",
@@ -138,7 +138,7 @@ func TestGerrit(t *testing.T) {
 			}
 
 			// Give some time for gerrit to pick up the change
-			wait.PollUntilContextTimeout(context.TODO(), 5*time.Second, 20*time.Second, true, expectedMessagesRecievedFunc(gerritClient, tc.change.ChangeID, tc.expectedMessages))
+			wait.PollUntilContextTimeout(context.TODO(), 5*time.Second, 20*time.Second, true, expectedMessagesReceivedFunc(gerritClient, tc.change.ChangeID, tc.expectedMessages))
 
 			resp, err := gerritClient.GetChange(gerritServer, tc.change.ChangeID)
 			if err != nil {
@@ -159,7 +159,7 @@ func TestGerrit(t *testing.T) {
 
 }
 
-func expectedMessagesRecievedFunc(gerritClient *client.Client, ChangeID string, expectedMessages []string) func(ctx context.Context) (bool, error) {
+func expectedMessagesReceivedFunc(gerritClient *client.Client, ChangeID string, expectedMessages []string) wait.ConditionWithContextFunc {
 	return func(ctx context.Context) (bool, error) {
 		resp, err := gerritClient.GetChange(gerritServer, ChangeID)
 		if err != nil {

--- a/test/integration/test/horologium_test.go
+++ b/test/integration/test/horologium_test.go
@@ -63,7 +63,7 @@ func TestLaunchProwJob(t *testing.T) {
 	}
 
 	// Horologium itself is pretty good at handling the configmap update, but
-	// not kubelet, accoriding to
+	// not kubelet, according to
 	// https://github.com/kubernetes/kubernetes/issues/30189 kubelet syncs
 	// configmap updates on existing pods every minute, which is a long wait.
 	// The proposed fix in the issue was updating the deployment, which imo


### PR DESCRIPTION
`make verify-spelling` didn't find these, but https://github.com/crate-ci/typos did. Sadly configuring `typos` to properly ignore some of the generated base64 stuff is tedious, so this PR does not attempt to replace the existing spellchecker script.

Most of the fixes are just internal, but 2 external things have changed:

* One Prometheus metric had a typo in it, `ghcache_cache_parititions`. I created a new metric with the fixed name, but kept the old one for backwards-compatibility.
* The `validate-supplemental-prow-config-hirarchy` check in `checkconfig` was renamed, but I made it so the old spelling is still accepted.