### PR TITLE
Point code links to correct k8s-sigs/prow repo

### DIFF
--- a/site/content/en/docs/build-test-update.md
+++ b/site/content/en/docs/build-test-update.md
@@ -33,7 +33,7 @@ go build ./cmd/hook
 go test ./pkg/plugins/lgtm
 ```
 (Note: `deck` depends on non-go static files, these were tested by integration
-tests, and for e2e test use [`runlocal`](https://github.com/kubernetes/test-infra/tree/master/prow/cmd/deck/runlocal) if desired.)
+tests, and for e2e test use [`runlocal`](https://github.com/kubernetes-sigs/prow/tree/main/cmd/deck/runlocal) if desired.)
 
 ### How to test a plugin
 

--- a/site/content/en/docs/components/_index.md
+++ b/site/content/en/docs/components/_index.md
@@ -13,49 +13,49 @@ Prow has a microservice architecture implemented as a collection of container im
 
 #### Core Components
 
-* `crier` ([doc](/docs/components/core/crier/), [code](https://github.com/kubernetes/test-infra/tree/master/prow/cmd/crier)) reports on ProwJob status changes. Can be configured to report to gerrit, github, pubsub, slack, etc.
-* `deck` ([doc](/docs/components/core/deck/), [code](https://github.com/kubernetes/test-infra/tree/master/prow/cmd/deck)) presents a nice view of [recent jobs](https://prow.k8s.io/), [command](https://prow.k8s.io/command-help) and [plugin](https://prow.k8s.io/plugins) help information, the [current status](https://prow.k8s.io/tide) and [history](https://prow.k8s.io/tide-history) of merge automation, and a [dashboard for PR authors](https://prow.k8s.io/pr).
-* `hook` ([doc](/docs/components/core/hook/), [code](https://github.com/kubernetes/test-infra/tree/master/prow/cmd/hook)) is the most important piece. It is a stateless server that listens for GitHub webhooks and dispatches them to the appropriate plugins. Hook's plugins are used to trigger jobs, implement 'slash' commands, post to Slack, and more. See the plugins [doc](/docs/components/plugins/) and [code directory](https://github.com/kubernetes/test-infra/tree/master/prow/plugins) for more information on plugins.
-* `horologium` ([doc](/docs/components/core/horologium/), [code](https://github.com/kubernetes/test-infra/tree/master/prow/cmd/horologium)) triggers periodic jobs when necessary.
-* `prow-controller-manager` ([doc](/docs/components/core/prow-controller-manager/), [code](https://github.com/kubernetes/test-infra/tree/master/prow/cmd/prow-controller-manager)) manages the job execution and lifecycle for jobs that run in k8s pods. It currently acts as a replacement for [`plank`](/docs/components/deprecated/plank/)
-* `sinker` ([doc](/docs/components/core/sinker/), [code](https://github.com/kubernetes/test-infra/tree/master/prow/cmd/sinker)) cleans up old jobs and pods.
+* `crier` ([doc](/docs/components/core/crier/), [code](https://github.com/kubernetes-sigs/prow/tree/main/cmd/crier)) reports on ProwJob status changes. Can be configured to report to gerrit, github, pubsub, slack, etc.
+* `deck` ([doc](/docs/components/core/deck/), [code](https://github.com/kubernetes-sigs/prow/tree/main/cmd/deck)) presents a nice view of [recent jobs](https://prow.k8s.io/), [command](https://prow.k8s.io/command-help) and [plugin](https://prow.k8s.io/plugins) help information, the [current status](https://prow.k8s.io/tide) and [history](https://prow.k8s.io/tide-history) of merge automation, and a [dashboard for PR authors](https://prow.k8s.io/pr).
+* `hook` ([doc](/docs/components/core/hook/), [code](https://github.com/kubernetes-sigs/prow/tree/main/cmd/hook)) is the most important piece. It is a stateless server that listens for GitHub webhooks and dispatches them to the appropriate plugins. Hook's plugins are used to trigger jobs, implement 'slash' commands, post to Slack, and more. See the plugins [doc](/docs/components/plugins/) and [code directory](https://github.com/kubernetes-sigs/prow/tree/main/pkg/plugins) for more information on plugins.
+* `horologium` ([doc](/docs/components/core/horologium/), [code](https://github.com/kubernetes-sigs/prow/tree/main/cmd/horologium)) triggers periodic jobs when necessary.
+* `prow-controller-manager` ([doc](/docs/components/core/prow-controller-manager/), [code](https://github.com/kubernetes-sigs/prow/tree/main/cmd/prow-controller-manager)) manages the job execution and lifecycle for jobs that run in k8s pods. It currently acts as a replacement for [`plank`](/docs/components/deprecated/plank/)
+* `sinker` ([doc](/docs/components/core/sinker/), [code](https://github.com/kubernetes-sigs/prow/tree/main/cmd/sinker)) cleans up old jobs and pods.
 
 #### Merge Automation
 
-* `tide` ([doc](/docs/components/core/tide/), [code](https://github.com/kubernetes/test-infra/tree/master/prow/cmd/tide)) manages retesting and merging PRs once they meet the configured merge criteria. See [its README](/docs/components/core/tide/) for more information.
+* `tide` ([doc](/docs/components/core/tide/), [code](https://github.com/kubernetes-sigs/prow/tree/main/cmd/tide)) manages retesting and merging PRs once they meet the configured merge criteria. See [its README](/docs/components/core/tide/) for more information.
 
 #### Optional Components
 
-* `branchprotector` ([doc](/docs/components/optional/branchprotector/), [code](https://github.com/kubernetes/test-infra/tree/master/prow/cmd/branchprotector)) configures [github branch protection](https://help.github.com/articles/about-protected-branches/) according to a specified policy
-* `exporter` ([doc](/docs/components/optional/exporter/), [code](https://github.com/kubernetes/test-infra/tree/master/prow/cmd/exporter)) exposes metrics about ProwJobs not directly related to a specific Prow component
-* `gcsupload` ([doc](/docs/components/optional/gcsupload/), [code](https://github.com/kubernetes/test-infra/tree/master/prow/cmd/gcsupload))
-* `gerrit` ([doc](/docs/components/optional/gerrit/), [code](https://github.com/kubernetes/test-infra/tree/master/prow/cmd/gerrit)) is a Prow-gerrit adapter for handling CI on [gerrit](https://www.gerritcodereview.com/) workflows
-* `hmac` ([doc](/docs/components/optional/hmac/), [code](https://github.com/kubernetes/test-infra/tree/master/prow/cmd/hmac)) updates HMAC tokens, GitHub webhooks and HMAC secrets for the orgs/repos specified in the Prow config file
-* `jenkins-operator` ([doc](/docs/components/optional/jenkins-operator/), [code](https://github.com/kubernetes/test-infra/tree/master/prow/cmd/jenkins-operator)) is the controller that manages jobs that run on Jenkins. We moved away from using this component in favor of running all jobs on Kubernetes.
-* `tot` ([doc](/docs/components/optional/tot/), [code](https://github.com/kubernetes/test-infra/tree/master/prow/cmd/tot)) vends sequential build numbers. Tot is only necessary for integration with automation that expects sequential build numbers. If Tot is not used, Prow automatically generates build numbers that are monotonically increasing, but not sequential.
-* `status-reconciler` ([doc](/docs/components/optional/status-reconciler/), [code](https://github.com/kubernetes/test-infra/tree/master/prow/cmd/status-reconciler)) ensures changes to blocking presubmits in Prow configuration does not cause in-flight GitHub PRs to get stuck
-* `sub` ([doc](/docs/components/optional/sub/), [code](https://github.com/kubernetes/test-infra/tree/master/prow/cmd/sub)) listen to Cloud Pub/Sub notification to trigger Prow Jobs.
+* `branchprotector` ([doc](/docs/components/optional/branchprotector/), [code](https://github.com/kubernetes-sigs/prow/tree/main/cmd/branchprotector)) configures [github branch protection](https://help.github.com/articles/about-protected-branches/) according to a specified policy
+* `exporter` ([doc](/docs/components/optional/exporter/), [code](https://github.com/kubernetes-sigs/prow/tree/main/cmd/exporter)) exposes metrics about ProwJobs not directly related to a specific Prow component
+* `gcsupload` ([doc](/docs/components/optional/gcsupload/), [code](https://github.com/kubernetes-sigs/prow/tree/main/cmd/gcsupload))
+* `gerrit` ([doc](/docs/components/optional/gerrit/), [code](https://github.com/kubernetes-sigs/prow/tree/main/cmd/gerrit)) is a Prow-gerrit adapter for handling CI on [gerrit](https://www.gerritcodereview.com/) workflows
+* `hmac` ([doc](/docs/components/optional/hmac/), [code](https://github.com/kubernetes-sigs/prow/tree/main/cmd/hmac)) updates HMAC tokens, GitHub webhooks and HMAC secrets for the orgs/repos specified in the Prow config file
+* `jenkins-operator` ([doc](/docs/components/optional/jenkins-operator/), [code](https://github.com/kubernetes-sigs/prow/tree/main/cmd/jenkins-operator)) is the controller that manages jobs that run on Jenkins. We moved away from using this component in favor of running all jobs on Kubernetes.
+* `tot` ([doc](/docs/components/optional/tot/), [code](https://github.com/kubernetes-sigs/prow/tree/main/cmd/tot)) vends sequential build numbers. Tot is only necessary for integration with automation that expects sequential build numbers. If Tot is not used, Prow automatically generates build numbers that are monotonically increasing, but not sequential.
+* `status-reconciler` ([doc](/docs/components/optional/status-reconciler/), [code](https://github.com/kubernetes-sigs/prow/tree/main/cmd/status-reconciler)) ensures changes to blocking presubmits in Prow configuration does not cause in-flight GitHub PRs to get stuck
+* `sub` ([doc](/docs/components/optional/sub/), [code](https://github.com/kubernetes-sigs/prow/tree/main/cmd/sub)) listen to Cloud Pub/Sub notification to trigger Prow Jobs.
 
 ## CLI Tools
 
-* `checkconfig` ([doc](/docs/components/cli-tools/checkconfig/), [code](https://github.com/kubernetes/test-infra/tree/master/prow/cmd/checkconfig)) loads and verifies the configuration, useful as a pre-submit.
-* `config-bootstrapper` ([doc](/docs/components/cli-tools/config-bootstrapper/), [code](https://github.com/kubernetes/test-infra/tree/master/prow/cmd/config-bootstrapper)) bootstraps a configuration that would be incrementally updated by the [`updateconfig` Prow plugin](/docs/components/plugins/updateconfig/)
-* `generic-autobumper` ([doc](/docs/components/cli-tools/generic-autobumper/), [code](https://github.com/kubernetes/test-infra/tree/master/prow/cmd/generic-autobumper)) automates image version upgrades (e.g. for a Prow deployment) by opening a PR with images changed to their latest version according to a config file.
-* `invitations-accepter` ([doc](/docs/components/cli-tools/invitations-accepter/), [code](https://github.com/kubernetes/test-infra/tree/master/prow/cmd/invitations-accepter)) approves all pending GitHub repository invitations
-* `mkpj` ([doc](/docs/components/cli-tools/mkpj/), [code](https://github.com/kubernetes/test-infra/tree/master/prow/cmd/mkpj)) creates `ProwJobs` using Prow configuration.
-* `mkpod` ([doc](/docs/components/cli-tools/mkpod/), [code](https://github.com/kubernetes/test-infra/tree/master/prow/cmd/mkpod)) creates `Pods` from `ProwJobs`.
-* `peribolos` ([doc](/docs/components/cli-tools/peribolos/), [code](https://github.com/kubernetes/test-infra/tree/master/prow/cmd/peribolos)) manages GitHub org, team and membership settings according to a config file. Used by [kubernetes/org](https://github.com/kubernetes/org)
-* `phaino` ([doc](/docs/components/cli-tools/phaino/), [code](https://github.com/kubernetes/test-infra/tree/master/prow/cmd/phaino)) runs an approximation of a ProwJob on your local workstation
-* `phony` ([doc](/docs/components/cli-tools/phony/), [code](https://github.com/kubernetes/test-infra/tree/master/prow/cmd/phony)) sends fake webhooks for testing hook and plugins.
+* `checkconfig` ([doc](/docs/components/cli-tools/checkconfig/), [code](https://github.com/kubernetes-sigs/prow/tree/main/cmd/checkconfig)) loads and verifies the configuration, useful as a pre-submit.
+* `config-bootstrapper` ([doc](/docs/components/cli-tools/config-bootstrapper/), [code](https://github.com/kubernetes-sigs/prow/tree/main/cmd/config-bootstrapper)) bootstraps a configuration that would be incrementally updated by the [`updateconfig` Prow plugin](/docs/components/plugins/updateconfig/)
+* `generic-autobumper` ([doc](/docs/components/cli-tools/generic-autobumper/), [code](https://github.com/kubernetes-sigs/prow/tree/main/cmd/generic-autobumper)) automates image version upgrades (e.g. for a Prow deployment) by opening a PR with images changed to their latest version according to a config file.
+* `invitations-accepter` ([doc](/docs/components/cli-tools/invitations-accepter/), [code](https://github.com/kubernetes-sigs/prow/tree/main/cmd/invitations-accepter)) approves all pending GitHub repository invitations
+* `mkpj` ([doc](/docs/components/cli-tools/mkpj/), [code](https://github.com/kubernetes-sigs/prow/tree/main/cmd/mkpj)) creates `ProwJobs` using Prow configuration.
+* `mkpod` ([doc](/docs/components/cli-tools/mkpod/), [code](https://github.com/kubernetes-sigs/prow/tree/main/cmd/mkpod)) creates `Pods` from `ProwJobs`.
+* `peribolos` ([doc](/docs/components/cli-tools/peribolos/), [code](https://github.com/kubernetes-sigs/prow/tree/main/cmd/peribolos)) manages GitHub org, team and membership settings according to a config file. Used by [kubernetes/org](https://github.com/kubernetes/org)
+* `phaino` ([doc](/docs/components/cli-tools/phaino/), [code](https://github.com/kubernetes-sigs/prow/tree/main/cmd/phaino)) runs an approximation of a ProwJob on your local workstation
+* `phony` ([doc](/docs/components/cli-tools/phony/), [code](https://github.com/kubernetes-sigs/prow/tree/main/cmd/phony)) sends fake webhooks for testing hook and plugins.
 
 ## Pod Utilities
 
 These are small tools that are automatically added to ProwJob pods for jobs that request pod decoration. They are used to transparently provide source code cloning and upload of metadata, logs, and job artifacts to persistent storage. See [their README](/docs/components/pod-utilities/) for more information.
 
-* `clonerefs` ([doc](/docs/components/pod-utilities/clonerefs/), [code](https://github.com/kubernetes/test-infra/tree/master/prow/cmd/clonerefs))
-* `initupload` ([doc](/docs/components/pod-utilities/initupload/), [code](https://github.com/kubernetes/test-infra/tree/master/prow/cmd/initupload))
-* `entrypoint` ([doc](/docs/components/pod-utilities/entrypoint/), [code](https://github.com/kubernetes/test-infra/tree/master/prow/cmd/entrypoint))
-* `sidecar` ([doc](/docs/components/pod-utilities/sidecar/), [code](https://github.com/kubernetes/test-infra/tree/master/prow/cmd/sidecar))
+* `clonerefs` ([doc](/docs/components/pod-utilities/clonerefs/), [code](https://github.com/kubernetes-sigs/prow/tree/main/cmd/clonerefs))
+* `initupload` ([doc](/docs/components/pod-utilities/initupload/), [code](https://github.com/kubernetes-sigs/prow/tree/main/cmd/initupload))
+* `entrypoint` ([doc](/docs/components/pod-utilities/entrypoint/), [code](https://github.com/kubernetes-sigs/prow/tree/main/cmd/entrypoint))
+* `sidecar` ([doc](/docs/components/pod-utilities/sidecar/), [code](https://github.com/kubernetes-sigs/prow/tree/main/cmd/sidecar))
 
 ## Base Images
 
@@ -63,11 +63,11 @@ The container images in [`images`](https://github.com/kubernetes/test-infra/tree
 
 ## TODO: undocumented
 
-* `admission` ([doc](/docs/components/undocumented/admission/), [code](https://github.com/kubernetes/test-infra/tree/master/prow/cmd/admission))
-* `grandmatriarch` ([doc](/docs/components/undocumented/grandmatriarch/), [code](https://github.com/kubernetes/test-infra/tree/master/prow/cmd/grandmatriarch))
-* `pipeline` ([doc](/docs/components/undocumented/pipeline/), [code](https://github.com/kubernetes/test-infra/tree/master/prow/cmd/pipeline))
-* `tackle` ([doc](/docs/components/undocumented/tackle/), [code](https://github.com/kubernetes/test-infra/tree/master/prow/cmd/tackle))
+* `admission` ([doc](/docs/components/undocumented/admission/), [code](https://github.com/kubernetes-sigs/prow/tree/main/cmd/admission))
+* `grandmatriarch` ([doc](/docs/components/undocumented/grandmatriarch/), [code](https://github.com/kubernetes-sigs/prow/tree/main/cmd/grandmatriarch))
+* `pipeline` ([doc](/docs/components/undocumented/pipeline/), [code](https://github.com/kubernetes-sigs/prow/tree/main/cmd/pipeline))
+* `tackle` ([doc](/docs/components/undocumented/tackle/), [code](https://github.com/kubernetes-sigs/prow/tree/main/cmd/tackle))
 
 ## Deprecated
 
-* `cm2kc` ([doc](/docs/components/deprecated/cm2kc/), [code](https://github.com/kubernetes/test-infra/tree/master/prow/cmd/cm2kc)) is a CLI tool used to convert a [clustermap file](/docs/getting-started-deploy/#run-test-pods-in-different-clusters) to a [kubeconfig file](https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/). Deprecated because we have moved away from clustermaps; you should use [`gencred`](https://github.com/kubernetes/test-infra/tree/master/gencred) to generate a [kubeconfig file](https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/) directly.
+* `cm2kc` ([doc](/docs/components/deprecated/cm2kc/), [code](https://github.com/kubernetes-sigs/prow/tree/main/cmd/cm2kc)) is a CLI tool used to convert a [clustermap file](/docs/getting-started-deploy/#run-test-pods-in-different-clusters) to a [kubeconfig file](https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/). Deprecated because we have moved away from clustermaps; you should use [`gencred`](https://github.com/kubernetes/test-infra/tree/master/gencred) to generate a [kubeconfig file](https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/) directly.

--- a/site/content/en/docs/components/cli-tools/phony.md
+++ b/site/content/en/docs/components/cli-tools/phony.md
@@ -50,4 +50,4 @@ If you are testing `hook` and successfully sent the webhook from `phony`, you sh
 {"author":"","component":"hook","event-GUID":"GUID","event-type":"pull_request","level":"info","msg":"Pull request .","org":"","pr":0,"repo":"","time":"2018-05-29T11:38:57-07:00","url":""}
 ```
 
