### PR TITLE
New scheduling strategy: external

### DIFF
--- a/pkg/config/prow-config-documented.yaml
+++ b/pkg/config/prow-config-documented.yaml
@@ -1348,6 +1348,15 @@ push_gateway:
 # It has to be explicitly enabled.
 scheduler:
     enabled: true
+    external:
+        # Cache is the cache configuration for the external scheduling strategy
+        cache:
+            # CacheCleanupInterval is the interval to clean up the cache
+            cleanup_interval: 0s
+            # EntryTimeoutInterval is the interval to consider an entry in the cache
+            entry_timeout_interval: 0s
+        # URL is the URL of the REST API to query for the cluster assigned to prowjob
+        url: ' '
     # Scheduling strategies
     failover:
         # ClusterMappings maps a cluster to another one. It is used when we

--- a/pkg/config/scheduler.go
+++ b/pkg/config/scheduler.go
@@ -16,11 +16,14 @@ limitations under the License.
 
 package config
 
+import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 type Scheduler struct {
 	Enabled bool `json:"enabled,omitempty"`
 
 	// Scheduling strategies
 	Failover *FailoverScheduling `json:"failover,omitempty"`
+	External *ExternalScheduling `json:"external,omitempty"`
 }
 
 // FailoverScheduling is a configuration for the Failover scheduling strategy
@@ -29,4 +32,22 @@ type FailoverScheduling struct {
 	// want to schedule a ProJob to a cluster other than the one it was
 	// configured to in the first place.
 	ClusterMappings map[string]string `json:"mappings,omitempty"`
+}
+
+// ExternalSchedulingCache is a cache configuration for the external
+// scheduling strategy
+type ExternalSchedulingCache struct {
+	// EntryTimeoutInterval is the interval to consider an entry in the cache
+	EntryTimeoutInterval *metav1.Duration `json:"entry_timeout_interval,omitempty"`
+	// CacheCleanupInterval is the interval to clean up the cache
+	CleanupInterval *metav1.Duration `json:"cleanup_interval,omitempty"`
+}
+
+// ExternalScheduling is a configuration for the external scheduling strategy
+// querying by prowjob job field
+type ExternalScheduling struct {
+	// URL is the URL of the REST API to query for the cluster assigned to prowjob
+	URL string `json:"url,omitempty"`
+	// Cache is the cache configuration for the external scheduling strategy
+	Cache ExternalSchedulingCache `json:"cache,omitempty"`
 }

--- a/pkg/plugins/plugin-config-documented.yaml
+++ b/pkg/plugins/plugin-config-documented.yaml
@@ -295,7 +295,11 @@ cat:
     # Path to file containing an api key for thecatapi.com
     key_path: ' '
 cherry_pick_approved:
-    - # Approvers is the list of GitHub logins allowed to approve a cherry-pick.
+    - # AllowMissingApprovedLabel allows approving cherry-pick without the approved label.
+      allow_missing_approved_label: true
+      # AllowMissingLGTMLabel allows approving cherry-pick without the lgtm label.
+      allow_missing_lgtm_label: true
+      # Approvers is the list of GitHub logins allowed to approve a cherry-pick.
       approvers:
         - ""
       # BranchRegexp is the regular expression for branch names such that

--- a/pkg/scheduler/strategy/default.go
+++ b/pkg/scheduler/strategy/default.go
@@ -40,6 +40,9 @@ func Get(cfg *config.Config) Interface {
 	if cfg.Scheduler.Failover != nil {
 		return NewFailover(*cfg.Scheduler.Failover)
 	}
+	if cfg.Scheduler.External != nil {
+		return NewExternal(*cfg.Scheduler.External)
+	}
 	return &Passthrough{}
 }
 

