### PR TITLE
external-plugins/cherrypicker: include PR description as comment

### DIFF
--- a/cmd/external-plugins/cherrypicker/server.go
+++ b/cmd/external-plugins/cherrypicker/server.go
@@ -259,7 +259,7 @@ func (s *Server) handleIssueComment(l *logrus.Entry, ic github.IssueCommentEvent
 
 func (s *Server) handlePullRequest(l *logrus.Entry, pre github.PullRequestEvent) error {
 	// Only consider newly merged PRs
-	if pre.Action != github.PullRequestActionClosed && pre.Action != github.PullRequestActionLabeled {
+	if pre.Action != github.PullRequestActionClosed && pre.Action != github.PullRequestActionLabeled && pre.Action != github.PullRequestActionOpened {
 		return nil
 	}
 
@@ -291,6 +291,12 @@ func (s *Server) handlePullRequest(l *logrus.Entry, pre github.PullRequestEvent)
 	requestorToComments := make(map[string]map[string]*github.IssueComment)
 	// target branch -> chain branches (eg. "release-1.6" -> []string{"release-1.5", "release-1.4"})
 	targetBranchToChainBranches := make(map[string][]string)
+
+	// treat PR body/description as a comment
+	comments = append([]github.IssueComment{{
+		Body: body,
+		User: pr.User,
+	}}, comments...)
 
 	// first look for our special comments
 	for i := range comments {

--- a/cmd/external-plugins/cherrypicker/server_test.go
+++ b/cmd/external-plugins/cherrypicker/server_test.go
@@ -365,7 +365,7 @@ func TestCherryPickPRV2(t *testing.T) {
 func testCherryPickPR(clients localgit.Clients, t *testing.T) {
 	prNumber := fakePR.GetPRNumber()
 	lg, c := makeFakeRepoWithCommit(clients, t)
-	expectedBranches := []string{"release-1.5", "release-1.6", "release-1.8", "release-1.3", "release-1.12"}
+	expectedBranches := []string{"release-1.5", "release-1.6", "release-1.8", "release-1.3", "release-1.12", "release-1.13"}
 	for _, branch := range expectedBranches {
 		if err := lg.CheckoutNewBranch("foo", "bar", branch); err != nil {
 			t.Fatalf("Checking out pull branch: %v", err)
@@ -465,6 +465,10 @@ func testCherryPickPR(clients localgit.Clients, t *testing.T) {
 			Merged:   true,
 			MergeSHA: new(string),
 			Title:    "This is a fix for Y",
+			Body:     "This is a cherrypick.\n/cherrypick release-1.13",
+			User: github.User{
+				Login: "merge-bot",
+			},
 		},
 	}
 


### PR DESCRIPTION
This PR prepends the PR description to the comments list, allowing users to specify branches that they wish to cherrypick to when they first create the PR.

This change fixes the cherrypick chain functionality introduced in #136.