### PR TITLE
Use Cluster and not Manager for build clusters

### DIFF
--- a/cmd/prow-controller-manager/main.go
+++ b/cmd/prow-controller-manager/main.go
@@ -167,20 +167,20 @@ func main() {
 		interrupts.Terminate()
 	}
 
-	buildClusterManagers, err := o.kubernetes.BuildClusterManagers(o.dryRun,
+	buildClusters, err := o.kubernetes.BuildClusters(o.dryRun,
 		plank.RequiredTestPodVerbs(),
 		callBack,
 		cfg().PodNamespace,
 	)
 	if err != nil {
-		logrus.WithError(err).Error("Failed to construct build cluster managers. Please check that the kubeconfig secrets are correct, and that RBAC roles on the build cluster allow Prow's service account to list pods on it.")
+		logrus.WithError(err).Error("Failed to construct build clusters. Please check that the kubeconfig secrets are correct, and that RBAC roles on the build cluster allow Prow's service account to list pods on it.")
 	}
 
-	for buildClusterName, buildClusterManager := range buildClusterManagers {
-		if err := mgr.Add(buildClusterManager); err != nil {
+	for buildClusterName, buildCluster := range buildClusters {
+		if err := mgr.Add(buildCluster); err != nil {
 			logrus.WithError(err).WithFields(logrus.Fields{
 				"cluster": buildClusterName,
-			}).Fatalf("Failed to add build cluster manager to main manager")
+			}).Fatalf("Failed to add build clusters to manager")
 		}
 	}
 
@@ -205,7 +205,7 @@ func main() {
 	}
 
 	if enabledControllersSet.Has(plank.ControllerName) {
-		if err := plank.Add(mgr, buildClusterManagers, knownClusters, cfg, opener, o.totURL, o.selector); err != nil {
+		if err := plank.Add(mgr, buildClusters, knownClusters, cfg, opener, o.totURL, o.selector); err != nil {
 			logrus.WithError(err).Fatal("Failed to add plank to manager")
 		}
 	}

--- a/cmd/sinker/main.go
+++ b/cmd/sinker/main.go
@@ -175,7 +175,7 @@ func main() {
 		"patch",
 	}
 
-	buildManagers, err := o.kubernetes.BuildClusterManagers(o.dryRun,
+	buildClusters, err := o.kubernetes.BuildClusters(o.dryRun,
 		requiredTestPodVerbs,
 		// The watch apimachinery doesn't support restarts, so just exit the
 		// binary if a build cluster can be connected later .
@@ -183,15 +183,15 @@ func main() {
 		cfg().PodNamespace,
 	)
 	if err != nil {
-		logrus.WithError(err).Error("Failed to construct build cluster managers. Is there a bad entry in the kubeconfig secret?")
+		logrus.WithError(err).Error("Failed to construct build clusters. Is there a bad entry in the kubeconfig secret?")
 	}
 
 	buildClusterClients := map[string]ctrlruntimeclient.Client{}
-	for clusterName, buildManager := range buildManagers {
-		if err := mgr.Add(buildManager); err != nil {
-			logrus.WithError(err).Fatal("Failed to add build cluster manager to main manager")
+	for clusterName, cluster := range buildClusters {
+		if err := mgr.Add(cluster); err != nil {
+			logrus.WithError(err).Fatal("Failed to add build cluster manager")
 		}
-		buildClusterClients[clusterName] = buildManager.GetClient()
+		buildClusterClients[clusterName] = cluster.GetClient()
 	}
 
 	c := controller{

--- a/pkg/plank/reconciler_test.go
+++ b/pkg/plank/reconciler_test.go
@@ -44,6 +44,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/cache/informertest"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	fakectrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/cluster"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllertest"
 	ctrlruntimelog "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
@@ -159,11 +160,11 @@ func TestAdd(t *testing.T) {
 				t.Fatalf("failed to construct mgr: %v", err)
 			}
 			podInformerStarted := make(chan struct{})
-			buildMgr, err := mgrFromFakeInformer(corev1.SchemeGroupVersion.WithKind("Pod"), fakePodInformers, podInformerStarted)
+			buildCluster, err := mgrFromFakeInformer(corev1.SchemeGroupVersion.WithKind("Pod"), fakePodInformers, podInformerStarted)
 			if err != nil {
 				t.Fatalf("failed to construct mgr: %v", err)
 			}
-			buildMgrs := map[string]manager.Manager{"default": buildMgr}
+			buildMgrs := map[string]cluster.Cluster{"default": buildCluster}
 			cfg := func() *config.Config {
 				return &config.Config{ProwConfig: config.ProwConfig{ProwJobNamespace: prowJobNamespace}}
 			}


### PR DESCRIPTION
At the time controller-runtime was introduced to this project, it didn't have a clean abstraction for "cache + client of a cluster". The only thing it had was the manager, which is that plus some additional things like metrics, webhooks, leader election and code related to run things. As a result, we ended up using the manager and disabling everything it doesn't need.

By now, controller-runtime has the `cluster` abstraction for precisely this use-case. This change makes us use the `cluster` where appropriate. It should not result in any outwards-visible behavior changing.