-A list of supported events can be found in the [GitHub API Docs](https://developer.github.com/v3/activity/events/types/). Some example event payloads can be found in the [`examples`](https://github.com/kubernetes/test-infra/tree/master/prow/cmd/phony/examples) directory.
+A list of supported events can be found in the [GitHub API Docs](https://developer.github.com/v3/activity/events/types/). Some example event payloads can be found in the [`examples`](https://github.com/kubernetes-sigs/prow/tree/main/cmd/phony/examples) directory.

--- a/site/content/en/docs/components/core/crier.md
+++ b/site/content/en/docs/components/core/crier.md
@@ -12,7 +12,7 @@ Crier reports your prowjobs on their status changes.
 For any reporter you want to use, you need to mount your prow configs and specify `--config-path` and `job-config-path`
 flag as most of other prow controllers do.
 
-### [Gerrit reporter](https://github.com/kubernetes/test-infra/tree/master/prow/crier/reporters/gerrit)
+### [Gerrit reporter](https://github.com/kubernetes-sigs/prow/tree/main/pkg/crier/reporters/gerrit)
 
 You can enable gerrit reporter in crier by specifying `--gerrit-workers=n` flag.
 
@@ -27,7 +27,7 @@ The reporter will also cast a +1/-1 vote on the `prow.k8s.io/gerrit-report-label
 or by default it will vote on `CodeReview` label. Where `+1` means all jobs on the patshset pass and `-1`
 means one or more jobs failed on the patchset.
 
-### [Pubsub reporter](https://github.com/kubernetes/test-infra/tree/master/prow/crier/reporters/pubsub)
+### [Pubsub reporter](https://github.com/kubernetes-sigs/prow/tree/main/pkg/crier/reporters/pubsub)
 
 You can enable pubsub reporter in crier by specifying `--pubsub-workers=n` flag.
 
@@ -45,7 +45,7 @@ Pubsub reporter will report whenever prowjob has a state transition.
 
 You can check the reported result by [list the pubsub topic](https://cloud.google.com/sdk/gcloud/reference/pubsub/topics/list).
 
-### [GitHub reporter](https://github.com/kubernetes/test-infra/tree/master/prow/crier/reporters/github)
+### [GitHub reporter](https://github.com/kubernetes-sigs/prow/tree/main/pkg/crier/reporters/github)
 
 You can enable github reporter in crier by specifying `--github-workers=N` flag (N>0).
 
@@ -53,9 +53,9 @@ You also need to mount a github oauth token by specifying `--github-token-path` 
 
 If you have a [ghproxy](https://github.com/kubernetes/test-infra/tree/master/ghproxy) deployed, also remember to point `--github-endpoint` to your ghproxy to avoid token throttle.
 
-The actual report logic is in the [github report library](https://github.com/kubernetes/test-infra/tree/master/prow/github/report) for your reference.
+The actual report logic is in the [github report library](https://github.com/kubernetes-sigs/prow/tree/main/pkg/github/report) for your reference.
 
-### [Slack reporter](https://github.com/kubernetes/test-infra/tree/master/prow/crier/reporters/slack)
+### [Slack reporter](https://github.com/kubernetes-sigs/prow/tree/main/pkg/crier/reporters/slack)
 
 > **NOTE:** if enabling the slack reporter for the *first* time, Crier will message to the Slack channel for **all** ProwJobs matching the configured filtering criteria.
 

--- a/site/content/en/docs/components/core/tide/config.md
+++ b/site/content/en/docs/components/core/tide/config.md
@@ -160,7 +160,7 @@ All PRs that conform to the criteria are processed and merged.
 The processing itself can include running jobs (e.g. tests) to verify the PRs are good to go.
 All commits in PRs from `github.com/kubeflow/community` repository are squashed before merging.
 
-For a full list of properties of queries, please refer to [https://github.com/kubernetes/test-infra/blob/27c9a7f2784088c2db5ff133e8a7a1e2eab9ab3f/prow/config/prow-config-documented.yaml#:~:text=meet%20merge%20requirements.-,queries%3A,-%2D%20author%3A%20%27%20%27](https://github.com/kubernetes/test-infra/tree/master/prow/config/prow-config-documented.yaml).
+For a full list of properties of queries, please refer to [https://github.com/kubernetes/test-infra/blob/27c9a7f2784088c2db5ff133e8a7a1e2eab9ab3f/prow/config/prow-config-documented.yaml#:~:text=meet%20merge%20requirements.-,queries%3A,-%2D%20author%3A%20%27%20%27](https://github.com/kubernetes-sigs/prow/tree/main/pkg/config/prow-config-documented.yaml).
 
 ### Persistent Storage of Action History
 

--- a/site/content/en/docs/components/plugins/_index.md
+++ b/site/content/en/docs/components/plugins/_index.md
@@ -35,7 +35,7 @@ External plugins are well suited for:
 - Isolating a more or less privileged plugin or a plugin that executes PR code.
 - Integrating existing GitHub services with Prow.
 
-Examples of external plugins can be found in the [`prow/external-plugins`](https://github.com/kubernetes/test-infra/tree/master/prow/external-plugins) directory. The following is an example external plugin configuration that would live in [`plugins.yaml`](https://github.com/kubernetes/test-infra/tree/master/config/prow/plugins.yaml).
+Examples of external plugins can be found in the [`prow/pkg/external-plugins`](https://github.com/kubernetes-sigs/prow/tree/main/cmd/external-plugins) directory. The following is an example external plugin configuration that would live in [`plugins.yaml`](https://github.com/kubernetes/test-infra/tree/master/config/prow/plugins.yaml).
 
 ```yaml
 external_plugins:

--- a/site/content/en/docs/components/plugins/approve/approvers/_index.md
+++ b/site/content/en/docs/components/plugins/approve/approvers/_index.md
@@ -228,12 +228,12 @@ If an approval is cancelled, the bot will delete the status added to the PR and 
 ### Code Implementation Links
 
 Blunderbuss: 
-[prow/plugins/blunderbuss/blunderbuss.go](https://git.sigs.k8s.io/prow/pkg/plugins/blunderbuss/blunderbuss.go)
+[prow/pkg/plugins/blunderbuss/blunderbuss.go](https://github.com/kubernetes-sigs/prow/tree/main/pkg/plugins/blunderbuss/blunderbuss.go)
 
 LGTM:
-[prow/plugins/lgtm/lgtm.go](https://git.sigs.k8s.io/prow/pkg/plugins/lgtm/lgtm.go)
+[prow/pkg/plugins/lgtm/lgtm.go](https://github.com/kubernetes-sigs/prow/tree/main/pkg/plugins/lgtm/lgtm.go)
 
 Approve:
-[prow/plugins/approve/approve.go](https://git.sigs.k8s.io/prow/pkg/plugins/approve/approve.go)
+[prow/pkg/plugins/approve/approve.go](https://github.com/kubernetes-sigs/prow/tree/main/pkg/plugins/approve/approve.go)
 
-[prow/plugins/approve/approvers/owners.go](https://git.sigs.k8s.io/prow/pkg/plugins/approve/approvers/owners.go)
+[prow/pkg/plugins/approve/approvers/owners.go](https://github.com/kubernetes-sigs/prow/tree/main/pkg/plugins/approve/approvers/owners.go)

--- a/site/content/en/docs/config.md
+++ b/site/content/en/docs/config.md
@@ -8,4 +8,4 @@ description: >
 Core Prow component configuration is managed by the `config` package and stored in the [`Config` struct](https://godoc.org/sigs.k8s.io/prow/pkg/config#Config). If a configuration guide is available for a component it can be found in the ["Components"](/docs/components/) directory. See [`jobs.md`](/docs/jobs/) for a guide to configuring ProwJobs.
 Configuration for plugins is handled and stored separately. See the [`plugins`](/docs/components/plugins/) package for details.
 
-You can find a sample config with all possible options and a documentation of them [here.](https://github.com/kubernetes/test-infra/tree/master/prow/config/prow-config-documented.yaml)
+You can find a sample config with all possible options and a documentation of them [here.](https://github.com/kubernetes-sigs/prow/tree/main/pkg/config/prow-config-documented.yaml)

--- a/site/content/en/docs/gerrit.md
+++ b/site/content/en/docs/gerrit.md
@@ -9,14 +9,14 @@ description: >
 
 ## Related Deployments
 
-- Prow-gerrit adapter ([doc](/docs/components/optional/gerrit/), [code](https://github.com/kubernetes/test-infra/tree/master/prow/cmd/gerrit))
-- Crier (the reporter) ([doc](/docs/components/core/crier/), [code](https://github.com/kubernetes/test-infra/tree/master/prow/cmd/crier))
+- Prow-gerrit adapter ([doc](/docs/components/optional/gerrit/), [code](https://github.com/kubernetes-sigs/prow/tree/main/cmd/gerrit))
+- Crier (the reporter) ([doc](/docs/components/core/crier/), [code](https://github.com/kubernetes-sigs/prow/tree/main/cmd/crier))
 
 ## Related packages
 
 #### Client
 
-We have a [gerrit-client package](https://github.com/kubernetes/test-infra/tree/master/prow/gerrit/client) that provides a thin wrapper around  
+We have a [gerrit-client package](https://github.com/kubernetes-sigs/prow/tree/main/pkg/gerrit/client) that provides a thin wrapper around
 [andygrunwald/go-gerrit](https://github.com/andygrunwald/go-gerrit), which is a go client library
 for accessing the [Gerrit Code Review REST API](https://gerrit-review.googlesource.com/Documentation/rest-api.html)
 
@@ -52,7 +52,7 @@ presubmit and postsubmit jobs based on your prow config.
 
 #### Gerrit Labels
 
-Prow adds the following [Labels](https://github.com/kubernetes/test-infra/tree/master/prow/gerrit/client/client.go) to Gerrit Presubmits that can be accessed in the container by leveraging the [Downward API](https://kubernetes.io/docs/tasks/inject-data-application/environment-variable-expose-pod-information/).
+Prow adds the following [Labels](https://github.com/kubernetes-sigs/prow/tree/main/pkg/gerrit/client/client.go) to Gerrit Presubmits that can be accessed in the container by leveraging the [Downward API](https://kubernetes.io/docs/tasks/inject-data-application/environment-variable-expose-pod-information/).
 
 - "prow.k8s.io/gerrit-revision": SHA of current patchset from a gerrit change
 - "prow.k8s.io/gerrit-patchset": Numeric ID of the current patchset

--- a/site/content/en/docs/getting-started-deploy.md
+++ b/site/content/en/docs/getting-started-deploy.md
@@ -436,7 +436,7 @@ You may choose to run test pods in a separate cluster entirely. This is a good p
 One can use a Kubernetes [`kubeconfig`](https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/) file (i.e. `Config` object) to instruct Prow components to use the *build* cluster(s).
 All contexts in `kubeconfig` are used as *build* clusters and the [`InClusterConfig`](https://kubernetes.io/docs/tasks/access-application-cluster/access-cluster/#accessing-the-api-from-a-pod) (or `current-context`) is the *default*.
 
-NOTE: See the [`create-build-cluster.sh` script](https://github.com/kubernetes/test-infra/tree/master/prow/create-build-cluster.sh) to help you quickly create and register a GKE cluster as a build cluster for a Prow instance. Continue reading for information about registering a build cluster by hand.
+NOTE: See the [`create-build-cluster.sh` script](https://github.com/kubernetes-sigs/prow/tree/main/pkg/create-build-cluster.sh) to help you quickly create and register a GKE cluster as a build cluster for a Prow instance. Continue reading for information about registering a build cluster by hand.
 
 Create a secret containing a `kubeconfig` like this:
 

--- a/site/content/en/docs/github.md
+++ b/site/content/en/docs/github.md
@@ -10,19 +10,19 @@ It uses both [v3](https://developer.github.com/v3/) and [v4](https://developer.g
 of GitHub's API. It is subject to change as needed without notice, but you can reuse and extend it
 within this repository.
 
-Its primary component is [client.go](https://github.com/kubernetes/test-infra/tree/master/prow/github/client.go), a GitHub client that sends and receives API calls.
+Its primary component is [client.go](https://github.com/kubernetes-sigs/prow/tree/main/pkg/github/client.go), a GitHub client that sends and receives API calls.
 
 ## Recommended Usage
 
 ### Instantiation
 An application that takes flags may want to set GitHub flags, such as a proxy endpoint. To do that,
-[GitHubOptions](https://github.com/kubernetes/test-infra/tree/master/prow/flagutil/github.go) has a method that returns a GitHub client.
+[GitHubOptions](https://github.com/kubernetes-sigs/prow/tree/main/pkg/flagutil/github.go) has a method that returns a GitHub client.
 
 If you're not using flags, you can instantiate a client with the `NewClient` and
 `NewClientWithFields` methods
 
 ### Interfacing a Subset of Client
-This client has a lot of functions listed in the interfaces of [client.go](https://github.com/kubernetes/test-infra/tree/master/prow/github/client.go). Further,
+This client has a lot of functions listed in the interfaces of [client.go](https://github.com/kubernetes-sigs/prow/tree/main/pkg/github/client.go). Further,
 these interfaces may change at any time. To avoid having to extend the entire interface, we
 recommend writing a local interface that uses the functionality you need.
 
@@ -36,5 +36,5 @@ type githubClient interface {
 }
 ```
 
-The provided fake works like this; [FakeClient](https://github.com/kubernetes/test-infra/tree/master/prow/github/fakegithub/fakegithub.go) doesn't completely
+The provided fake works like this; [FakeClient](https://github.com/kubernetes-sigs/prow/tree/main/pkg/github/fakegithub/fakegithub.go) doesn't completely
 implement Client, but gives many common functions used in testing.

--- a/site/content/en/docs/more-prow.md
+++ b/site/content/en/docs/more-prow.md
@@ -23,7 +23,7 @@ postsubmit job that `kubectl apply`s the resource files whenever they are
 changed (based on a `run_if_changed` or `skip_if_only_changed` regexp). In
 order to `kubectl apply` to the cluster, the job will need to supply credentials
 (e.g. a kubeconfig file or
-[GCP service account key-file](https://github.com/kubernetes/test-infra/tree/master/prow/gcloud-deployer-service-account.sh)). Since
+[GCP service account key-file](https://github.com/kubernetes-sigs/prow/tree/main/pkg/gcloud-deployer-service-account.sh)). Since
 this job requires priviledged credentials to deploy to the cluster, it is
 important that it is run in a separate build cluster that is isolated from all
 presubmit jobs. See the

--- a/site/content/en/docs/overview/_index.md
+++ b/site/content/en/docs/overview/_index.md
@@ -129,7 +129,7 @@ If you need to contact the maintainers of Prow you have a few options:
 
 1. Open an issue in the [kubernetes/test-infra](https://github.com/kubernetes/test-infra) repo.
 1. Reach out to the `#prow` channel of the [Kubernetes Slack](https://github.com/kubernetes/community/tree/master/communication#social-media).
-1. Contact one of the code owners in [prow/OWNERS](https://github.com/kubernetes/test-infra/tree/master/prow/OWNERS) or in a more specifically scoped OWNERS file.
+1. Contact one of the code owners in [prow/pkg/OWNERS](https://github.com/kubernetes-sigs/prow/tree/main/pkg/OWNERS) or in a more specifically scoped OWNERS file.
 
 ### Bots home
 

--- a/site/content/en/docs/spyglass/architecture.md
+++ b/site/content/en/docs/spyglass/architecture.md
@@ -12,7 +12,7 @@ with artifacts.
 
 ## Spyglass Core
 
-The Spyglass Core is split across [`prow/spyglass`](https://github.com/kubernetes/test-infra/tree/master/prow/spyglass) and [`prow/cmd/deck`](https://github.com/kubernetes/test-infra/tree/master/prow/cmd/deck). It has
+The Spyglass Core is split across [`prow/pkg/spyglass`](https://github.com/kubernetes-sigs/prow/tree/main/pkg/spyglass) and [`prow/cmd/deck`](https://github.com/kubernetes-sigs/prow/tree/main/cmd/deck). It has
 the following responsibilities:
 
 - Looking up artifacts for a given job and mapping those to lenses
@@ -22,7 +22,7 @@ the following responsibilities:
 
 ## Spyglass Lenses
 
-Spyglass Lenses currently all live in [`prow/spyglass/lenses`](https://github.com/kubernetes/test-infra/tree/master/prow/spyglass/lenses), though hopefully in the
+Spyglass Lenses currently all live in [`prow/pkg/spyglass/lenses`](https://github.com/kubernetes-sigs/prow/tree/main/pkg/spyglass/lenses), though hopefully in the
 future they can live elsewhere. Spyglass lenses have the following responsibilities:
 
 - Fetching artifacts
@@ -34,17 +34,17 @@ intended API. In particular, this prevents lenses from interacting with other De
 the core spyglass page.
 
 In order to provide this API to lenses, a library
-([`prow/cmd/deck/static/spyglass/lens.ts`](https://github.com/kubernetes/test-infra/tree/master/prow/cmd/deck/static/spyglass/lens.ts)) is injected into
+([`prow/cmd/deck/static/spyglass/lens.ts`](https://github.com/kubernetes-sigs/prow/tree/main/cmd/deck/static/spyglass/lens.ts)) is injected into
 the lenses under the `spyglass` namespace. This library communicates with the spyglass core via
 [`window.postMessage`](https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage). The
 spyglass core then takes the requested action on the lens's behalf, which includes facilitating
 communication between the lens frontend and backend. The messages exchanged between the core and the
-lens are described in [`prow/cmd/deck/static/spyglass/common.ts`](https://github.com/kubernetes/test-infra/tree/master/prow/cmd/deck/static/spyglass/common.ts).
+lens are described in [`prow/cmd/deck/static/spyglass/common.ts`](https://github.com/kubernetes-sigs/prow/tree/main/cmd/deck/static/spyglass/common.ts).
 The messages are exchanged over a simple JSON-encoded protocol where each message sent from the lens
 has an ID number attached, and a response with the same ID number is expected to be received.
 
 For the purposes of static typing, the lens library is ambiently declared in
-[`spyglass/lenses/lens.d.ts`](https://github.com/kubernetes/test-infra/tree/master/prow/spyglass/lenses/lens.d.ts), which just re-exports the definition of
+[`spyglass/lenses/lens.d.ts`](https://github.com/kubernetes-sigs/prow/tree/main/pkg/spyglass/lenses/lens.d.ts), which just re-exports the definition of
 `spyglass` from `lens.ts`.
 
 This design is discussed in its [implementation PR](https://github.com/kubernetes/test-infra/pull/10208).

--- a/site/content/en/docs/spyglass/write-a-lens.md
+++ b/site/content/en/docs/spyglass/write-a-lens.md
@@ -10,7 +10,7 @@ Spyglass lenses consist of two components: a frontend (which may be trivial) and
 ## Lens backend
 
 Today, a lens backend must be linked in to the `deck` binary. As such, lenses must live under
-[`prow/spyglass/lenses`](https://github.com/kubernetes/test-infra/tree/master/prow/spyglass/lenses). Additionally lenses **must** be in a folder that matches the
+[`prow/pkg/spyglass/lenses`](https://github.com/kubernetes-sigs/prow/tree/main/pkg/spyglass/lenses). Additionally lenses **must** be in a folder that matches the
 name of the lens. The content of this folder will be served by `deck`, enabling you to reference
 static content such as images, stylesheets, or scripts.
 
@@ -64,7 +64,7 @@ If you want to read resources included in your lens (such as templates), you can
 provided `resourceDir`.
 
 Finally, you will need to import your lens from `deck` in order to actually link it in. You can do
-this by `import`ing it from [`prow/cmd/deck/main.go`](https://github.com/kubernetes/test-infra/tree/master/prow/cmd/deck/main.go), alongside the other lenses:
+this by `import`ing it from [`prow/cmd/deck/main.go`](https://github.com/kubernetes-sigs/prow/tree/main/cmd/deck/main.go), alongside the other lenses:
 
 ```go
 import (
@@ -104,7 +104,7 @@ a template called `template.html`, a typescript file called `sample.ts`, a style
 }
 ```
 
-2. Add a line in [prow/cmd/deck/.ts-packages](https://github.com/kubernetes/test-infra/tree/master/prow/cmd/deck/.ts-packages):
+2. Add a line in [prow/cmd/deck/.ts-packages](https://github.com/kubernetes-sigs/prow/tree/main/cmd/deck/.ts-packages):
 
 ```
 prow/spyglass/lenses/sample/sample.ts->script_bundle.min.js

--- a/site/content/en/docs/test/integration/_index.md
+++ b/site/content/en/docs/test/integration/_index.md
@@ -30,7 +30,7 @@ description: >
 Assume we want to add `most-awesome-component` (source code in `cmd/most-awesome-component`).
 
 1. Add `most-awesome-component` to the `PROW_COMPONENTS`, `PROW_IMAGES`, and
-   `PROW_IMAGES_TO_COMPONENTS` variables in [lib.sh](https://github.com/kubernetes/test-infra/tree/master/prow/test/integration/lib.sh).
+   `PROW_IMAGES_TO_COMPONENTS` variables in [lib.sh](https://github.com/kubernetes-sigs/prow/tree/main/test/integration/lib.sh).
 
    - Add the line `most-awesome-component` to `PROW_COMPONENTS`.
    - Add the line `[most-awesome-component]=cmd/most-awesome-component` to `PROW_IMAGES`.
@@ -48,7 +48,7 @@ Assume we want to add `most-awesome-component` (source code in `cmd/most-awesome
 2. Set up Kubernetes Deployment and Service configurations inside the
    [configuration folder][config/prow/cluster] for your new component. This
    way the test cluster will pick it up when it [deploys Prow
-   components](https://github.com/kubernetes/test-infra/tree/master/prow/test/integration/setup-prow-components.sh).
+   components](https://github.com/kubernetes-sigs/prow/tree/main/test/integration/setup-prow-components.sh).
 
    - If you want to deploy an existing Prow component used in production (i.e.,
      <https://prow.k8s.io>), you can reuse (symlink) the configurations used in
@@ -60,7 +60,7 @@ Assume we want to add `most-awesome-component` (source code in `cmd/most-awesome
 
 ## New tests
 
-Tests are written under the [`test`](https://github.com/kubernetes/test-infra/tree/master/prow/test/integration/test) directory. They are named with the
+Tests are written under the [`test`](https://github.com/kubernetes-sigs/prow/tree/main/test/integration/test) directory. They are named with the
 pattern `<COMPONENT>_test.go*`. Continuing the example above, you would add new
 tests in `most-awesome-component_test.go`
 
@@ -82,7 +82,7 @@ your tests still need some tweaking), repeat steps 1 and 3 as needed.
 
 # How it works
 
-In short, the [integration-test.sh](https://github.com/kubernetes/test-infra/tree/master/prow/test/integration/integration-test.sh) script creates a
+In short, the [integration-test.sh](https://github.com/kubernetes-sigs/prow/tree/main/test/integration/integration-test.sh) script creates a
 [KIND](https://kind.sigs.k8s.io/) Kubernetes cluster, runs all available
 integration tests, and finally deletes the cluster.
 
@@ -92,9 +92,9 @@ deploy certain Prow components, and then from the integration tests we can
 create a Kubernetes Client to talk to this deployment of Prow.
 
 Note that the integration tests do not test all components (we need to fix
-this). [The PROW_COMPONENTS variable](https://github.com/kubernetes/test-infra/tree/master/prow/test/integration/lib.sh) is a list of components currently
+this). [The PROW_COMPONENTS variable](https://github.com/kubernetes-sigs/prow/tree/main/test/integration/lib.sh) is a list of components currently
 tested. These components are compiled and deployed into the test cluster on
-every invocation of [integration-test.sh](https://github.com/kubernetes/test-infra/tree/master/prow/test/integration/integration-test.sh).
+every invocation of [integration-test.sh](https://github.com/kubernetes-sigs/prow/tree/main/test/integration/integration-test.sh).
 
 Each tested component needs a Kubernetes configuration so that KIND understands
 how to deploy it into the cluster, but that's about it (more on this below). The


### PR DESCRIPTION
Point links that referred to the old test-infra repo to the new repo. No attempt was made to detect/correct bad links, just replacing paths known to be outdated.