### PR TITLE
replace deprecated NewFakeClient with NewClientBuilder

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -33,8 +33,5 @@ issues:
     text: ".*should not use dot dot imports"
   - linters:
     - staticcheck
-    text: "SA1019: fakectrlruntimeclient.NewFakeClient is deprecated"
-  - linters:
-    - staticcheck
     # TODO: Is this really supposed to be deprecated? Ref https://github.com/kubernetes/test-infra/issues/14875
     text: "SA1019: t.*.TrustedOrg is deprecated: TrustedOrg functionality is deprecated and will be removed in January 2020"

--- a/cmd/sinker/main_test.go
+++ b/cmd/sinker/main_test.go
@@ -718,12 +718,12 @@ func TestClean(t *testing.T) {
 	deletedPodsTrusted := sets.New[string]("old-failed-trusted")
 
 	fpjc := &clientWrapper{
-		Client:          fakectrlruntimeclient.NewFakeClient(prowJobs...),
+		Client:          fakectrlruntimeclient.NewClientBuilder().WithRuntimeObjects(prowJobs...).Build(),
 		getOnlyProwJobs: map[string]*prowv1.ProwJob{"ns/get-only-prowjob": {}},
 	}
 	fkc := []*podClientWrapper{
-		{t: t, Client: fakectrlruntimeclient.NewFakeClient(pods...)},
-		{t: t, Client: fakectrlruntimeclient.NewFakeClient(podsTrusted...)},
+		{t: t, Client: fakectrlruntimeclient.NewClientBuilder().WithRuntimeObjects(pods...).Build()},
+		{t: t, Client: fakectrlruntimeclient.NewClientBuilder().WithRuntimeObjects(podsTrusted...).Build()},
 	}
 	fpc := map[string]ctrlruntimeclient.Client{"unreachable": unreachableCluster{}}
 	for idx, fakeClient := range fkc {
@@ -810,14 +810,14 @@ func TestNotClean(t *testing.T) {
 	)
 
 	fpjc := &clientWrapper{
-		Client:          fakectrlruntimeclient.NewFakeClient(prowJobs...),
+		Client:          fakectrlruntimeclient.NewClientBuilder().WithRuntimeObjects(prowJobs...).Build(),
 		getOnlyProwJobs: map[string]*prowv1.ProwJob{"ns/get-only-prowjob": {}},
 	}
 	podClientValid := podClientWrapper{
-		t: t, Client: fakectrlruntimeclient.NewFakeClient(pods...),
+		t: t, Client: fakectrlruntimeclient.NewClientBuilder().WithRuntimeObjects(pods...).Build(),
 	}
 	podClientExcluded := podClientWrapper{
-		t: t, Client: fakectrlruntimeclient.NewFakeClient(podsExcluded...),
+		t: t, Client: fakectrlruntimeclient.NewClientBuilder().WithRuntimeObjects(podsExcluded...).Build(),
 	}
 	fpc := map[string]ctrlruntimeclient.Client{
 		"build-cluster-valid":    &podClientValid,
@@ -963,7 +963,7 @@ func TestDeletePodToleratesNotFound(t *testing.T) {
 			},
 		},
 	}
-	client := fakectrlruntimeclient.NewFakeClient(pod)
+	client := fakectrlruntimeclient.NewClientBuilder().WithRuntimeObjects(pod).Build()
 
 	c.deletePod(l, &corev1api.Pod{}, "reason", client, m)
 	c.deletePod(l, pod, "reason", client, m)

--- a/pkg/crier/controller_test.go
+++ b/pkg/crier/controller_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	ctrlruntime "sigs.k8s.io/controller-runtime"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -278,12 +277,12 @@ func TestReconcile(t *testing.T) {
 				err: test.reportErr,
 			}
 
-			var prowjobs []runtime.Object
+			builder := fakectrlruntimeclient.NewClientBuilder()
 			if test.job != nil {
-				prowjobs = append(prowjobs, test.job)
 				test.job.Name = toReconcile
+				builder.WithRuntimeObjects(test.job)
 			}
-			cs := &patchTrackingClient{Client: fakectrlruntimeclient.NewFakeClient(prowjobs...)}
+			cs := &patchTrackingClient{Client: builder.Build()}
 			r := &reconciler{
 				pjclientset:       cs,
 				reporter:          &rp,

--- a/pkg/crier/reporters/gerrit/reporter_test.go
+++ b/pkg/crier/reporters/gerrit/reporter_test.go
@@ -32,7 +32,6 @@ import (
 	"golang.org/x/sync/errgroup"
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/diff"
 	fakectrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -2012,15 +2011,16 @@ func TestReport(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			fgc := &fgc{instance: "gerrit", changes: changes}
-			allpj := []runtime.Object{tc.pj}
+
+			builder := fakectrlruntimeclient.NewClientBuilder().WithRuntimeObjects(tc.pj)
 			for idx, pj := range tc.existingPJs {
 				pj.Name = strconv.Itoa(idx)
-				allpj = append(allpj, pj)
+				builder.WithRuntimeObjects(pj)
 			}
 
 			reporter := &Client{
 				gc:          fgc,
-				pjclientset: fakectrlruntimeclient.NewFakeClient(allpj...),
+				pjclientset: builder.Build(),
 				prLocks:     criercommonlib.NewShardedLock(),
 			}
 
@@ -2125,15 +2125,16 @@ func TestMultipleWorks(t *testing.T) {
 			}
 
 			fgc := &fgc{instance: "gerrit", changes: changes}
-			var allpj []runtime.Object
+
+			builder := fakectrlruntimeclient.NewClientBuilder()
 			for idx, pj := range existingPJs {
 				pj.Name = strconv.Itoa(idx)
-				allpj = append(allpj, pj)
+				builder.WithRuntimeObjects(pj)
 			}
 
 			reporter := &Client{
 				gc:          fgc,
-				pjclientset: fakectrlruntimeclient.NewFakeClient(allpj...),
+				pjclientset: builder.Build(),
 				prLocks:     criercommonlib.NewShardedLock(),
 			}
 

--- a/pkg/crier/reporters/github/reporter_test.go
+++ b/pkg/crier/reporters/github/reporter_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 
 	v1 "sigs.k8s.io/prow/pkg/apis/prowjobs/v1"
 	"sigs.k8s.io/prow/pkg/config"
@@ -998,12 +997,12 @@ func TestPjsToReport(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			allpj := []runtime.Object{tc.pj}
+			builder := fakectrlruntimeclient.NewClientBuilder().WithObjects(tc.pj)
 			for _, pj := range tc.existingPJs {
-				allpj = append(allpj, pj)
+				builder.WithObjects(pj)
 			}
 
-			lister := fakectrlruntimeclient.NewFakeClient(allpj...)
+			lister := builder.Build()
 
 			gotPjs, gotErr := pjsToReport(context.Background(), &logrus.Entry{}, lister, tc.pj)
 			if (gotErr != nil && !tc.wantErr) || (gotErr == nil && tc.wantErr) {

--- a/pkg/deck/jobs/jobs_test.go
+++ b/pkg/deck/jobs/jobs_test.go
@@ -716,12 +716,12 @@ func TestListProwJobs(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		var data []runtime.Object
+		builder := fakectrlruntimeclient.NewClientBuilder()
 		for _, generator := range testCase.prowJobs {
-			data = append(data, generator(templateJob.DeepCopy()))
+			builder.WithRuntimeObjects(generator(templateJob.DeepCopy()))
 		}
 		fakeProwJobClient := &possiblyErroringFakeCtrlRuntimeClient{
-			Client:      fakectrlruntimeclient.NewFakeClient(data...),
+			Client:      builder.Build(),
 			shouldError: testCase.listErr,
 		}
 		lister := filteringProwJobLister{

--- a/pkg/pjutil/abort_test.go
+++ b/pkg/pjutil/abort_test.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	fakectrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -433,13 +432,13 @@ func TestTerminateOlderJobs(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			var clientPJs []runtime.Object
+			builder := fakectrlruntimeclient.NewClientBuilder()
 			var origPJs []prowv1.ProwJob
 			for i := range tc.pjs {
-				clientPJs = append(clientPJs, &tc.pjs[i])
+				builder.WithRuntimeObjects(&tc.pjs[i])
 				origPJs = append(origPJs, tc.pjs[i])
 			}
-			fakeProwJobClient := fakectrlruntimeclient.NewFakeClient(clientPJs...)
+			fakeProwJobClient := builder.Build()
 			log := logrus.NewEntry(logrus.StandardLogger())
 			if err := TerminateOlderJobs(fakeProwJobClient, log, tc.pjs); err != nil {
 				t.Fatalf("%s: error terminating the older presubmit jobs: %v", tc.name, err)

--- a/pkg/tide/status_test.go
+++ b/pkg/tide/status_test.go
@@ -1239,7 +1239,7 @@ func TestSetStatusRespectsRequiredContexts(t *testing.T) {
 		logger:   log,
 		ghc:      fghc,
 		config:   ca.Config,
-		pjClient: fakectrlruntimeclient.NewFakeClient(),
+		pjClient: fakectrlruntimeclient.NewClientBuilder().Build(),
 		ghProvider: &GitHubProvider{
 			ghc:          fghc,
 			mergeChecker: newMergeChecker(ca.Config, fghc),

--- a/pkg/tide/tide_test.go
+++ b/pkg/tide/tide_test.go
@@ -2246,7 +2246,7 @@ func TestSync(t *testing.T) {
 			}
 			mergeChecker := newMergeChecker(ca.Config, fgc)
 			sc := &statusController{
-				pjClient: fakectrlruntimeclient.NewFakeClient(),
+				pjClient: fakectrlruntimeclient.NewClientBuilder().Build(),
 				logger:   logrus.WithField("controller", "status-update"),
 				ghc:      fgc,
 				gc:       nil,
@@ -2264,7 +2264,7 @@ func TestSync(t *testing.T) {
 			c := &syncController{
 				config:        ca.Config,
 				provider:      ghProvider,
-				prowJobClient: fakectrlruntimeclient.NewFakeClient(),
+				prowJobClient: fakectrlruntimeclient.NewClientBuilder().Build(),
 				logger:        log,
 				changedFiles: &changedFilesAgent{
 					provider:        ghProvider,
@@ -2894,7 +2894,7 @@ func TestIsPassing(t *testing.T) {
 			if tc.passing {
 				c := &syncController{
 					provider:      &GitHubProvider{ghc: ghc, logger: log},
-					prowJobClient: fakectrlruntimeclient.NewFakeClient(),
+					prowJobClient: fakectrlruntimeclient.NewClientBuilder().Build(),
 					config:        func() *config.Config { return &config.Config{} },
 				}
 				// isRetestEligible is more lenient than isPassingTests, which means we expect it to allow
@@ -4062,7 +4062,7 @@ func getProwJob(pjtype prowapi.ProwJobType, org, repo, branch, sha string, state
 
 func newFakeManager(objs ...runtime.Object) *fakeManager {
 	client := &indexingClient{
-		Client:     fakectrlruntimeclient.NewFakeClient(objs...),
+		Client:     fakectrlruntimeclient.NewClientBuilder().WithRuntimeObjects(objs...).Build(),
 		indexFuncs: map[string]ctrlruntimeclient.IndexerFunc{},
 	}
 	return &fakeManager{
@@ -5251,9 +5251,9 @@ func TestIsBatchCandidateEligible(t *testing.T) {
 				tc.pjManipulator(&pj)
 			}
 
-			var initObjects []runtime.Object
+			builder := fakectrlruntimeclient.NewClientBuilder()
 			if pj != nil {
-				initObjects = append(initObjects, pj)
+				builder.WithRuntimeObjects(pj)
 			}
 
 			cfg := func() *config.Config { return &config.Config{} }
@@ -5261,7 +5261,7 @@ func TestIsBatchCandidateEligible(t *testing.T) {
 				config:        cfg,
 				provider:      &GitHubProvider{cfg: cfg},
 				ctx:           context.Background(),
-				prowJobClient: fakectrlruntimeclient.NewFakeClient(initObjects...),
+				prowJobClient: builder.Build(),
 			}
 
 			cc := &config.TideContextPolicy{


### PR DESCRIPTION
This performs some cleanup and replaces the deprecated usage of NewFakeClient() with the new NewClientBuilder() API.