### PR TITLE
config: Enable Netlify build for `site/` directory only

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,7 +2,7 @@
 base = "site/"
 publish = "public/"
 command = "make netlify-build"
-ignore = "false"
+ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF site"
 
 [build.environment]
 HUGO_VERSION = "0.91.2"


### PR DESCRIPTION
This PR is related with the issue #151.

This PR updates `netlify.toml` so that the Netlify build proceeds only if there are changes within the `site/` directory.