### PR TITLE
Fix assign plugins

### DIFF
--- a/pkg/plugins/assign/assign.go
+++ b/pkg/plugins/assign/assign.go
@@ -136,7 +136,11 @@ func handle(h *handler) error {
 		} else {
 			for _, login := range parseLogins(re[2]) {
 				if isTeamLogin(login) {
-					teamMembers, err := h.gc.ListTeamMembersBySlug(org, login, "all")
+					org, teamSlug := strings.Split(login, "/")[0], strings.Split(login, "/")[1]
+					if org == "" || teamSlug == "" {
+						return fmt.Errorf("invalid team login: %s", login)
+					}
+					teamMembers, err := h.gc.ListTeamMembersBySlug(org, teamSlug, "all")
 					if err != nil {
 						return fmt.Errorf("failed to list team members: %w", err)
 					}

--- a/pkg/plugins/assign/assign_test.go
+++ b/pkg/plugins/assign/assign_test.go
@@ -96,7 +96,7 @@ func (c *fakeClient) CreateComment(owner, repo string, number int, comment strin
 }
 
 func (c *fakeClient) ListTeamMembersBySlug(org, teamSlug, role string) ([]github.TeamMember, error) {
-	if teamSlug == "kubernetes/sig-testing-misc" {
+	if org == "kubernetes" && teamSlug == "sig-testing-misc" {
 		return []github.TeamMember{
 			{Login: "cjwagner"},
 			{Login: "merlin"},


### PR DESCRIPTION
this PR is following up to #164 

## Bug Description

[`ListTeamMembersBySlug` function](https://github.com/kubernetes-sigs/prow/blob/79d27b6e3be35974fbe103d3f574d70dfea6f03c/pkg/github/client.go#L3758-L3786) requires `org` and `teamSlug` as arguments, but I mistakenly passed org and login as arguments.

```go
teamMembers, err := h.gc.ListTeamMembersBySlug(org, login, "all")
```

Meaning, I was passing arguments like `kubernetes, kubernetes/sig-misc-approvers` - The correct arguments are `kubernetes, sig-misc-approvers`

## Change List 

- Split the `login` into org and teamSlug before passing them to the function