### PR TITLE
external-plugins/cherrypicker: add support for branch chains

### DIFF
--- a/cmd/external-plugins/cherrypicker/lib/lib.go
+++ b/cmd/external-plugins/cherrypicker/lib/lib.go
@@ -16,16 +16,22 @@ limitations under the License.
 
 package cherrypicker
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 // CreateCherrypickBody creates the body of a cherrypick PR
-func CreateCherrypickBody(num int, requestor, note string) string {
+func CreateCherrypickBody(num int, requestor, note string, chainBranches []string) string {
 	cherryPickBody := fmt.Sprintf("This is an automated cherry-pick of #%d", num)
 	if len(requestor) != 0 {
 		cherryPickBody = fmt.Sprintf("%s\n\n/assign %s", cherryPickBody, requestor)
 	}
 	if len(note) != 0 {
 		cherryPickBody = fmt.Sprintf("%s\n\n%s", cherryPickBody, note)
+	}
+	if len(chainBranches) != 0 {
+		cherryPickBody = fmt.Sprintf("%s\n\n/cherrypick %s", cherryPickBody, strings.Join(chainBranches, " "))
 	}
 	return cherryPickBody
 }

--- a/cmd/external-plugins/cherrypicker/server_test.go
+++ b/cmd/external-plugins/cherrypicker/server_test.go
@@ -351,7 +351,6 @@ func testCherryPickIC(clients localgit.Clients, t *testing.T) {
 	if err := s.handleIssueComment(logrus.NewEntry(logrus.StandardLogger()), ic); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	t.Logf("Comments: %+v; PRs: %+v", ghc.comments, ghc.prs)
 	got := prToString(ghc.prs[0])
 	if got != expected {
 		t.Errorf("Expected (%d):\n%s\nGot (%d):\n%+v\n", len(expected), expected, len(got), got)
@@ -366,7 +365,7 @@ func TestCherryPickPRV2(t *testing.T) {
 func testCherryPickPR(clients localgit.Clients, t *testing.T) {
 	prNumber := fakePR.GetPRNumber()
 	lg, c := makeFakeRepoWithCommit(clients, t)
-	expectedBranches := []string{"release-1.5", "release-1.6", "release-1.8", "release-1.3"}
+	expectedBranches := []string{"release-1.5", "release-1.6", "release-1.8", "release-1.3", "release-1.12"}
 	for _, branch := range expectedBranches {
 		if err := lg.CheckoutNewBranch("foo", "bar", branch); err != nil {
 			t.Fatalf("Checking out pull branch: %v", err)
@@ -409,6 +408,12 @@ func testCherryPickPR(clients localgit.Clients, t *testing.T) {
 					Login: "approver",
 				},
 				Body: "/cherrypick release-1.3 release-1.2",
+			},
+			{
+				User: github.User{
+					Login: "approver",
+				},
+				Body: "/cherrypick release-1.12 release-1.11 release-1.10 release-1.9",
 			},
 			{
 				User: github.User{
@@ -490,6 +495,9 @@ func testCherryPickPR(clients localgit.Clients, t *testing.T) {
 		expectedBody := fmt.Sprintf("This is an automated cherry-pick of #%d", prNumber)
 		if branch == "release-1.3" {
 			expectedBody = fmt.Sprintf("%s\n\n/cherrypick release-1.2", expectedBody)
+		}
+		if branch == "release-1.12" {
+			expectedBody = fmt.Sprintf("%s\n\n/cherrypick release-1.11 release-1.10 release-1.9", expectedBody)
 		}
 		expectedHead := fmt.Sprintf(botUser.Login+":"+cherryPickBranchFmt, prNumber, branch)
 		expectedLabels := s.labels

--- a/cmd/external-plugins/cherrypicker/server_test.go
+++ b/cmd/external-plugins/cherrypicker/server_test.go
@@ -351,6 +351,7 @@ func testCherryPickIC(clients localgit.Clients, t *testing.T) {
 	if err := s.handleIssueComment(logrus.NewEntry(logrus.StandardLogger()), ic); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	t.Logf("Comments: %+v; PRs: %+v", ghc.comments, ghc.prs)
 	got := prToString(ghc.prs[0])
 	if got != expected {
 		t.Errorf("Expected (%d):\n%s\nGot (%d):\n%+v\n", len(expected), expected, len(got), got)
@@ -365,7 +366,7 @@ func TestCherryPickPRV2(t *testing.T) {
 func testCherryPickPR(clients localgit.Clients, t *testing.T) {
 	prNumber := fakePR.GetPRNumber()
 	lg, c := makeFakeRepoWithCommit(clients, t)
-	expectedBranches := []string{"release-1.5", "release-1.6", "release-1.8"}
+	expectedBranches := []string{"release-1.5", "release-1.6", "release-1.8", "release-1.3"}
 	for _, branch := range expectedBranches {
 		if err := lg.CheckoutNewBranch("foo", "bar", branch); err != nil {
 			t.Fatalf("Checking out pull branch: %v", err)
@@ -402,6 +403,12 @@ func testCherryPickPR(clients localgit.Clients, t *testing.T) {
 					Login: "approver",
 				},
 				Body: "/cherrypick release-1.6",
+			},
+			{
+				User: github.User{
+					Login: "approver",
+				},
+				Body: "/cherrypick release-1.3 release-1.2",
 			},
 			{
 				User: github.User{
@@ -481,6 +488,9 @@ func testCherryPickPR(clients localgit.Clients, t *testing.T) {
 	var expectedFn = func(branch string) string {
 		expectedTitle := fmt.Sprintf("[%s] This is a fix for Y", branch)
 		expectedBody := fmt.Sprintf("This is an automated cherry-pick of #%d", prNumber)
+		if branch == "release-1.3" {
+			expectedBody = fmt.Sprintf("%s\n\n/cherrypick release-1.2", expectedBody)
+		}
 		expectedHead := fmt.Sprintf(botUser.Login+":"+cherryPickBranchFmt, prNumber, branch)
 		expectedLabels := s.labels
 		return fmt.Sprintf(expectedFmt, expectedTitle, expectedBody, expectedHead, branch, expectedLabels)
@@ -1007,13 +1017,13 @@ func TestHandleLocks(t *testing.T) {
 
 	go func() {
 		defer close(routine1Done)
-		if err := s.handle(l, "", &github.IssueComment{}, "org", "repo", "targetBranch", "baseBranch", "title", "body", 0); err != nil {
+		if err := s.handle(l, "", &github.IssueComment{}, "org", "repo", "targetBranch", "baseBranch", []string{}, "title", "body", 0); err != nil {
 			t.Errorf("routine failed: %v", err)
 		}
 	}()
 	go func() {
 		defer close(routine2Done)
-		if err := s.handle(l, "", &github.IssueComment{}, "org", "repo", "targetBranch", "baseBranch", "title", "body", 0); err != nil {
+		if err := s.handle(l, "", &github.IssueComment{}, "org", "repo", "targetBranch", "baseBranch", []string{}, "title", "body", 0); err != nil {
 			t.Errorf("routine failed: %v", err)
 		}
 	}()

--- a/pkg/plugins/bugzilla/bugzilla_test.go
+++ b/pkg/plugins/bugzilla/bugzilla_test.go
@@ -2244,7 +2244,7 @@ func TestGetCherrypickPRMatch(t *testing.T) {
 	}
 	for _, testCase := range testCases {
 		testPR := *pr
-		testPR.PullRequest.Body = cherrypicker.CreateCherrypickBody(prNum, testCase.requestor, testCase.note)
+		testPR.PullRequest.Body = cherrypicker.CreateCherrypickBody(prNum, testCase.requestor, testCase.note, []string{})
 		cherrypick, cherrypickOfPRNum, cherrypickTo, err := getCherryPickMatch(testPR)
 		if err != nil {
 			t.Fatalf("%s: Got error but did not expect one: %v", testCase.name, err)


### PR DESCRIPTION
This PR adds support for listing multiple branches to cherrypick to in a single line. When multiple branches are detected, a cherrypick is created for the first listed branch and the cherrypick will contain a `/cherrypick` command for the remaining branches. This allows a user to specify a chain of cherrypicks, where the first listed branch must be merged before moving onto the next.