### PR TITLE
Specify the image file for image build/push.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,22 +106,22 @@ PROW_IMAGE ?=
 
 .PHONY: push-images
 push-images:
-	hack/make-rules/go-run/arbitrary.sh run ./hack/prowimagebuilder --ko-docker-repo="${REGISTRY}" --push=true
+	hack/make-rules/go-run/arbitrary.sh run ./hack/prowimagebuilder --prow-images-file=./.prow-images.yaml --ko-docker-repo="${REGISTRY}" --push=true
 
 .PHONY: build-images
 build-images:
-	hack/make-rules/go-run/arbitrary.sh run ./hack/prowimagebuilder --ko-docker-repo="ko.local" --push=false
+	hack/make-rules/go-run/arbitrary.sh run ./hack/prowimagebuilder --prow-images-file=./.prow-images.yaml --ko-docker-repo="ko.local" --push=false
 
 .PHONY: push-single-image
 push-single-image:
-	hack/make-rules/go-run/arbitrary.sh run ./hack/prowimagebuilder --ko-docker-repo="${REGISTRY}" --push=true --image=${PROW_IMAGE}
+	hack/make-rules/go-run/arbitrary.sh run ./hack/prowimagebuilder --prow-images-file=./.prow-images.yaml --ko-docker-repo="${REGISTRY}" --push=true --image=${PROW_IMAGE}
 
 .PHONY: build-single-image
 build-single-image:
-	hack/make-rules/go-run/arbitrary.sh run ./hack/prowimagebuilder --ko-docker-repo="ko.local" --push=false --image=${PROW_IMAGE}
+	hack/make-rules/go-run/arbitrary.sh run ./hack/prowimagebuilder --prow-images-file=./.prow-images.yaml --ko-docker-repo="ko.local" --push=false --image=${PROW_IMAGE}
 
 .PHONY: build-tarball
 build-tarball:
 # use --ko-docker-repo="something.not.exist" as ko skips writing `.tar` file if
 # it's `ko.local.
-	hack/make-rules/go-run/arbitrary.sh run ./hack/prowimagebuilder --ko-docker-repo="something.not.exist" --push=false --image=${PROW_IMAGE}
+	hack/make-rules/go-run/arbitrary.sh run ./hack/prowimagebuilder --prow-images-file=./.prow-images.yaml --ko-docker-repo="something.not.exist" --push=false --image=${PROW_IMAGE}


### PR DESCRIPTION
The default is `prow/.prow-images.yaml`, which made sense when Prow was in k8s/test-infra since it was nested in a subdirectory, but doesn't make sense anymore now that the files are unnested in their own repo. We could update the default instead, but I think having the argument here explicitly is clearer in this crops up again in future.

I believe this should fix the image push job for Prow images (`post-k8s-infra-prow-images`), which doesn't have any published images in k8s-staging-test-infra yet.

Ref https://github.com/kubernetes/test-infra/issues/32432