### PR TITLE
tide: consider `skipped` run conclusion as `success`

### DIFF
--- a/pkg/tide/tide.go
+++ b/pkg/tide/tide.go
@@ -2130,7 +2130,7 @@ func checkRunToContext(checkRun CheckRun) Context {
 		return context
 	}
 
-	if checkRun.Conclusion == checkRunConclusionNeutral || checkRun.Conclusion == githubql.String(githubql.StatusStateSuccess) {
+	if checkRun.Conclusion == checkRunConclusionNeutral || checkRun.Conclusion == githubql.String(githubql.CheckConclusionStateSkipped) || checkRun.Conclusion == githubql.String(githubql.StatusStateSuccess) {
 		context.State = githubql.StatusStateSuccess
 		return context
 	}


### PR DESCRIPTION
The GitHub API seems to have changed the conclusion to now return `skipped`. Tide should consider this status as success to be able to merge the PR.

Fixes https://github.com/kubernetes-sigs/prow/issues/130

