### PR TITLE
cherrypickapproved: implement org-level configuration

### DIFF
--- a/pkg/plugins/cherrypickapproved/cherrypickapproved.go
+++ b/pkg/plugins/cherrypickapproved/cherrypickapproved.go
@@ -135,10 +135,18 @@ func (h *handler) handle(log *logrus.Entry, gc plugins.PluginGitHubClient, e git
 	)
 
 	// Filter configurations
-	foundRepoOrg := false
+	foundConfig := false
 	for _, cfg := range cfgs {
 		if cfg.Org == org && cfg.Repo == repo {
-			foundRepoOrg = true
+			foundConfig = true
+			approvers = cfg.Approvers
+			branchRe = cfg.BranchRe
+			allowMissingApprovedLabel = cfg.AllowMissingApprovedLabel
+			allowMissingLGTMLabel = cfg.AllowMissingLGTMLabel
+
+			break
+		} else if cfg.Org == org && cfg.Repo == "" {
+			foundConfig = true
 			approvers = cfg.Approvers
 			branchRe = cfg.BranchRe
 			allowMissingApprovedLabel = cfg.AllowMissingApprovedLabel
@@ -146,7 +154,8 @@ func (h *handler) handle(log *logrus.Entry, gc plugins.PluginGitHubClient, e git
 		}
 	}
 
-	if !foundRepoOrg {
+	// If we didn't found config at this point, fail, otherwise parse it
+	if !foundConfig {
 		log.Debugf("Skipping because repo %s/%s is not part of plugin configuration", org, repo)
 		return nil
 	}

--- a/pkg/plugins/cherrypickapproved/cherrypickapproved_test.go
+++ b/pkg/plugins/cherrypickapproved/cherrypickapproved_test.go
@@ -89,6 +89,56 @@ func TestHandle(t *testing.T) {
 			},
 		},
 		{
+			name: "success apply cherry-pick-approved label with org-level config",
+			config: []plugins.CherryPickApproved{
+				{
+					Org:       testOrgRepo,
+					BranchRe:  regexp.MustCompile("^release-*"),
+					Approvers: []string{"user"},
+				},
+			},
+			prepare: func(mock *cherrypickapprovedfakes.FakeImpl) {
+				mock.GetCombinedStatusReturns(&github.CombinedStatus{}, nil)
+				mock.GetIssueLabelsReturns(
+					[]github.Label{
+						{Name: labels.LGTM},
+						{Name: labels.Approved},
+						{Name: labels.CpUnapproved},
+					},
+					nil,
+				)
+			},
+			assert: func(mock *cherrypickapprovedfakes.FakeImpl, err error) {
+				assert.NoError(t, err)
+				assert.EqualValues(t, 1, mock.AddLabelCallCount())
+				assert.EqualValues(t, 1, mock.RemoveLabelCallCount())
+			},
+		},
+		{
+			name: "success apply cherry-pick-approved label with both repo and org-level config",
+			config: append(testConfig, plugins.CherryPickApproved{
+				Org:       testOrgRepo,
+				BranchRe:  regexp.MustCompile("^test-*"),
+				Approvers: []string{"user"},
+			}),
+			prepare: func(mock *cherrypickapprovedfakes.FakeImpl) {
+				mock.GetCombinedStatusReturns(&github.CombinedStatus{}, nil)
+				mock.GetIssueLabelsReturns(
+					[]github.Label{
+						{Name: labels.LGTM},
+						{Name: labels.Approved},
+						{Name: labels.CpUnapproved},
+					},
+					nil,
+				)
+			},
+			assert: func(mock *cherrypickapprovedfakes.FakeImpl, err error) {
+				assert.NoError(t, err)
+				assert.EqualValues(t, 1, mock.AddLabelCallCount())
+				assert.EqualValues(t, 1, mock.RemoveLabelCallCount())
+			},
+		},
+		{
 			name:   "success but failed to apply/remove labels",
 			config: testConfig,
 			prepare: func(mock *cherrypickapprovedfakes.FakeImpl) {


### PR DESCRIPTION
This PR implements the org-level configuration for the `cherrypickapproved` plugin. Right now, it's possible to configure this plugin only on the repo-level. If you have multiple repos, you have to repeat the config for each repo, which is inefficient and clutters the configuration file, especially if the config is the same for all repos.

With this PR, such a configuration is allowed:

```yaml
cherry_pick_approved:
  - org: org-name
    branchregexp: '^release/v.*$'
    approvers:
      - ...
```

The repo-level config has the priority over the org level configuration. This also means that this is not a breaking change, i.e. the existing configurations will continue working as before.

/assign @saschagrunert 
cc @kubernetes-sigs/release-engineering 