### PR TITLE
Use GitHub API native status types

### DIFF
--- a/pkg/tide/status_test.go
+++ b/pkg/tide/status_test.go
@@ -273,7 +273,7 @@ func TestExpectedStatus(t *testing.T) {
 		{
 			name:              "single bad checkrun",
 			labels:            neededLabels,
-			checkRuns:         []CheckRun{{Name: githubql.String("job-name"), Status: checkRunStatusCompleted, Conclusion: githubql.String(githubql.StatusStateFailure)}},
+			checkRuns:         []CheckRun{{Name: githubql.String("job-name"), Status: githubql.String(githubql.CheckStatusStateCompleted), Conclusion: githubql.String(githubql.StatusStateFailure)}},
 			author:            "batman",
 			firstQueryAuthor:  "batman",
 			secondQueryAuthor: "batman",
@@ -286,7 +286,7 @@ func TestExpectedStatus(t *testing.T) {
 		{
 			name:              "single good checkrun",
 			labels:            neededLabels,
-			checkRuns:         []CheckRun{{Name: githubql.String("job-name"), Status: checkRunStatusCompleted, Conclusion: githubql.String(githubql.StatusStateSuccess)}},
+			checkRuns:         []CheckRun{{Name: githubql.String("job-name"), Status: githubql.String(githubql.CheckStatusStateCompleted), Conclusion: githubql.String(githubql.StatusStateSuccess)}},
 			author:            "batman",
 			firstQueryAuthor:  "batman",
 			secondQueryAuthor: "batman",
@@ -300,8 +300,8 @@ func TestExpectedStatus(t *testing.T) {
 			name:   "multiple good checkruns",
 			labels: neededLabels,
 			checkRuns: []CheckRun{
-				{Name: githubql.String("job-name"), Status: checkRunStatusCompleted, Conclusion: githubql.String(githubql.StatusStateSuccess)},
-				{Name: githubql.String("another-job"), Status: checkRunStatusCompleted, Conclusion: githubql.String(githubql.StatusStateSuccess)},
+				{Name: githubql.String("job-name"), Status: githubql.String(githubql.CheckStatusStateCompleted), Conclusion: githubql.String(githubql.StatusStateSuccess)},
+				{Name: githubql.String("another-job"), Status: githubql.String(githubql.CheckStatusStateCompleted), Conclusion: githubql.String(githubql.StatusStateSuccess)},
 			},
 			author:            "batman",
 			firstQueryAuthor:  "batman",
@@ -316,8 +316,8 @@ func TestExpectedStatus(t *testing.T) {
 			name:   "mix of good and bad checkruns",
 			labels: neededLabels,
 			checkRuns: []CheckRun{
-				{Name: githubql.String("job-name"), Status: checkRunStatusCompleted, Conclusion: githubql.String(githubql.StatusStateSuccess)},
-				{Name: githubql.String("another-job"), Status: checkRunStatusCompleted, Conclusion: githubql.String(githubql.StatusStateFailure)},
+				{Name: githubql.String("job-name"), Status: githubql.String(githubql.CheckStatusStateCompleted), Conclusion: githubql.String(githubql.StatusStateSuccess)},
+				{Name: githubql.String("another-job"), Status: githubql.String(githubql.CheckStatusStateCompleted), Conclusion: githubql.String(githubql.StatusStateFailure)},
 			},
 			author:            "batman",
 			firstQueryAuthor:  "batman",
@@ -332,7 +332,7 @@ func TestExpectedStatus(t *testing.T) {
 			name:   "mix of good status contexts and checkruns",
 			labels: neededLabels,
 			checkRuns: []CheckRun{
-				{Name: githubql.String("job-name"), Status: checkRunStatusCompleted, Conclusion: githubql.String(githubql.StatusStateSuccess)},
+				{Name: githubql.String("job-name"), Status: githubql.String(githubql.CheckStatusStateCompleted), Conclusion: githubql.String(githubql.StatusStateSuccess)},
 			},
 			contexts: []Context{
 				{Context: githubql.String("other-job-name"), State: githubql.StatusStateSuccess},
@@ -350,7 +350,7 @@ func TestExpectedStatus(t *testing.T) {
 			name:   "mix of bad status contexts and checkruns",
 			labels: neededLabels,
 			checkRuns: []CheckRun{
-				{Name: githubql.String("job-name"), Status: checkRunStatusCompleted, Conclusion: githubql.String(githubql.StatusStateFailure)},
+				{Name: githubql.String("job-name"), Status: githubql.String(githubql.CheckStatusStateCompleted), Conclusion: githubql.String(githubql.StatusStateFailure)},
 			},
 			contexts: []Context{
 				{Context: githubql.String("other-job-name"), State: githubql.StatusStateFailure},
@@ -368,7 +368,7 @@ func TestExpectedStatus(t *testing.T) {
 			name:   "good context, bad checkrun",
 			labels: neededLabels,
 			checkRuns: []CheckRun{
-				{Name: githubql.String("job-name"), Status: checkRunStatusCompleted, Conclusion: githubql.String(githubql.StatusStateFailure)},
+				{Name: githubql.String("job-name"), Status: githubql.String(githubql.CheckStatusStateCompleted), Conclusion: githubql.String(githubql.StatusStateFailure)},
 			},
 			contexts: []Context{
 				{Context: githubql.String("other-job-name"), State: githubql.StatusStateSuccess},
@@ -386,7 +386,7 @@ func TestExpectedStatus(t *testing.T) {
 			name:   "bad context, good checkrun",
 			labels: neededLabels,
 			checkRuns: []CheckRun{
-				{Name: githubql.String("job-name"), Status: checkRunStatusCompleted, Conclusion: githubql.String(githubql.StatusStateSuccess)},
+				{Name: githubql.String("job-name"), Status: githubql.String(githubql.CheckStatusStateCompleted), Conclusion: githubql.String(githubql.StatusStateSuccess)},
 			},
 			contexts: []Context{
 				{Context: githubql.String("other-job-name"), State: githubql.StatusStateFailure},
@@ -424,8 +424,8 @@ func TestExpectedStatus(t *testing.T) {
 			secondQueryAuthor: "batman",
 			milestone:         "v1.0",
 			checkRuns: []CheckRun{
-				{Name: githubql.String("job-name"), Status: checkRunStatusCompleted, Conclusion: githubql.String(githubql.StatusStateFailure)},
-				{Name: githubql.String("other-job-name"), Status: checkRunStatusCompleted, Conclusion: githubql.String(githubql.StatusStateFailure)},
+				{Name: githubql.String("job-name"), Status: githubql.String(githubql.CheckStatusStateCompleted), Conclusion: githubql.String(githubql.StatusStateFailure)},
+				{Name: githubql.String("other-job-name"), Status: githubql.String(githubql.CheckStatusStateCompleted), Conclusion: githubql.String(githubql.StatusStateFailure)},
 			},
 			inPool: false,
 

--- a/pkg/tide/tide.go
+++ b/pkg/tide/tide.go
@@ -2114,23 +2114,18 @@ func isStateBetter(previous, current githubql.StatusState) bool {
 	return false
 }
 
-const (
-	checkRunStatusCompleted   = githubql.String("COMPLETED")
-	checkRunConclusionNeutral = githubql.String("NEUTRAL")
-)
-
 // checkRunToContext translates a checkRun to a classic context
 // ref: https://developer.github.com/v3/checks/runs/#parameters
 func checkRunToContext(checkRun CheckRun) Context {
 	context := Context{
 		Context: checkRun.Name,
 	}
-	if checkRun.Status != checkRunStatusCompleted {
+	if checkRun.Status != githubql.String(githubql.CheckStatusStateCompleted) {
 		context.State = githubql.StatusStatePending
 		return context
 	}
 
-	if checkRun.Conclusion == checkRunConclusionNeutral || checkRun.Conclusion == githubql.String(githubql.CheckConclusionStateSkipped) || checkRun.Conclusion == githubql.String(githubql.StatusStateSuccess) {
+	if checkRun.Conclusion == githubql.String(githubql.CheckConclusionStateNeutral) || checkRun.Conclusion == githubql.String(githubql.CheckConclusionStateSkipped) || checkRun.Conclusion == githubql.String(githubql.StatusStateSuccess) {
 		context.State = githubql.StatusStateSuccess
 		return context
 	}

--- a/pkg/tide/tide_test.go
+++ b/pkg/tide/tide_test.go
@@ -2374,7 +2374,7 @@ func TestFilterSubpool(t *testing.T) {
 					},
 					checkRuns: []CheckRun{{
 						Name:       githubql.String("other-a"),
-						Status:     checkRunStatusCompleted,
+						Status:     githubql.String(githubql.CheckStatusStateCompleted),
 						Conclusion: githubql.String(githubql.StatusStateSuccess),
 					}},
 				},
@@ -2399,8 +2399,8 @@ func TestFilterSubpool(t *testing.T) {
 					},
 					checkRuns: []CheckRun{{
 						Name:       githubql.String("other-a"),
-						Status:     checkRunStatusCompleted,
-						Conclusion: checkRunConclusionNeutral,
+						Status:     githubql.String(githubql.CheckStatusStateCompleted),
+						Conclusion: githubql.String(githubql.CheckConclusionStateNeutral),
 					}},
 				},
 			},
@@ -2447,7 +2447,7 @@ func TestFilterSubpool(t *testing.T) {
 					},
 					checkRuns: []CheckRun{{
 						Name:       githubql.String("other-a"),
-						Status:     checkRunStatusCompleted,
+						Status:     githubql.String(githubql.CheckStatusStateCompleted),
 						Conclusion: githubql.String(githubql.StatusStateFailure),
 					}},
 				},
@@ -4276,24 +4276,24 @@ func TestCheckRunNodesToContexts(t *testing.T) {
 		},
 		{
 			name:      "Neutral checkrun is considered success",
-			checkRuns: []CheckRun{{Name: githubql.String("some-job"), Status: checkRunStatusCompleted, Conclusion: checkRunConclusionNeutral}},
+			checkRuns: []CheckRun{{Name: githubql.String("some-job"), Status: githubql.String(githubql.CheckStatusStateCompleted), Conclusion: githubql.String(githubql.CheckConclusionStateNeutral)}},
 			expected:  []Context{{Context: "some-job", State: githubql.StatusStateSuccess}},
 		},
 		{
 			name:      "Successful checkrun is considered success",
-			checkRuns: []CheckRun{{Name: githubql.String("some-job"), Status: checkRunStatusCompleted, Conclusion: githubql.String(githubql.StatusStateSuccess)}},
+			checkRuns: []CheckRun{{Name: githubql.String("some-job"), Status: githubql.String(githubql.CheckStatusStateCompleted), Conclusion: githubql.String(githubql.StatusStateSuccess)}},
 			expected:  []Context{{Context: "some-job", State: githubql.StatusStateSuccess}},
 		},
 		{
 			name:      "Other checkrun conclusion is considered failure",
-			checkRuns: []CheckRun{{Name: githubql.String("some-job"), Status: checkRunStatusCompleted, Conclusion: "unclear"}},
+			checkRuns: []CheckRun{{Name: githubql.String("some-job"), Status: githubql.String(githubql.CheckStatusStateCompleted), Conclusion: "unclear"}},
 			expected:  []Context{{Context: "some-job", State: githubql.StatusStateFailure}},
 		},
 		{
 			name: "Multiple checkruns are translated correctly",
 			checkRuns: []CheckRun{
-				{Name: githubql.String("some-job"), Status: checkRunStatusCompleted, Conclusion: checkRunConclusionNeutral},
-				{Name: githubql.String("another-job"), Status: checkRunStatusCompleted, Conclusion: checkRunConclusionNeutral},
+				{Name: githubql.String("some-job"), Status: githubql.String(githubql.CheckStatusStateCompleted), Conclusion: githubql.String(githubql.CheckConclusionStateNeutral)},
+				{Name: githubql.String("another-job"), Status: githubql.String(githubql.CheckStatusStateCompleted), Conclusion: githubql.String(githubql.CheckConclusionStateNeutral)},
 			},
 			expected: []Context{
 				{Context: "another-job", State: githubql.StatusStateSuccess},
@@ -4303,10 +4303,10 @@ func TestCheckRunNodesToContexts(t *testing.T) {
 		{
 			name: "De-duplicate checkruns, success > everything",
 			checkRuns: []CheckRun{
-				{Name: githubql.String("some-job"), Status: checkRunStatusCompleted, Conclusion: githubql.String("FAILURE")},
-				{Name: githubql.String("some-job"), Status: checkRunStatusCompleted, Conclusion: githubql.String("ERROR")},
-				{Name: githubql.String("some-job"), Status: checkRunStatusCompleted},
-				{Name: githubql.String("some-job"), Status: checkRunStatusCompleted, Conclusion: githubql.String(githubql.StatusStateSuccess)},
+				{Name: githubql.String("some-job"), Status: githubql.String(githubql.CheckStatusStateCompleted), Conclusion: githubql.String("FAILURE")},
+				{Name: githubql.String("some-job"), Status: githubql.String(githubql.CheckStatusStateCompleted), Conclusion: githubql.String("ERROR")},
+				{Name: githubql.String("some-job"), Status: githubql.String(githubql.CheckStatusStateCompleted)},
+				{Name: githubql.String("some-job"), Status: githubql.String(githubql.CheckStatusStateCompleted), Conclusion: githubql.String(githubql.StatusStateSuccess)},
 			},
 			expected: []Context{
 				{Context: "some-job", State: githubql.StatusStateSuccess},
@@ -4315,10 +4315,10 @@ func TestCheckRunNodesToContexts(t *testing.T) {
 		{
 			name: "De-duplicate checkruns, neutral > everything",
 			checkRuns: []CheckRun{
-				{Name: githubql.String("some-job"), Status: checkRunStatusCompleted, Conclusion: githubql.String("FAILURE")},
-				{Name: githubql.String("some-job"), Status: checkRunStatusCompleted, Conclusion: githubql.String("ERROR")},
-				{Name: githubql.String("some-job"), Status: checkRunStatusCompleted},
-				{Name: githubql.String("some-job"), Status: checkRunStatusCompleted, Conclusion: checkRunConclusionNeutral},
+				{Name: githubql.String("some-job"), Status: githubql.String(githubql.CheckStatusStateCompleted), Conclusion: githubql.String("FAILURE")},
+				{Name: githubql.String("some-job"), Status: githubql.String(githubql.CheckStatusStateCompleted), Conclusion: githubql.String("ERROR")},
+				{Name: githubql.String("some-job"), Status: githubql.String(githubql.CheckStatusStateCompleted)},
+				{Name: githubql.String("some-job"), Status: githubql.String(githubql.CheckStatusStateCompleted), Conclusion: githubql.String(githubql.CheckConclusionStateNeutral)},
 			},
 			expected: []Context{
 				{Context: "some-job", State: githubql.StatusStateSuccess},
@@ -4327,9 +4327,9 @@ func TestCheckRunNodesToContexts(t *testing.T) {
 		{
 			name: "De-duplicate checkruns, pending > failure",
 			checkRuns: []CheckRun{
-				{Name: githubql.String("some-job"), Status: checkRunStatusCompleted, Conclusion: githubql.String("FAILURE")},
-				{Name: githubql.String("some-job"), Status: checkRunStatusCompleted, Conclusion: githubql.String("ERROR")},
-				{Name: githubql.String("some-job"), Status: checkRunStatusCompleted},
+				{Name: githubql.String("some-job"), Status: githubql.String(githubql.CheckStatusStateCompleted), Conclusion: githubql.String("FAILURE")},
+				{Name: githubql.String("some-job"), Status: githubql.String(githubql.CheckStatusStateCompleted), Conclusion: githubql.String("ERROR")},
+				{Name: githubql.String("some-job"), Status: githubql.String(githubql.CheckStatusStateCompleted)},
 				{Name: githubql.String("some-job")},
 			},
 			expected: []Context{
@@ -4339,9 +4339,9 @@ func TestCheckRunNodesToContexts(t *testing.T) {
 		{
 			name: "De-duplicate checkruns, only failures",
 			checkRuns: []CheckRun{
-				{Name: githubql.String("some-job"), Status: checkRunStatusCompleted, Conclusion: githubql.String("FAILURE")},
-				{Name: githubql.String("some-job"), Status: checkRunStatusCompleted, Conclusion: githubql.String("ERROR")},
-				{Name: githubql.String("some-job"), Status: checkRunStatusCompleted},
+				{Name: githubql.String("some-job"), Status: githubql.String(githubql.CheckStatusStateCompleted), Conclusion: githubql.String("FAILURE")},
+				{Name: githubql.String("some-job"), Status: githubql.String(githubql.CheckStatusStateCompleted), Conclusion: githubql.String("ERROR")},
+				{Name: githubql.String("some-job"), Status: githubql.String(githubql.CheckStatusStateCompleted)},
 			},
 			expected: []Context{
 				{Context: "some-job", State: githubql.StatusStateFailure},


### PR DESCRIPTION
Utilize the API native status type `CheckStatusStateCompleted` as well as `CheckConclusionStateNeutral` instead of the own type definitions.