### PR TITLE
Fix panic in gerrit client ChangeExist

### DIFF
--- a/pkg/gerrit/client/client.go
+++ b/pkg/gerrit/client/client.go
@@ -462,7 +462,7 @@ func (c *Client) ChangeExist(instance, id string) (bool, error) {
 	_, resp, err := h.changeService.GetChange(id, nil)
 
 	if err != nil {
-		if resp.StatusCode == http.StatusNotFound {
+		if resp != nil && resp.StatusCode == http.StatusNotFound {
 			return false, nil
 		}
 		return false, fmt.Errorf("error getting current change: %w", responseBodyError(err, resp))

--- a/pkg/gerrit/client/client_test.go
+++ b/pkg/gerrit/client/client_test.go
@@ -18,6 +18,8 @@ package client
 
 import (
 	"context"
+	"errors"
+	"net/http"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -215,6 +217,82 @@ func TestQueryStringsFromQueryFilter(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestChangeExistErrs(t *testing.T) {
+	tests := []struct {
+		name        string
+		resp        *gerrit.Response
+		err         error
+		wantChanged bool
+		wantErr     bool
+	}{
+		{
+			name:        "with err only",
+			err:         errors.New("error"),
+			wantChanged: false,
+			wantErr:     true,
+		},
+		{
+			name: "with err and response not found",
+			resp: &gerrit.Response{
+				Response: &http.Response{
+					StatusCode: http.StatusNotFound,
+					Body:       http.NoBody,
+				},
+			},
+			err:         errors.New("error"),
+			wantChanged: false,
+			wantErr:     false,
+		},
+		{
+			name: "with err and other response",
+			resp: &gerrit.Response{
+				Response: &http.Response{
+					StatusCode: http.StatusInternalServerError,
+					Body:       http.NoBody,
+				},
+			},
+			err:         errors.New("error"),
+			wantChanged: false,
+			wantErr:     true,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			cl := &Client{
+				handlers: map[string]*gerritInstanceHandler{
+					"instance": {
+						changeService: &fgcWithErr{
+							resp: tc.resp,
+							err:  tc.err,
+						},
+					},
+				},
+			}
+			gotChanged, err := cl.ChangeExist("instance", "id")
+			gotErr := err != nil
+			if gotErr != tc.wantErr {
+				t.Errorf("%s: ChangeExist() err = %v; wantErr = %t", tc.name, gotErr, tc.wantErr)
+			}
+			if gotChanged != tc.wantChanged {
+				t.Errorf("%s: ChangeExist() changed = %v; wantChanged = %t", tc.name, gotChanged, tc.wantChanged)
+			}
+
+		})
+	}
+}
+
+type fgcWithErr struct {
+	resp *gerrit.Response
+	err  error
+	gerritChange
+}
+
+func (f *fgcWithErr) GetChange(changeId string, opt *gerrit.ChangeOptions) (*ChangeInfo, *gerrit.Response, error) {
+	return nil, f.resp, f.err
 }
 
 func (f *fgc) QueryChanges(opt *gerrit.QueryChangeOptions) (*[]gerrit.ChangeInfo, *gerrit.Response, error) {


### PR DESCRIPTION
The old code assumed that when `err != nil`, the `resp` is still populated, which isn't true in all branches. This causes a panic which can occur every 6 hours

We add a `resp != nil` check to protect against this panic.

Also, add a unit test and fake gerritChange with errors which would catch this panic. I confirmed that removing the change triggers the test failure.