### PR TITLE
[Feature]: [assign plugin] Support GitHub Organization Teams as targets for assign/cc commands

### DIFF
--- a/pkg/plugins/assign/assign.go
+++ b/pkg/plugins/assign/assign.go
@@ -87,7 +87,11 @@ func handleGenericComment(pc plugins.Agent, e github.GenericCommentEvent) error 
 }
 
 func isTeamLogin(login string) bool {
-	return strings.Contains(login, "/")
+	match, err := regexp.MatchString(`^[a-zA-Z0-9]+/[a-zA-Z0-9]+$`, login)
+	if err != nil {
+		return false
+	}
+	return match
 }
 
 func parseLogins(text string) []string {

--- a/pkg/plugins/assign/assign.go
+++ b/pkg/plugins/assign/assign.go
@@ -87,7 +87,7 @@ func handleGenericComment(pc plugins.Agent, e github.GenericCommentEvent) error 
 }
 
 func isTeamLogin(login string) bool {
-	match, err := regexp.MatchString(`^[a-zA-Z0-9]+/[a-zA-Z0-9]+$`, login)
+	match, err := regexp.MatchString(`^[a-zA-Z0-9]+(?:-[a-zA-Z0-9]+)*/[a-zA-Z0-9]+(?:-[a-zA-Z0-9]+)*$`, login)
 	if err != nil {
 		return false
 	}

--- a/pkg/plugins/assign/assign_test.go
+++ b/pkg/plugins/assign/assign_test.go
@@ -95,6 +95,16 @@ func (c *fakeClient) CreateComment(owner, repo string, number int, comment strin
 	return nil
 }
 
+func (c *fakeClient) ListTeamMembersBySlug(org, teamSlug, role string) ([]github.TeamMember, error) {
+	if teamSlug == "kubernetes/sig-testing-misc" {
+		return []github.TeamMember{
+			{Login: "cjwagner"},
+			{Login: "merlin"},
+		}, nil
+	}
+	return []github.TeamMember{}, nil
+}
+
 func newFakeClient(contribs []string) *fakeClient {
 	c := &fakeClient{
 		contributors: make(map[string]bool),
@@ -378,13 +388,13 @@ func TestAssignAndReview(t *testing.T) {
 			name:      "request team review",
 			body:      "/cc @kubernetes/sig-testing-misc",
 			commenter: "rando",
-			requested: []string{"kubernetes/sig-testing-misc"},
+			requested: []string{"cjwagner", "merlin"},
 		},
 		{
 			name:        "unrequest team review",
 			body:        "/uncc @kubernetes/sig-testing-misc",
 			commenter:   "rando",
-			unrequested: []string{"kubernetes/sig-testing-misc"},
+			unrequested: []string{"cjwagner", "merlin"},
 		},
 	}
 	for _, tc := range testcases {


### PR DESCRIPTION
close #145 

## Feature Description

Support `/cc <teams>` `/assign <teams>` command to request review(s) to teams,

**Example**

For example, let’s assume that the members of the `kubernetes/sig-team-foo` team are Alice, Bob, and Carol.
In this case, `/cc kubernetes/sig-team-foo` command will request reviews from all three members: Alice, Bob, and Carol.
Of course,  `/assign` command works in the same way.