--- a/pkg/scheduler/strategy/external.go
+++ b/pkg/scheduler/strategy/external.go
@@ -1,0 +1,120 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package strategy
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	prowv1 "sigs.k8s.io/prow/pkg/apis/prowjobs/v1"
+	"sigs.k8s.io/prow/pkg/config"
+)
+
+// SchedulingRequest represents the incoming request structure
+type SchedulingRequest struct {
+	Job string `json:"job"`
+}
+
+// SchedulingResponse represents the response structure
+type SchedulingResponse struct {
+	Cluster string `json:"cluster"`
+}
+
+type cacheEntry struct {
+	r         SchedulingResponse
+	timestamp time.Time
+}
+
+// External is a strategy that schedules a ProwJob on a specific cluster
+// based on the response of the ProwJob's Job name to given URL
+type External struct {
+	cfg       config.ExternalScheduling
+	cache     map[string]*cacheEntry
+	timestamp time.Time
+}
+
+// NewExternal creates a new External instance with caching
+func NewExternal(cfg config.ExternalScheduling) *External {
+	e := &External{
+		cfg:   cfg,
+		cache: make(map[string]*cacheEntry),
+	}
+	return e
+}
+
+// query sends a POST request to the specified URL with the provided request body
+// and returns the response as a SchedulingResponse object
+func query(url string, reqBody SchedulingRequest) (SchedulingResponse, error) {
+	jsonData, err := json.Marshal(reqBody)
+	if err != nil {
+		return SchedulingResponse{}, fmt.Errorf("error marshaling JSON: %w", err)
+	}
+
+	resp, err := http.Post(url, "application/json", bytes.NewBuffer(jsonData))
+	if err != nil {
+		return SchedulingResponse{}, fmt.Errorf("error sending request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return SchedulingResponse{}, fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+	}
+
+	var respBody SchedulingResponse
+	if err := json.NewDecoder(resp.Body).Decode(&respBody); err != nil {
+		return SchedulingResponse{}, fmt.Errorf("error decoding response: %w", err)
+	}
+
+	return respBody, nil
+}
+
+// Schedule checks the cache for a valid response or queries the REST API if the cache is stale
+func (e *External) Schedule(_ context.Context, pj *prowv1.ProwJob) (Result, error) {
+	if time.Since(e.timestamp) > e.cfg.Cache.CleanupInterval.Duration {
+		e.cleanupCache()
+	}
+	entry, found := e.cache[pj.Spec.Job]
+
+	if found && time.Since(entry.timestamp) < e.cfg.Cache.EntryTimeoutInterval.Duration {
+		return Result(entry.r), nil
+	}
+
+	resp, err := query(e.cfg.URL, SchedulingRequest{Job: pj.Spec.Job})
+	if err != nil {
+		return Result{}, fmt.Errorf("error querying URL: %w", err)
+	}
+
+	e.cache[pj.Spec.Job] = &cacheEntry{
+		r:         resp,
+		timestamp: time.Now(),
+	}
+	return Result(resp), nil
+}
+
+// cleanupCache removes stale entries from the cache
+func (e *External) cleanupCache() {
+	e.timestamp = time.Now()
+	for key, entry := range e.cache {
+		if time.Since(entry.timestamp) >= e.cfg.Cache.EntryTimeoutInterval.Duration {
+			delete(e.cache, key)
+		}
+	}
+}

--- a/pkg/scheduler/strategy/external_test.go
+++ b/pkg/scheduler/strategy/external_test.go
@@ -1,0 +1,148 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package strategy
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	prowv1 "sigs.k8s.io/prow/pkg/apis/prowjobs/v1"
+	"sigs.k8s.io/prow/pkg/config"
+)
+
+// Mock REST API server to simulate scheduling response
+func mockServer(response SchedulingResponse, statusCode int) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(statusCode)
+		json.NewEncoder(w).Encode(response)
+	}))
+}
+
+func TestExternalSchedule(t *testing.T) {
+	tests := []struct {
+		name        string
+		pj          *prowv1.ProwJob
+		cache       map[string]*cacheEntry
+		response    SchedulingResponse
+		statusCode  int
+		want        Result
+		wantErr     bool
+		mockCleanup bool
+	}{
+		{
+			name: "cache hit, valid entry",
+			pj: &prowv1.ProwJob{
+				Spec: prowv1.ProwJobSpec{Job: "test-job"},
+			},
+			cache: map[string]*cacheEntry{
+				"test-job": {
+					r:         SchedulingResponse{Cluster: "cluster-1"},
+					timestamp: time.Now(),
+				},
+			},
+			response:    SchedulingResponse{Cluster: "cluster-1"},
+			statusCode:  http.StatusOK,
+			want:        Result{Cluster: "cluster-1"},
+			wantErr:     false,
+			mockCleanup: false,
+		},
+		{
+			name: "cache miss, fetch from REST API",
+			pj: &prowv1.ProwJob{
+				Spec: prowv1.ProwJobSpec{Job: "test-job-2"},
+			},
+			cache:       map[string]*cacheEntry{},
+			response:    SchedulingResponse{Cluster: "cluster-2"},
+			statusCode:  http.StatusOK,
+			want:        Result{Cluster: "cluster-2"},
+			wantErr:     false,
+			mockCleanup: true,
+		},
+		{
+			name: "cache stale, fetch from REST API",
+			pj: &prowv1.ProwJob{
+				Spec: prowv1.ProwJobSpec{Job: "test-job-3"},
+			},
+			cache: map[string]*cacheEntry{
+				"test-job-3": {
+					r:         SchedulingResponse{Cluster: "cluster-3"},
+					timestamp: time.Now().Add(-15 * time.Minute),
+				},
+			},
+			response:    SchedulingResponse{Cluster: "cluster-4"},
+			statusCode:  http.StatusOK,
+			want:        Result{Cluster: "cluster-4"},
+			wantErr:     false,
+			mockCleanup: true,
+		},
+		{
+			name: "REST API error",
+			pj: &prowv1.ProwJob{
+				Spec: prowv1.ProwJobSpec{Job: "test-job-4"},
+			},
+			cache:       map[string]*cacheEntry{},
+			response:    SchedulingResponse{},
+			statusCode:  http.StatusInternalServerError,
+			want:        Result{},
+			wantErr:     true,
+			mockCleanup: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := mockServer(tt.response, tt.statusCode)
+			defer server.Close()
+
+			rbj := &External{
+				cfg: config.ExternalScheduling{
+					URL: server.URL,
+					Cache: config.ExternalSchedulingCache{
+						EntryTimeoutInterval: &metav1.Duration{Duration: 10 * time.Minute},
+						CleanupInterval:      &metav1.Duration{Duration: 1 * time.Hour},
+					},
+				},
+				cache:     tt.cache,
+				timestamp: time.Now().Add(-3 * time.Hour), // To trigger cache cleanup if mockCleanup is true
+			}
+
+			got, err := rbj.Schedule(context.Background(), tt.pj)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("external.Schedule() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("external.Schedule() = %v, want %v", got, tt.want)
+			}
+
+			if tt.mockCleanup && len(rbj.cache) > 0 {
+				for key, entry := range rbj.cache {
+					if time.Since(entry.timestamp) >= rbj.cfg.Cache.EntryTimeoutInterval.Duration {
+						t.Errorf("Cache not cleaned up properly for key: %s", key)
+					}
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
`External` sends `Job` field from prowjob spec to URL and expects cluster assignment in return