### PR TITLE
doc: Fix broken link to GitHub repo in home page

### DIFF
--- a/site/content/en/_index.html
+++ b/site/content/en/_index.html
@@ -8,7 +8,7 @@ title = "Prow"
 	<a class="btn btn-lg btn-primary mr-3 mb-4" href="{{< relref "/docs" >}}">
 		Learn more <i class="fas fa-arrow-alt-circle-right ml-2"></i>
 	</a>
-	<a class="btn btn-lg btn-secondary mr-3 mb-4" href="https://github.com/kubernetes-sigs/prow/tree/main/prow">
+	<a class="btn btn-lg btn-secondary mr-3 mb-4" href="https://github.com/kubernetes-sigs/prow">
 		Get the code <i class="fab fa-github ml-2 "></i>
 	</a>
     <br />


### PR DESCRIPTION
Currently, the "Get the code" link in home page is broken.
This PR fixes the broken link to GitHub repo in home page.

/label tide/merge-method-squash