### PR TITLE
Organize `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,34 @@
 _bin/
 _output/
 .python_virtual_env
-/yarn.lock
-/node_modules
+*.min.js
+
+pj.yaml
+pod.yaml
+
+# See https://github.com/kubernetes-sigs/prow/pull/101#discussion_r1568605799
+yarn.lock
+node_modules/
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Go vendor directory
+vendor/
+
+# Go workspace file
+go.work
+go.work.sum
+
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
 cmd/branchprotector/branchprotector
 cmd/build/build
 cmd/checkconfig/checkconfig
@@ -34,7 +60,17 @@ cmd/external-plugins/cherrypicker/cherrypicker
 cmd/external-plugins/needs-rebase/needs-rebase
 cmd/external-plugins/refresh/refresh
 cmd/ghproxy/ghproxy
-pj.yaml
-pod.yaml
-*.min.js
-vendor/
+
+# Generated files by hugo
+site/public/
+site/resources/_gen/
+site/assets/jsconfig.json
+hugo_stats.json
+
+# Executable may be added to repository
+hugo.exe
+hugo.darwin
+hugo.linux
+
+# Temporary lock file while building
+.hugo_build.lock


### PR DESCRIPTION
This PR organizes `.gitignore` file, where the details are:

- adds some heading comments
- adds Golang-related entities
  (from https://github.com/github/gitignore/blob/main/Go.gitignore)
- adds Hugo-related entities
  (from https://github.com/github/gitignore/blob/main/community/Golang/Hugo.gitignore)

/label tide/merge-method-squash