### PR TITLE
Bump git-custom-k8s-auth image

### DIFF
--- a/.ko.yaml
+++ b/.ko.yaml
@@ -4,17 +4,17 @@ baseImageOverrides:
   sigs.k8s.io/prow/cmd/branchprotector: gcr.io/k8s-prow/alpine:v20240129-a0a4e743bf
   sigs.k8s.io/prow/cmd/checkconfig: gcr.io/k8s-prow/git:v20240129-a0a4e743bf
   sigs.k8s.io/prow/cmd/clonerefs: gcr.io/k8s-prow/git:v20240129-a0a4e743bf
-  sigs.k8s.io/prow/cmd/config-bootstrapper: gcr.io/k8s-prow/git-custom-k8s-auth:v20240129-a0a4e743bf
-  sigs.k8s.io/prow/cmd/deck: gcr.io/k8s-prow/git-custom-k8s-auth:v20240129-a0a4e743bf
+  sigs.k8s.io/prow/cmd/config-bootstrapper: gcr.io/k8s-prow/git-custom-k8s-auth:v20240711-119864967d
+  sigs.k8s.io/prow/cmd/deck: gcr.io/k8s-prow/git-custom-k8s-auth:v20240711-119864967d
   sigs.k8s.io/prow/cmd/exporter: gcr.io/k8s-prow/alpine:v20240129-a0a4e743bf
-  sigs.k8s.io/prow/cmd/crier: gcr.io/k8s-prow/git-custom-k8s-auth:v20240129-a0a4e743bf
+  sigs.k8s.io/prow/cmd/crier: gcr.io/k8s-prow/git-custom-k8s-auth:v20240711-119864967d
   sigs.k8s.io/prow/cmd/entrypoint: gcr.io/k8s-prow/git:v20240129-a0a4e743bf
   sigs.k8s.io/prow/cmd/gangway: gcr.io/k8s-prow/git:v20240129-a0a4e743bf
   sigs.k8s.io/prow/cmd/generic-autobumper: gcr.io/k8s-prow/git:v20240129-a0a4e743bf
   sigs.k8s.io/prow/cmd/gerrit: gcr.io/k8s-prow/git:v20240129-a0a4e743bf
   sigs.k8s.io/prow/cmd/grandmatriarch: gcr.io/cloud-builders/gcloud@sha256:66d12ecfe21e565af386706bd51d7777e13b471b433cdac7147fb3f3f57e0fc4
   sigs.k8s.io/prow/cmd/gcsupload: gcr.io/k8s-prow/alpine:v20240129-a0a4e743bf
-  sigs.k8s.io/prow/cmd/hook: gcr.io/k8s-prow/git-custom-k8s-auth:v20240129-a0a4e743bf
+  sigs.k8s.io/prow/cmd/hook: gcr.io/k8s-prow/git-custom-k8s-auth:v20240711-119864967d
   sigs.k8s.io/prow/cmd/hmac: gcr.io/k8s-prow/alpine:v20240129-a0a4e743bf
   sigs.k8s.io/prow/cmd/horologium: gcr.io/k8s-prow/alpine:v20240129-a0a4e743bf
   sigs.k8s.io/prow/cmd/initupload: gcr.io/k8s-prow/git:v20240129-a0a4e743bf
@@ -23,12 +23,12 @@ baseImageOverrides:
   sigs.k8s.io/prow/cmd/moonraker: gcr.io/k8s-prow/git:v20240129-a0a4e743bf
   sigs.k8s.io/prow/cmd/peribolos: gcr.io/k8s-prow/alpine:v20240129-a0a4e743bf
   sigs.k8s.io/prow/cmd/sidecar: gcr.io/k8s-prow/git:v20240129-a0a4e743bf
-  sigs.k8s.io/prow/cmd/sinker: gcr.io/k8s-prow/git-custom-k8s-auth:v20240129-a0a4e743bf
+  sigs.k8s.io/prow/cmd/sinker: gcr.io/k8s-prow/git-custom-k8s-auth:v20240711-119864967d
   sigs.k8s.io/prow/cmd/status-reconciler: gcr.io/k8s-prow/alpine:v20240129-a0a4e743bf
   sigs.k8s.io/prow/cmd/sub: gcr.io/k8s-prow/git:v20240129-a0a4e743bf
   sigs.k8s.io/prow/cmd/tide: gcr.io/k8s-prow/git:v20240129-a0a4e743bf
   sigs.k8s.io/prow/cmd/tot: gcr.io/k8s-prow/alpine:v20240129-a0a4e743bf
-  sigs.k8s.io/prow/cmd/prow-controller-manager: gcr.io/k8s-prow/git-custom-k8s-auth:v20240129-a0a4e743bf
+  sigs.k8s.io/prow/cmd/prow-controller-manager: gcr.io/k8s-prow/git-custom-k8s-auth:v20240711-119864967d
   sigs.k8s.io/prow/cmd/admission: gcr.io/k8s-prow/alpine:v20240129-a0a4e743bf
   sigs.k8s.io/prow/cmd/webhook-server: gcr.io/distroless/static:nonroot@sha256:9ecc53c269509f63c69a266168e4a687c7eb8c0cfd753bd8bfcaa4f58a90876f
   sigs.k8s.io/prow/cmd/mkpj: gcr.io/k8s-prow/alpine:v20240129-a0a4e743bf


### PR DESCRIPTION
Bump git-custom-k8s-auth as a follow-up of:
  - https://github.com/kubernetes/test-infra/pull/32940
  
  This should help onboard Azure KS clusters on prow control plane.