### PR TITLE
cherrypickapproved: Add option to approve PRs without lgtm or approved labels

### DIFF
--- a/pkg/plugins/config.go
+++ b/pkg/plugins/config.go
@@ -726,6 +726,10 @@ type CherryPickApproved struct {
 	BranchRe     *regexp.Regexp `json:"-"`
 	// Approvers is the list of GitHub logins allowed to approve a cherry-pick.
 	Approvers []string `json:"approvers,omitempty"`
+	// AllowMissingApprovedLabel allows approving cherry-pick without the approved label.
+	AllowMissingApprovedLabel bool `json:"allow_missing_approved_label,omitempty"`
+	// AllowMissingLGTMLabel allows approving cherry-pick without the lgtm label.
+	AllowMissingLGTMLabel bool `json:"allow_missing_lgtm_label,omitempty"`
 }
 
 // CherryPickUnapproved is the config for the cherrypick-unapproved plugin.


### PR DESCRIPTION
This PR extends the `cherrypickapproved` plugin with two new configuration options: `allow_missing_approved_label` and `allow_missing_lgtm_label`. Those two fields are bools defaulted to `false`. If the option is set to `true`, the respective label will not be needed to successfully cherry-pick approve the PR.

This is very useful for projects where approvers are also cherry-pick-approvers. At the moment, this plugin is not much useful to those projects, because you either have to approve the PR two times or manually remove the cherry-pick-not-approved label. This change should make the user experience a bit better for this use case.

/assign @saschagrunert @cpanato @puerco 
cc @kubernetes-sigs/release-engineering 