### PR TITLE
docs: Deprecate `grandmatriarch` docs

### DIFF
--- a/site/content/en/docs/components/_index.md
+++ b/site/content/en/docs/components/_index.md
@@ -63,11 +63,11 @@ The container images in [`images`](https://github.com/kubernetes/test-infra/tree
 ## TODO: undocumented
 
 * `admission` ([doc](/docs/components/undocumented/admission/), [code](https://github.com/kubernetes-sigs/prow/tree/main/cmd/admission))
-* `grandmatriarch` ([doc](/docs/components/undocumented/grandmatriarch/), [code](https://github.com/kubernetes-sigs/prow/tree/main/cmd/grandmatriarch))
 * `pipeline` ([doc](/docs/components/undocumented/pipeline/), [code](https://github.com/kubernetes-sigs/prow/tree/main/cmd/pipeline))
 * `tackle` ([doc](/docs/components/undocumented/tackle/), [code](https://github.com/kubernetes-sigs/prow/tree/main/cmd/tackle))
 
 ## Deprecated
 
 * `cm2kc` ([doc](/docs/components/deprecated/cm2kc/), [code](https://github.com/kubernetes-sigs/prow/tree/main/cmd/cm2kc)) is a CLI tool used to convert a [clustermap file](/docs/getting-started-deploy/#run-test-pods-in-different-clusters) to a [kubeconfig file](https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/). Deprecated because we have moved away from clustermaps; you should use [`gencred`](https://github.com/kubernetes/test-infra/tree/master/gencred) to generate a [kubeconfig file](https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/) directly.
+* `grandmatriarch`
 * `phaino` ([doc](/docs/components/deprecated/phaino/)) runs an approximation of a ProwJob on your local workstation

--- a/site/content/en/docs/components/undocumented/grandmatriarch.md
+++ b/site/content/en/docs/components/undocumented/grandmatriarch.md
@@ -1,8 +1,0 @@
----
-title: "grandmatriarch"
-weight: 10
-description: >
-  
----
-
-This is a placeholder page. Some contents needs to be filled.

--- a/site/content/en/docs/gerrit.md
+++ b/site/content/en/docs/gerrit.md
@@ -40,9 +40,6 @@ c.Start(cookiefilePath)
 
 The client will try to refetch token from the path every 10 minutes.
 
-You should also utilize [`grandmatriarch`](/docs/components/undocumented/grandmatriarch/) to generate a token from a
-passed-in service account credential.
-
 If you need extra features, feel free to introduce new gerrit API functions to the client package.
 
 #### Adapter


### PR DESCRIPTION
The PR #218 has deleted `grandmatriach` codes from source base.
This PR deprecates `grandmatriach`-related docs accordingly.