### PR TITLE
Add Orgs sharding for Blunderbuss

### DIFF
--- a/cmd/deck/main_test.go
+++ b/cmd/deck/main_test.go
@@ -1115,8 +1115,9 @@ func TestHandlePluginConfig(t *testing.T) {
 			}},
 		},
 		Blunderbuss: plugins.Blunderbuss{
-			ExcludeApprovers: true,
-		},
+			BlunderbussConfig: &plugins.BlunderbussConfig{
+				ExcludeApprovers: true,
+			}},
 	}
 	pluginAgent := &plugins.ConfigAgent{}
 	pluginAgent.Set(&c)

--- a/pkg/config/prow-config-documented.yaml
+++ b/pkg/config/prow-config-documented.yaml
@@ -474,6 +474,9 @@ gerrit:
     # job runs for a given CL.
     deck_url: ' '
     org_repos_config: null
+    # RateLimit defines how many changes to query per gerrit API call
+    # default is 5.
+    ratelimit: 1
     # TickInterval is how often we do a sync with bound gerrit instance.
     tick_interval: 0s
 # GitHubOptions allows users to control how prow applications display GitHub website links.
@@ -524,6 +527,13 @@ jenkins_operators:
       # For label selector syntax, see below:
       # https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
       label_selector: ' '
+      # MaxConcurrency is the maximum number of tests running concurrently that
+      # will be allowed by the controller. 0 implies no limit.
+      max_concurrency: 1
+      # MaxGoroutines is the maximum number of goroutines spawned inside the
+      # controller to handle tests. Defaults to 20. Needs to be a positive
+      # number.
+      max_goroutines: 1
       # ReportTemplateString compiles into ReportTemplate at load time.
       report_template: ' '
       # ReportTemplateStrings is a mapping of template comments.
@@ -1347,6 +1357,13 @@ plank:
     # JobURLPrefixDisableAppendStorageProvider disables that the storageProvider is
     # automatically appended to the JobURLPrefix.
     jobURLPrefixDisableAppendStorageProvider: true
+    # MaxConcurrency is the maximum number of tests running concurrently that
+    # will be allowed by the controller. 0 implies no limit.
+    max_concurrency: 1
+    # MaxGoroutines is the maximum number of goroutines spawned inside the
+    # controller to handle tests. Defaults to 20. Needs to be a positive
+    # number.
+    max_goroutines: 1
     # MaxRevivals is the maximum number of times a prowjob will be retried in case of an
     # unexpected stop of the job before being marked as failed. Generally a job is stopped
     # unexpectedly due to the underlying Node being terminated, evicted or becoming unreachable.
@@ -1582,6 +1599,9 @@ tide:
               org: ' '
               repos:
                 - ""
+        # RateLimit defines how many changes to query per gerrit API call
+        # default is 5.
+        ratelimit: 1
     # GitHubMergeBlocksPolicyMap configures on org or org/repo level how Tide should handle
     # GitHub's mergeStateStatus (BLOCKED state from branch protection rules, rulesets,
     # required reviews, etc.).
@@ -1589,6 +1609,10 @@ tide:
     # Valid values: "ignore", "permit", "block"
     github_merge_blocks_policy:
         "": ""
+    # MaxGoroutines is the maximum number of goroutines spawned inside the
+    # controller to handle org/repo:branch pools. Defaults to 20. Needs to be a
+    # positive number.
+    max_goroutines: 1
     # A key/value pair of an org/repo as the key and Go template to override
     # the default merge commit title and/or message. Template is passed the
     # PullRequest struct (prow/github/types.go#PullRequest)

--- a/pkg/genyaml/genyaml.go
+++ b/pkg/genyaml/genyaml.go
@@ -313,6 +313,9 @@ func fieldType(field *ast.Field, recurse bool) (string, bool) {
 		case *ast.SelectorExpr:
 			// SelectorExpr are not object types yet reference one, thus continue with DFS.
 			isSelect = true
+		case *ast.StarExpr:
+			// Encountered a pointer--overwrite typeName with ast.Expr
+			typeName = fmt.Sprint(x.X)
 		}
 
 		return recurse || isSelect

--- a/pkg/genyaml/populate_struct.go
+++ b/pkg/genyaml/populate_struct.go
@@ -127,6 +127,10 @@ func PopulateStruct(in any) any {
 			if strings.Contains(typeOf.Elem().Field(i).Tag.Get("json"), ",omitempty") {
 				valueOf.Elem().Field(i).SetBool(true)
 			}
+		case reflect.Int:
+			if strings.Contains(typeOf.Elem().Field(i).Tag.Get("json"), ",omitempty") {
+				valueOf.Elem().Field(i).SetInt(1)
+			}
 		}
 
 	}

--- a/pkg/plugins/blunderbuss/blunderbuss.go
+++ b/pkg/plugins/blunderbuss/blunderbuss.go
@@ -59,25 +59,47 @@ func configString(reviewCount int) string {
 }
 
 func helpProvider(config *plugins.Configuration, _ []config.OrgRepo) (*pluginhelp.PluginHelp, error) {
-	var reviewCount int
+	reviewCount := 2
 	if config.Blunderbuss.ReviewerCount != nil {
 		reviewCount = *config.Blunderbuss.ReviewerCount
 	}
-	two := 2
 	yamlSnippet, err := plugins.CommentMap.GenYaml(&plugins.Configuration{
 		Blunderbuss: plugins.Blunderbuss{
-			ReviewerCount:         &two,
-			MaxReviewerCount:      3,
-			ExcludeApprovers:      true,
-			UseStatusAvailability: true,
-			IgnoreAuthors:         []string{},
+			BlunderbussConfig: &plugins.BlunderbussConfig{
+				ReviewerCount:         &reviewCount,
+				MaxReviewerCount:      3,
+				ExcludeApprovers:      true,
+				UseStatusAvailability: true,
+				IgnoreAuthors:         []string{},
+			},
+			Orgs: map[string]plugins.BlunderbussOrgConfig{
+				"": {
+					BlunderbussConfig: &plugins.BlunderbussConfig{
+						ReviewerCount:         &reviewCount,
+						MaxReviewerCount:      3,
+						ExcludeApprovers:      true,
+						UseStatusAvailability: true,
+						IgnoreAuthors:         []string{},
+					},
+					Repos: map[string]plugins.BlunderbussConfig{
+						"": {
+							ReviewerCount:         &reviewCount,
+							MaxReviewerCount:      3,
+							ExcludeApprovers:      true,
+							UseStatusAvailability: true,
+							IgnoreAuthors:         []string{},
+						},
+					},
+				},
+			},
 		},
 	})
 	if err != nil {
 		logrus.WithError(err).Warnf("cannot generate comments for %s plugin", PluginName)
 	}
 	pluginHelp := &pluginhelp.PluginHelp{
-		Description: "The blunderbuss plugin automatically requests reviews from reviewers when a new PR is created. The reviewers are selected based on the reviewers specified in the OWNERS files that apply to the files modified by the PR.",
+		Description: "The blunderbuss plugin automatically requests reviews from reviewers when a new PR is created. " +
+			"The reviewers are selected based on the reviewers specified in the OWNERS files that apply to the files modified by the PR.",
 		Config: map[string]string{
 			"": configString(reviewCount),
 		},
@@ -140,14 +162,14 @@ func handlePullRequestEvent(pc plugins.Agent, pre github.PullRequestEvent) error
 		pc.GitHubClient,
 		pc.OwnersClient,
 		pc.Logger,
-		pc.PluginConfig.Blunderbuss,
+		pc.PluginConfig.BlunderbussFor(pre.Repo.Owner.Login, pre.Repo.Name),
 		pre.Action,
 		&pre.PullRequest,
 		&pre.Repo,
 	)
 }
 
-func handlePullRequest(ghc githubClient, roc repoownersClient, log *logrus.Entry, config plugins.Blunderbuss, action github.PullRequestEventAction, pr *github.PullRequest, repo *github.Repo) error {
+func handlePullRequest(ghc githubClient, roc repoownersClient, log *logrus.Entry, config plugins.BlunderbussConfig, action github.PullRequestEventAction, pr *github.PullRequest, repo *github.Repo) error {
 	// Ignore pull request event if:
 	// - not an opened or ready for review event
 	// - if they have a /cc command in the description (will be handled elsewhere)
@@ -181,7 +203,7 @@ func handleGenericCommentEvent(pc plugins.Agent, ce github.GenericCommentEvent) 
 		pc.GitHubClient,
 		pc.OwnersClient,
 		pc.Logger,
-		pc.PluginConfig.Blunderbuss,
+		pc.PluginConfig.BlunderbussFor(ce.Repo.Owner.Login, ce.Repo.Name),
 		ce.Action,
 		ce.IsPR,
 		ce.Number,
@@ -191,7 +213,7 @@ func handleGenericCommentEvent(pc plugins.Agent, ce github.GenericCommentEvent) 
 	)
 }
 
-func handleGenericComment(ghc githubClient, roc repoownersClient, log *logrus.Entry, config plugins.Blunderbuss, action github.GenericCommentEventAction, isPR bool, prNumber int, issueState string, repo *github.Repo, body string) error {
+func handleGenericComment(ghc githubClient, roc repoownersClient, log *logrus.Entry, config plugins.BlunderbussConfig, action github.GenericCommentEventAction, isPR bool, prNumber int, issueState string, repo *github.Repo, body string) error {
 	if action != github.GenericCommentActionCreated || !isPR || issueState == "closed" {
 		return nil
 	}
@@ -227,7 +249,7 @@ func handleStatusEvent(pc plugins.Agent, se github.StatusEvent) error {
 		pc.GitHubClient,
 		pc.OwnersClient,
 		pc.Logger,
-		pc.PluginConfig.Blunderbuss,
+		pc.PluginConfig.BlunderbussFor(se.Repo.Owner.Login, se.Repo.Name),
 		se.SHA,
 		se.Context,
 		se.State,
@@ -237,7 +259,7 @@ func handleStatusEvent(pc plugins.Agent, se github.StatusEvent) error {
 
 }
 
-func handleStatus(ghc githubClient, roc repoownersClient, log *logrus.Entry, config plugins.Blunderbuss, sha string, context string, state string, description string, repo *github.Repo) error {
+func handleStatus(ghc githubClient, roc repoownersClient, log *logrus.Entry, config plugins.BlunderbussConfig, sha string, context string, state string, description string, repo *github.Repo) error {
 	wfs := config.WaitForStatus
 	if wfs == nil {
 		return nil
@@ -329,37 +351,40 @@ func handle(ghc githubClient, roc repoownersClient, log *logrus.Entry, reviewerC
 
 	var reviewers []string
 	var requiredReviewers []string
-	if reviewerCount != nil {
-		reviewers, requiredReviewers, err = getReviewers(oc, ghc, log, pr.User.Login, changes, *reviewerCount, useStatusAvailability)
-		if err != nil {
-			return err
-		}
-		if missing := *reviewerCount - len(reviewers); missing > 0 {
-			if !excludeApprovers {
-				// Attempt to use approvers as additional reviewers. This must use
-				// reviewerCount instead of missing because owners can be both reviewers
-				// and approvers and the search might stop too early if it finds
-				// duplicates.
-				frc := fallbackReviewersClient{ownersClient: oc}
-				approvers, _, err := getReviewers(frc, ghc, log, pr.User.Login, changes, *reviewerCount, useStatusAvailability)
-				if err != nil {
-					return err
-				}
-				var added int
-				combinedReviewers := sets.New[string](reviewers...)
-				for _, approver := range approvers {
-					if !combinedReviewers.Has(approver) {
-						reviewers = append(reviewers, approver)
-						combinedReviewers.Insert(approver)
-						added++
-					}
-				}
-				log.Infof("Added %d approvers as reviewers. %d/%d reviewers found.", added, combinedReviewers.Len(), *reviewerCount)
+
+	if reviewerCount == nil {
+		return fmt.Errorf("unexpected error: reviewer count is nil")
+	}
+
+	reviewers, requiredReviewers, err = getReviewers(oc, ghc, log, pr.User.Login, changes, *reviewerCount, useStatusAvailability)
+	if err != nil {
+		return err
+	}
+	if missing := *reviewerCount - len(reviewers); missing > 0 {
+		if !excludeApprovers {
+			// Attempt to use approvers as additional reviewers. This must use
+			// reviewerCount instead of missing because owners can be both reviewers
+			// and approvers and the search might stop too early if it finds
+			// duplicates.
+			frc := fallbackReviewersClient{ownersClient: oc}
+			approvers, _, err := getReviewers(frc, ghc, log, pr.User.Login, changes, *reviewerCount, useStatusAvailability)
+			if err != nil {
+				return err
 			}
+			var added int
+			combinedReviewers := sets.New[string](reviewers...)
+			for _, approver := range approvers {
+				if !combinedReviewers.Has(approver) {
+					reviewers = append(reviewers, approver)
+					combinedReviewers.Insert(approver)
+					added++
+				}
+			}
+			log.Infof("Added %d approvers as reviewers. %d/%d reviewers found.", added, combinedReviewers.Len(), *reviewerCount)
 		}
-		if missing := *reviewerCount - len(reviewers); missing > 0 {
-			log.Debugf("Not enough reviewers found in OWNERS files for files touched by this PR. %d/%d reviewers found.", len(reviewers), *reviewerCount)
-		}
+	}
+	if missing := *reviewerCount - len(reviewers); missing > 0 {
+		log.Debugf("Not enough reviewers found in OWNERS files for files touched by this PR. %d/%d reviewers found.", len(reviewers), *reviewerCount)
 	}
 
 	if maxReviewers > 0 && len(reviewers) > maxReviewers {

--- a/pkg/plugins/blunderbuss/blunderbuss_test.go
+++ b/pkg/plugins/blunderbuss/blunderbuss_test.go
@@ -685,7 +685,7 @@ func TestHandlePullRequest(t *testing.T) {
 			pr := github.PullRequest{Number: 5, User: github.User{Login: "author"}, Body: tc.body, Draft: tc.draft}
 			repo := github.Repo{Owner: github.User{Login: "org"}, Name: "repo"}
 			fghc := newFakeGitHubClient(&pr, tc.filesChanged)
-			c := plugins.Blunderbuss{
+			c := plugins.BlunderbussConfig{
 				ReviewerCount:    &tc.reviewerCount,
 				MaxReviewerCount: 0,
 				ExcludeApprovers: false,
@@ -705,6 +705,105 @@ func TestHandlePullRequest(t *testing.T) {
 			sort.Strings(tc.expectedRequested)
 			if !reflect.DeepEqual(fghc.requested, tc.expectedRequested) {
 				t.Fatalf("expected the requested reviewers to be %q, but got %q.", tc.expectedRequested, fghc.requested)
+			}
+		})
+	}
+}
+
+func TestHandlePullRequestShardedConfig(t *testing.T) {
+	froc := &fakeRepoownersClient{
+		foc: &fakeOwnersClient{
+			owners: map[string]string{
+				"a.go": "1",
+				"b.go": "2",
+			},
+			leafReviewers: map[string]sets.Set[string]{
+				"a.go": sets.New("al"),
+				"b.go": sets.New("bob"),
+				"c.go": sets.New("sarah"),
+				"d.go": sets.New("busy-user"),
+			},
+		},
+	}
+
+	overrideOrgReviewerCount := 2
+	overrideRepoReviewerCount := 3
+	var testcases = []struct {
+		name              string
+		orgConfig         map[string]plugins.BlunderbussOrgConfig
+		expectedRequested int
+	}{
+		{
+			name: "overrides default config with org config",
+			orgConfig: map[string]plugins.BlunderbussOrgConfig{
+				"org": {
+					BlunderbussConfig: &plugins.BlunderbussConfig{
+						ReviewerCount:    &overrideOrgReviewerCount,
+						MaxReviewerCount: overrideOrgReviewerCount,
+					}},
+			},
+			expectedRequested: 2,
+		},
+		{
+			name: "overrides default and org config with repo config",
+			orgConfig: map[string]plugins.BlunderbussOrgConfig{
+				"org": {
+					BlunderbussConfig: &plugins.BlunderbussConfig{
+						ReviewerCount:    &overrideOrgReviewerCount,
+						MaxReviewerCount: overrideOrgReviewerCount,
+					},
+					Repos: map[string]plugins.BlunderbussConfig{
+						"org/repo": {
+							ReviewerCount:    &overrideRepoReviewerCount,
+							MaxReviewerCount: overrideRepoReviewerCount,
+						}},
+				},
+			},
+			expectedRequested: 3,
+		},
+		{
+			name: "uses org config with invalid repo config key",
+			orgConfig: map[string]plugins.BlunderbussOrgConfig{
+				"org": {
+					BlunderbussConfig: &plugins.BlunderbussConfig{
+						ReviewerCount:    &overrideOrgReviewerCount,
+						MaxReviewerCount: overrideOrgReviewerCount,
+					},
+					Repos: map[string]plugins.BlunderbussConfig{
+						"repo": {
+							ReviewerCount:    &overrideRepoReviewerCount,
+							MaxReviewerCount: overrideRepoReviewerCount,
+						}}},
+			},
+			expectedRequested: 2,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			pr := github.PullRequest{Number: 5, User: github.User{Login: "author"}}
+			fghc := newFakeGitHubClient(&pr, []string{"a.go", "b.go", "c.go", "d.go"})
+			repo := github.Repo{Owner: github.User{Login: "org"}, Name: "repo"}
+			reviewerCount := 1
+
+			config := &plugins.Configuration{
+				Blunderbuss: plugins.Blunderbuss{
+					BlunderbussConfig: &plugins.BlunderbussConfig{
+						ReviewerCount: &reviewerCount,
+					},
+					Orgs: tc.orgConfig,
+				}}
+			bc := config.BlunderbussFor(repo.Owner.Login, repo.Name)
+
+			if err := handlePullRequest(
+				fghc, froc, logrus.WithField("plugin", PluginName),
+				bc, github.PullRequestActionOpened, &pr, &repo,
+			); err != nil {
+				t.Fatalf("unexpected error from handle: %v", err)
+			}
+
+			if tc.expectedRequested != len(fghc.requested) {
+				t.Fatalf("expected the requested reviewers to be %d, but got %d.", tc.expectedRequested, len(fghc.requested))
 			}
 		})
 	}
@@ -783,7 +882,7 @@ func TestHandleGenericComment(t *testing.T) {
 			pr := github.PullRequest{Number: 5, User: github.User{Login: "author"}}
 			fghc := newFakeGitHubClient(&pr, tc.filesChanged)
 			repo := github.Repo{Owner: github.User{Login: "org"}, Name: "repo"}
-			config := plugins.Blunderbuss{
+			config := plugins.BlunderbussConfig{
 				ReviewerCount:    &tc.reviewerCount,
 				MaxReviewerCount: 0,
 				ExcludeApprovers: false,
@@ -800,6 +899,106 @@ func TestHandleGenericComment(t *testing.T) {
 			sort.Strings(tc.expectedRequested)
 			if !reflect.DeepEqual(fghc.requested, tc.expectedRequested) {
 				t.Fatalf("expected the requested reviewers to be %q, but got %q.", tc.expectedRequested, fghc.requested)
+			}
+		})
+	}
+}
+
+func TestHandleGenericCommentShardedConfig(t *testing.T) {
+	froc := &fakeRepoownersClient{
+		foc: &fakeOwnersClient{
+			owners: map[string]string{
+				"a.go": "1",
+				"b.go": "2",
+			},
+			leafReviewers: map[string]sets.Set[string]{
+				"a.go": sets.New("al"),
+				"b.go": sets.New("bob"),
+				"c.go": sets.New("sarah"),
+				"d.go": sets.New("busy-user"),
+			},
+		},
+	}
+
+	overrideOrgReviewerCount := 2
+	overrideRepoReviewerCount := 3
+	var testcases = []struct {
+		name              string
+		orgConfig         map[string]plugins.BlunderbussOrgConfig
+		expectedRequested int
+	}{
+		{
+			name: "overrides default config with org config",
+			orgConfig: map[string]plugins.BlunderbussOrgConfig{
+				"org": {
+					BlunderbussConfig: &plugins.BlunderbussConfig{
+						ReviewerCount:    &overrideOrgReviewerCount,
+						MaxReviewerCount: overrideOrgReviewerCount,
+					}},
+			},
+			expectedRequested: 2,
+		},
+		{
+			name: "overrides default and org config with repo config",
+			orgConfig: map[string]plugins.BlunderbussOrgConfig{
+				"org": {
+					BlunderbussConfig: &plugins.BlunderbussConfig{
+						ReviewerCount:    &overrideOrgReviewerCount,
+						MaxReviewerCount: overrideOrgReviewerCount,
+					},
+					Repos: map[string]plugins.BlunderbussConfig{
+						"org/repo": {
+							ReviewerCount:    &overrideRepoReviewerCount,
+							MaxReviewerCount: overrideRepoReviewerCount,
+						}}},
+			},
+			expectedRequested: 3,
+		},
+		{
+			name: "Uses org config with invalid repo config key",
+			orgConfig: map[string]plugins.BlunderbussOrgConfig{
+				"org": {
+					BlunderbussConfig: &plugins.BlunderbussConfig{
+						ReviewerCount:    &overrideOrgReviewerCount,
+						MaxReviewerCount: overrideOrgReviewerCount,
+					},
+					Repos: map[string]plugins.BlunderbussConfig{
+						"repo": {
+							ReviewerCount:    &overrideRepoReviewerCount,
+							MaxReviewerCount: overrideRepoReviewerCount,
+						}}},
+			},
+			expectedRequested: 2,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			pr := github.PullRequest{Number: 5, User: github.User{Login: "author"}}
+			fghc := newFakeGitHubClient(&pr, []string{"a.go", "b.go", "c.go", "d.go"})
+			repo := github.Repo{Owner: github.User{Login: "org"}, Name: "repo"}
+			reviewerCount := 1
+
+			config := &plugins.Configuration{
+				Blunderbuss: plugins.Blunderbuss{
+					BlunderbussConfig: &plugins.BlunderbussConfig{
+						IgnoreAuthors:         []string{"bob"},
+						ReviewerCount:         &reviewerCount,
+						UseStatusAvailability: false,
+					},
+					Orgs: tc.orgConfig,
+				}}
+			bc := config.BlunderbussFor(repo.Owner.Login, repo.Name)
+
+			if err := handleGenericComment(
+				fghc, froc, logrus.WithField("plugin", PluginName), bc,
+				github.GenericCommentActionCreated, true, pr.Number, "open", &repo, "/auto-cc",
+			); err != nil {
+				t.Fatalf("unexpected error from handle: %v", err)
+			}
+
+			if tc.expectedRequested != len(fghc.requested) {
+				t.Fatalf("expected the requested reviewers to be %d, but got %d.", tc.expectedRequested, len(fghc.requested))
 			}
 		})
 	}
@@ -950,7 +1149,7 @@ func TestHandleStatus(t *testing.T) {
 			fghc := newFakeGitHubClient(&pr, tc.filesChanged)
 			repo := github.Repo{Owner: github.User{Login: "org"}, Name: "repo"}
 			descriptionPattern := "Not mergeable. (PullRequest is missing sufficient approving GitHub review\\(s\\)|Needs (lgtm|approved|approved, lgtm) labels?)\\.?"
-			config := plugins.Blunderbuss{
+			config := plugins.BlunderbussConfig{
 				ReviewerCount:    &tc.reviewerCount,
 				MaxReviewerCount: 0,
 				ExcludeApprovers: false,
@@ -979,9 +1178,127 @@ func TestHandleStatus(t *testing.T) {
 	}
 }
 
+func TestHandleStatusShardedConfig(t *testing.T) {
+	froc := &fakeRepoownersClient{
+		foc: &fakeOwnersClient{
+			owners: map[string]string{
+				"a.go": "1",
+			},
+			leafReviewers: map[string]sets.Set[string]{
+				"a.go": sets.New[string]("al"),
+			},
+		},
+	}
+
+	descriptionPattern := "Not mergeable. (PullRequest is missing sufficient approving GitHub review\\(s\\)|Needs (lgtm|approved|approved, lgtm) labels?)\\.?"
+	waitForStatus := &plugins.ContextMatch{
+		Context:       "tide",
+		Description:   descriptionPattern,
+		DescriptionRe: regexp.MustCompile(descriptionPattern),
+		State:         "pending",
+	}
+	otherWaitForStatus := &plugins.ContextMatch{
+		Context:       "other",
+		Description:   descriptionPattern,
+		DescriptionRe: regexp.MustCompile(descriptionPattern),
+		State:         "pending",
+	}
+	reviewerCount := 1
+
+	var testcases = []struct {
+		name              string
+		orgConfig         map[string]plugins.BlunderbussOrgConfig
+		expectedRequested []string
+	}{
+		{
+			name: "overrides default config with org config",
+			orgConfig: map[string]plugins.BlunderbussOrgConfig{
+				"org": {
+					BlunderbussConfig: &plugins.BlunderbussConfig{
+						ReviewerCount: &reviewerCount,
+						WaitForStatus: waitForStatus,
+					}},
+			},
+			expectedRequested: []string{"al"},
+		},
+		{
+			name: "overrides default and org config with repo config",
+			orgConfig: map[string]plugins.BlunderbussOrgConfig{
+				"org": {
+					BlunderbussConfig: &plugins.BlunderbussConfig{
+						ReviewerCount: &reviewerCount,
+						WaitForStatus: otherWaitForStatus,
+					},
+					Repos: map[string]plugins.BlunderbussConfig{
+						"org/repo": {
+							ReviewerCount: &reviewerCount,
+							WaitForStatus: waitForStatus,
+						}},
+				},
+			},
+			expectedRequested: []string{"al"},
+		},
+		{
+			name: "uses org config with invalid repo config key",
+			orgConfig: map[string]plugins.BlunderbussOrgConfig{
+				"org": {
+					BlunderbussConfig: &plugins.BlunderbussConfig{
+						ReviewerCount: &reviewerCount,
+						WaitForStatus: waitForStatus,
+					},
+					Repos: map[string]plugins.BlunderbussConfig{
+						"repo": {
+							ReviewerCount: &reviewerCount,
+							WaitForStatus: otherWaitForStatus,
+						}},
+				},
+			},
+			expectedRequested: []string{"al"},
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			pr := github.PullRequest{
+				Number: 5,
+				User:   github.User{Login: "author"},
+				Head:   github.PullRequestBranch{Ref: "test", SHA: "0001"},
+			}
+			fghc := newFakeGitHubClient(&pr, []string{"a.go"})
+			repo := github.Repo{Owner: github.User{Login: "org"}, Name: "repo"}
+
+			config := &plugins.Configuration{
+				Blunderbuss: plugins.Blunderbuss{
+					BlunderbussConfig: &plugins.BlunderbussConfig{
+						ReviewerCount: &reviewerCount,
+					},
+					Orgs: tc.orgConfig,
+				}}
+			bc := config.BlunderbussFor(repo.Owner.Login, repo.Name)
+
+			if err := handleStatus(
+				fghc, froc, logrus.WithField("plugin", PluginName), bc,
+				"0001", "tide", "pending",
+				"Not mergeable. PullRequest is missing sufficient approving GitHub review(s)",
+				&repo,
+			); err != nil {
+				t.Fatalf("unexpected error from handle: %v", err)
+			}
+
+			sort.Strings(fghc.requested)
+			sort.Strings(tc.expectedRequested)
+			if !reflect.DeepEqual(fghc.requested, tc.expectedRequested) {
+				t.Fatalf("expected the requested reviewers to be %q, but got %q.", tc.expectedRequested, fghc.requested)
+			}
+		})
+	}
+}
+
 func TestHandleGenericCommentEvent(t *testing.T) {
 	pc := plugins.Agent{
-		PluginConfig: &plugins.Configuration{},
+		PluginConfig: &plugins.Configuration{
+			Blunderbuss: plugins.Blunderbuss{
+				BlunderbussConfig: &plugins.BlunderbussConfig{},
+			}},
 	}
 	ce := github.GenericCommentEvent{}
 	handleGenericCommentEvent(pc, ce)
@@ -989,7 +1306,10 @@ func TestHandleGenericCommentEvent(t *testing.T) {
 
 func TestHandlePullRequestEvent(t *testing.T) {
 	pc := plugins.Agent{
-		PluginConfig: &plugins.Configuration{},
+		PluginConfig: &plugins.Configuration{
+			Blunderbuss: plugins.Blunderbuss{
+				BlunderbussConfig: &plugins.BlunderbussConfig{},
+			}},
 	}
 	pre := github.PullRequestEvent{}
 	handlePullRequestEvent(pc, pre)
@@ -1008,6 +1328,7 @@ func TestHelpProvider(t *testing.T) {
 		{Org: "org1", Repo: "repo"},
 		{Org: "org2", Repo: "repo"},
 	}
+	reviewerCount := 1
 	cases := []struct {
 		name               string
 		config             *plugins.Configuration
@@ -1016,20 +1337,24 @@ func TestHelpProvider(t *testing.T) {
 		configInfoIncludes []string
 	}{
 		{
-			name:               "Empty config",
-			config:             &plugins.Configuration{},
+			name: "Empty config",
+			config: &plugins.Configuration{
+				Blunderbuss: plugins.Blunderbuss{
+					BlunderbussConfig: &plugins.BlunderbussConfig{},
+				}},
 			enabledRepos:       enabledRepos,
-			configInfoIncludes: []string{configString(0)},
+			configInfoIncludes: []string{configString(2)},
 		},
 		{
 			name: "ReviewerCount specified",
 			config: &plugins.Configuration{
 				Blunderbuss: plugins.Blunderbuss{
-					ReviewerCount: &[]int{2}[0],
-				},
+					BlunderbussConfig: &plugins.BlunderbussConfig{
+						ReviewerCount: &reviewerCount,
+					}},
 			},
 			enabledRepos:       enabledRepos,
-			configInfoIncludes: []string{configString(2)},
+			configInfoIncludes: []string{configString(1)},
 		},
 	}
 	for _, c := range cases {

--- a/pkg/plugins/config.go
+++ b/pkg/plugins/config.go
@@ -181,21 +181,21 @@ type ExternalPlugin struct {
 }
 
 type ContextMatch struct {
-	// Context name of the context to match on, defaults to "tide"
+	// Context name of the context to match on. Defaults to "tide".
 	Context string `json:"context,omitempty"`
-	// Description regular expression to match the context description, defaults to
+	// Description regular expression to match the context description. Defaults to
 	// "Not mergeable. (PullRequest is missing sufficient approving GitHub review\(s\)|Needs (lgtm|approved) label)"
 	Description string `json:"description,omitempty"`
 	// Compiled description
 	DescriptionRe *regexp.Regexp `json:"-"`
-	// State is the state we want the context to be in before requesting reviews, e.g. "pending"
+	// State is the state we want the context to be in before requesting reviews. Defaults to "pending".
 	State string `json:"state,omitempty"`
 }
 
-// Blunderbuss defines configuration for the blunderbuss plugin.
-type Blunderbuss struct {
+// BlunderbussConfig defines configuration options for the blunderbuss plugin.
+type BlunderbussConfig struct {
 	// ReviewerCount is the minimum number of reviewers to request
-	// reviews from. Defaults to requesting reviews from 2 reviewers
+	// reviews from. Defaults to requesting reviews from 2 reviewers.
 	ReviewerCount *int `json:"request_count,omitempty"`
 	// MaxReviewerCount is the maximum number of reviewers to request
 	// reviews from. Defaults to 0 meaning no limit.
@@ -211,15 +211,32 @@ type Blunderbuss struct {
 	// how many busy reviewers it had to pass over).
 	UseStatusAvailability bool `json:"use_status_availability,omitempty"`
 	// IgnoreDrafts instructs the plugin to ignore assigning reviewers
-	// to the PR that is in Draft state. Default it's false.
+	// to the PR that is in Draft state. Defaults to false.
 	IgnoreDrafts bool `json:"ignore_drafts,omitempty"`
 	// IgnoreAuthors skips requesting reviewers for specified users.
 	// This is useful when a bot user or admin opens a PR that will be
 	// merged regardless of approvals.
 	IgnoreAuthors []string `json:"ignore_authors,omitempty"`
-	// WaitForStatus specifies whether to request reviews if the tide status indicates that
-	// the tests have passed but there are insufficient pull request reviews.
+	// WaitForStatus specifies whether to wait to request reviews until a status
+	// check matches the given criteria.
 	WaitForStatus *ContextMatch `json:"wait_for_status,omitempty"`
+}
+
+// BlunderbussOrgConfig defines organization-specific configuration for the blunderbuss plugin.
+type BlunderbussOrgConfig struct {
+	*BlunderbussConfig `json:",inline,omitempty"`
+	// Repos allows sharding for repository-specific Blunderbuss settings, provided under keys using
+	// the format organization/repository.
+	Repos map[string]BlunderbussConfig `json:"repos,omitempty"`
+}
+
+// Blunderbuss defines overall configuration for the blunderbuss plugin.
+type Blunderbuss struct {
+	*BlunderbussConfig `json:",inline,omitempty"`
+	// Orgs allows sharding for organization-specific Blunderbuss settings, provided under keys with
+	// the name of the organization. For repository-specific settings, provide
+	// organization/repository keys under orgs[].repos.
+	Orgs map[string]BlunderbussOrgConfig `json:"orgs,omitempty"`
 }
 
 // Owners contains configuration related to handling OWNERS files.
@@ -1058,6 +1075,32 @@ func (c *Configuration) ApproveFor(org, repo string) *Approve {
 	return a
 }
 
+// BlunderbussFor finds the BlunderbussConfig for an org or repo, if one exists.
+// Blunderbuss configuration can be listed for a repository or an organization.
+func (c *Configuration) BlunderbussFor(org, repo string) BlunderbussConfig {
+	fullName := fmt.Sprintf("%s/%s", org, repo)
+
+	if orgConfig, ok := c.Blunderbuss.Orgs[org]; ok {
+		if repoConfig, ok := orgConfig.Repos[fullName]; ok {
+			// Return repo configuration
+			return repoConfig
+		}
+
+		// Return org configuration if defined
+		if orgConfig.BlunderbussConfig != nil {
+			return *orgConfig.BlunderbussConfig
+		}
+	}
+
+	// Return base config
+	if c.Blunderbuss.BlunderbussConfig != nil {
+		return *c.Blunderbuss.BlunderbussConfig
+	}
+
+	// Fallback to empty config (Blunderbuss.SetDefaults() also handles this case)
+	return BlunderbussConfig{}
+}
+
 // LgtmFor finds the Lgtm for a repo, if one exists
 // a trigger can be listed for the repo itself or for the
 // owning organization
@@ -1256,21 +1299,7 @@ func (c *Configuration) setDefaults() {
 			c.ExternalPlugins[repo][i].Endpoint = fmt.Sprintf("http://%s", p.Name)
 		}
 	}
-	if c.Blunderbuss.ReviewerCount == nil {
-		c.Blunderbuss.ReviewerCount = new(int)
-		*c.Blunderbuss.ReviewerCount = defaultBlunderbussReviewerCount
-	}
-	if c.Blunderbuss.WaitForStatus != nil {
-		if c.Blunderbuss.WaitForStatus.Context == "" {
-			c.Blunderbuss.WaitForStatus.Context = "tide"
-		}
-		if c.Blunderbuss.WaitForStatus.State == "" {
-			c.Blunderbuss.WaitForStatus.State = "pending"
-		}
-		if c.Blunderbuss.WaitForStatus.Description == "" {
-			c.Blunderbuss.WaitForStatus.Description = "Not mergeable. (PullRequest is missing sufficient approving GitHub review\\(s\\)|Needs (lgtm|approved|approved, lgtm) labels?)\\.?"
-		}
-	}
+	c.Blunderbuss.SetDefaults()
 	for i := range c.Triggers {
 		c.Triggers[i].SetDefaults()
 	}
@@ -1393,11 +1422,86 @@ func validateExternalPlugins(pluginMap map[string][]ExternalPlugin) error {
 	return nil
 }
 
-func validateBlunderbuss(b *Blunderbuss) error {
-	if b.ReviewerCount != nil && *b.ReviewerCount < 1 {
-		return fmt.Errorf("invalid request_count: %v (needs to be positive)", *b.ReviewerCount)
+func (b *Blunderbuss) SetDefaults() {
+	// Instantiate a global Blunderbuss config if it wasn't set in the config
+	if b.BlunderbussConfig == nil {
+		b.BlunderbussConfig = &BlunderbussConfig{}
 	}
-	return nil
+
+	// Set field defaults for all configs
+	_ = b.descendShards(func(b *BlunderbussConfig) error {
+		// Set default reviewer count if it's unset
+		if b.ReviewerCount == nil {
+			reviewerCount := defaultBlunderbussReviewerCount
+			b.ReviewerCount = &reviewerCount
+		}
+		// Set default "wait for status" fields if they're unset
+		if b.WaitForStatus != nil {
+			if b.WaitForStatus.Context == "" {
+				b.WaitForStatus.Context = "tide"
+			}
+			if b.WaitForStatus.State == "" {
+				b.WaitForStatus.State = "pending"
+			}
+			if b.WaitForStatus.Description == "" {
+				b.WaitForStatus.Description = "Not mergeable. (PullRequest is missing sufficient approving GitHub review\\(s\\)|Needs (lgtm|approved|approved, lgtm) labels?)\\.?"
+			}
+		}
+
+		return nil
+	})
+}
+
+// descendShards recurses the Blunderbuss config into the global config, org
+// configs, and repo configs, calling the provided function for each config.
+func (b *Blunderbuss) descendShards(f func(*BlunderbussConfig) error) error {
+	var errs []error
+	// Global config
+	if b.BlunderbussConfig != nil {
+		if err := f(b.BlunderbussConfig); err != nil {
+			errs = append(errs, fmt.Errorf("error in global blunderbuss configuration: %w", err))
+		}
+	}
+	// Org configs
+	for org, orgConfig := range b.Orgs {
+		if orgConfig.BlunderbussConfig != nil {
+			if err := f(orgConfig.BlunderbussConfig); err != nil {
+				errs = append(errs, fmt.Errorf("error in blunderbuss configuration for org %s: %w", org, err))
+			}
+		}
+		// Repo configs
+		for repo, repoConfig := range orgConfig.Repos {
+			if err := f(&repoConfig); err != nil {
+				errs = append(errs, fmt.Errorf("error in blunderbuss configuration for repo %s/%s: %w", org, repo, err))
+			}
+		}
+	}
+
+	return utilerrors.NewAggregate(errs)
+}
+
+func (b Blunderbuss) validateBlunderbuss() error {
+	return b.descendShards(
+		func(b *BlunderbussConfig) error {
+			if b == nil {
+				return nil
+			}
+			if b.ReviewerCount != nil && *b.ReviewerCount < 1 {
+				return fmt.Errorf("invalid request_count: %d (must be at least 1)", b.ReviewerCount)
+			}
+			if b.MaxReviewerCount < 0 {
+				return fmt.Errorf("invalid max_request_count: %d (must be positive)", b.MaxReviewerCount)
+			}
+			reviewerCount := 2
+			if b.ReviewerCount != nil {
+				reviewerCount = *b.ReviewerCount
+			}
+			if b.MaxReviewerCount > 0 && b.MaxReviewerCount < reviewerCount {
+				return fmt.Errorf("invalid reviewer configuration: max_request_count %d must be at least request_count %d", b.MaxReviewerCount, b.ReviewerCount)
+			}
+
+			return nil
+		})
 }
 
 // ConfigMapID is a name/namespace/cluster combination that identifies a config map
@@ -1561,6 +1665,23 @@ func validateRepoMilestone(milestones map[string]Milestone) {
 	}
 }
 
+func (b *Blunderbuss) compileRegexpsAndDurations() error {
+	return b.descendShards(
+		func(b *BlunderbussConfig) error {
+			if b == nil {
+				return nil
+			}
+			var err error
+			if b.WaitForStatus != nil {
+				b.WaitForStatus.DescriptionRe, err = regexp.Compile(b.WaitForStatus.Description)
+				if err != nil {
+					return fmt.Errorf("failed to compile blunderbuss wait for context description regular expression: %q, error: %w", b.WaitForStatus.Description, err)
+				}
+			}
+			return nil
+		})
+}
+
 func compileRegexpsAndDurations(pc *Configuration) error {
 	cRe, err := regexp.Compile(pc.SigMention.Regexp)
 	if err != nil {
@@ -1615,12 +1736,11 @@ func compileRegexpsAndDurations(pc *Configuration) error {
 		rs[i].GracePeriodDuration = dur
 	}
 
-	if pc.Blunderbuss.WaitForStatus != nil {
-		pc.Blunderbuss.WaitForStatus.DescriptionRe, err = regexp.Compile(pc.Blunderbuss.WaitForStatus.Description)
-		if err != nil {
-			return fmt.Errorf("failed to compile blunderbuss wait for context description regular expression: %q, error: %w", pc.Blunderbuss.WaitForStatus.Description, err)
-		}
+	err = pc.Blunderbuss.compileRegexpsAndDurations()
+	if err != nil {
+		return fmt.Errorf("failed to compile blunderbuss regular expressions: %w", err)
 	}
+
 	return nil
 }
 
@@ -1642,7 +1762,7 @@ func (c *Configuration) Validate() error {
 	if err := validateExternalPlugins(c.ExternalPlugins); err != nil {
 		return err
 	}
-	if err := validateBlunderbuss(&c.Blunderbuss); err != nil {
+	if err := c.Blunderbuss.validateBlunderbuss(); err != nil {
 		return err
 	}
 	if err := validateConfigUpdater(&c.ConfigUpdater); err != nil {
@@ -2258,7 +2378,8 @@ func (c *Configuration) mergeFrom(other *Configuration) error {
 
 	diff := cmp.Diff(other, &Configuration{Approve: other.Approve, Bugzilla: other.Bugzilla,
 		ExternalPlugins: other.ExternalPlugins, Label: Label{RestrictedLabels: other.Label.RestrictedLabels},
-		Lgtm: other.Lgtm, Plugins: other.Plugins, Triggers: other.Triggers, Welcome: other.Welcome},
+		Lgtm: other.Lgtm, Plugins: other.Plugins, Triggers: other.Triggers, Welcome: other.Welcome,
+		Blunderbuss: other.Blunderbuss},
 		config.DefaultDiffOpts...)
 
 	if diff != "" {
@@ -2280,6 +2401,10 @@ func (c *Configuration) mergeFrom(other *Configuration) error {
 	c.Lgtm = append(c.Lgtm, other.Lgtm...)
 	c.Triggers = append(c.Triggers, other.Triggers...)
 	c.Welcome = append(c.Welcome, other.Welcome...)
+
+	if err := c.Blunderbuss.mergeFrom(&other.Blunderbuss); err != nil {
+		errs = append(errs, fmt.Errorf("failed to merge .blunderbuss from supplemental config: %w", err))
+	}
 
 	if err := c.mergeExternalPluginsFrom(other.ExternalPlugins); err != nil {
 		errs = append(errs, fmt.Errorf("failed to merge .external-plugins from supplemental config: %w", err))
@@ -2397,6 +2522,69 @@ func (l *Label) mergeFrom(other *Label) error {
 	return utilerrors.NewAggregate(errs)
 }
 
+// Merge two Blunderbuss configurations, returning an aggregated error for conflicts
+func (b *Blunderbuss) mergeFrom(other *Blunderbuss) error {
+	// No config actually specified, so no action required
+	if other == nil {
+		return nil
+	}
+
+	var errs []error
+
+	// Handle global configs
+	if other.BlunderbussConfig != nil {
+		if b.BlunderbussConfig == nil {
+			b.BlunderbussConfig = other.BlunderbussConfig
+		} else if !reflect.DeepEqual(*b.BlunderbussConfig, *other.BlunderbussConfig) {
+			// Add error when both configs declare different global defaults
+			errs = append(errs, fmt.Errorf("global configurations for blunderbuss do not match"))
+		}
+	}
+
+	// Initialize the Orgs map if it's empty to accept incoming Orgs configs
+	if other.Orgs != nil && b.Orgs == nil {
+		b.Orgs = map[string]BlunderbussOrgConfig{}
+	}
+
+	// Merge Orgs configs, skipping conflicts and adding a message to the aggregated error message
+	for org, otherOrgConfig := range other.Orgs {
+		if orgConfig, ok := b.Orgs[org]; ok {
+			// Use incoming org if current org config is empty, otherwise verify they're the same
+			if otherOrgConfig.BlunderbussConfig != nil {
+				if orgConfig.BlunderbussConfig == nil {
+					orgConfig.BlunderbussConfig = otherOrgConfig.BlunderbussConfig
+					b.Orgs[org] = orgConfig
+				} else if !reflect.DeepEqual(*orgConfig.BlunderbussConfig, *otherOrgConfig.BlunderbussConfig) {
+					errs = append(errs, fmt.Errorf("found conflicting config for blunderbuss.orgs[\"%s\"]", org))
+					continue
+				}
+			}
+			// Initialize Repos map if it's empty to accept incoming Repos configs
+			if otherOrgConfig.Repos != nil && orgConfig.Repos == nil {
+				orgConfig.Repos = map[string]BlunderbussConfig{}
+				b.Orgs[org] = orgConfig
+			}
+			// Merge Repos configs, skipping conflicts and adding a message to the aggregated error message
+			for repo, otherRepoConfig := range otherOrgConfig.Repos {
+				if repoConfig, ok := orgConfig.Repos[repo]; ok {
+					// Verify the repo configurations are the same
+					if !reflect.DeepEqual(repoConfig, otherRepoConfig) {
+						errs = append(errs, fmt.Errorf(
+							"found conflicting config for blunderbuss.orgs[\"%s\"].repos[\"%s\"]", org, repo))
+						continue
+					}
+				} else {
+					b.Orgs[org].Repos[repo] = otherRepoConfig
+				}
+			}
+		} else {
+			b.Orgs[org] = otherOrgConfig
+		}
+	}
+
+	return utilerrors.NewAggregate(errs)
+}
+
 func getLabelConfigFromRestrictedLabelsSlice(s []RestrictedLabel, label string) int {
 	for idx, item := range s {
 		if item.Label == label {
@@ -2409,11 +2597,11 @@ func getLabelConfigFromRestrictedLabelsSlice(s []RestrictedLabel, label string) 
 
 func (c *Configuration) HasConfigFor() (global bool, orgs sets.Set[string], repos sets.Set[string]) {
 	equals := reflect.DeepEqual(c,
-		&Configuration{Approve: c.Approve, Bugzilla: c.Bugzilla, ExternalPlugins: c.ExternalPlugins,
-			Label: Label{RestrictedLabels: c.Label.RestrictedLabels}, Lgtm: c.Lgtm, Plugins: c.Plugins,
-			Triggers: c.Triggers, Welcome: c.Welcome})
+		&Configuration{Approve: c.Approve, Blunderbuss: c.Blunderbuss, Bugzilla: c.Bugzilla,
+			ExternalPlugins: c.ExternalPlugins, Label: Label{RestrictedLabels: c.Label.RestrictedLabels},
+			Lgtm: c.Lgtm, Plugins: c.Plugins, Triggers: c.Triggers, Welcome: c.Welcome})
 
-	if !equals || c.Bugzilla.Default != nil {
+	if !equals || c.Bugzilla.Default != nil || c.Blunderbuss.BlunderbussConfig != nil {
 		global = true
 	}
 	orgs = sets.Set[string]{}
@@ -2423,6 +2611,15 @@ func (c *Configuration) HasConfigFor() (global bool, orgs sets.Set[string], repo
 			repos.Insert(orgOrRepo)
 		} else {
 			orgs.Insert(orgOrRepo)
+		}
+	}
+
+	for org, orgConfig := range c.Blunderbuss.Orgs {
+		if orgConfig.BlunderbussConfig != nil {
+			orgs.Insert(org)
+		}
+		for repo := range orgConfig.Repos {
+			repos.Insert(repo)
 		}
 	}
 

--- a/pkg/plugins/config_test.go
+++ b/pkg/plugins/config_test.go
@@ -1727,6 +1727,275 @@ func TestPluginsMergeFrom(t *testing.T) {
 	}
 }
 
+func TestBlunderbussFor(t *testing.T) {
+	t.Parallel()
+
+	globalReviewerCount := 1
+	orgReviewerCount := 2
+	repoReviewerCount := 3
+
+	globalConfig := BlunderbussConfig{
+		ReviewerCount:    &globalReviewerCount,
+		MaxReviewerCount: 10,
+	}
+	orgConfig := BlunderbussConfig{
+		ReviewerCount:    &orgReviewerCount,
+		MaxReviewerCount: 20,
+	}
+	repoConfig := BlunderbussConfig{
+		ReviewerCount:    &repoReviewerCount,
+		MaxReviewerCount: 30,
+	}
+
+	config := Configuration{
+		Blunderbuss: Blunderbuss{
+			BlunderbussConfig: &globalConfig,
+			Orgs: map[string]BlunderbussOrgConfig{
+				"org": {
+					BlunderbussConfig: &orgConfig,
+					Repos: map[string]BlunderbussConfig{
+						"org/repo": repoConfig,
+					},
+				},
+				"org-wrong-repo-key": {
+					BlunderbussConfig: &orgConfig,
+					Repos: map[string]BlunderbussConfig{
+						"repo": {
+							ReviewerCount:    &repoReviewerCount,
+							MaxReviewerCount: 40,
+						},
+					},
+				},
+				"repos-only-org": {
+					Repos: map[string]BlunderbussConfig{
+						"repos-only-org/some-repo": repoConfig,
+					},
+				},
+			},
+		},
+	}
+
+	testCases := []struct {
+		name     string
+		org      string
+		repo     string
+		expected BlunderbussConfig
+	}{
+		{
+			name:     "returns global config for unknown org",
+			org:      "unknown",
+			repo:     "repo",
+			expected: globalConfig,
+		},
+		{
+			name:     "returns org config when repo is not configured",
+			org:      "org",
+			repo:     "other",
+			expected: orgConfig,
+		},
+		{
+			name:     "returns org config when repo key is not formatted as org/repo",
+			org:      "org-wrong-repo-key",
+			repo:     "repo",
+			expected: orgConfig,
+		},
+		{
+			name:     "returns repo config over org and global",
+			org:      "org",
+			repo:     "repo",
+			expected: repoConfig,
+		},
+		{
+			name:     "falls back to global when org has only repos and repo does not match",
+			org:      "repos-only-org",
+			repo:     "other-repo",
+			expected: globalConfig,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			actual := config.BlunderbussFor(tc.org, tc.repo)
+			if diff := cmp.Diff(tc.expected, actual, cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("BlunderbussFor(%q, %q) mismatch (-want +got):\n%s", tc.org, tc.repo, diff)
+			}
+		})
+	}
+}
+
+func TestBlunderbussMergeFrom(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name           string
+		from           *Blunderbuss
+		to             *Blunderbuss
+		expected       *Blunderbuss
+		expectedErrMsg string
+	}{
+		{
+			name: "Merging for two different repos in an org",
+			from: &Blunderbuss{
+				Orgs: map[string]BlunderbussOrgConfig{"org": {
+					Repos: map[string]BlunderbussConfig{"org/repo-1": {}}}}},
+			to: &Blunderbuss{
+				Orgs: map[string]BlunderbussOrgConfig{"org": {
+					Repos: map[string]BlunderbussConfig{"org/repo-2": {}}}}},
+			expected: &Blunderbuss{
+				Orgs: map[string]BlunderbussOrgConfig{"org": {
+					Repos: map[string]BlunderbussConfig{
+						"org/repo-1": {},
+						"org/repo-2": {}}}}},
+		},
+		{
+			name: "Merging org and repo in org",
+			from: &Blunderbuss{
+				Orgs: map[string]BlunderbussOrgConfig{"org": {
+					Repos: map[string]BlunderbussConfig{"org/repo-2": {}}}}},
+			to: &Blunderbuss{
+				Orgs: map[string]BlunderbussOrgConfig{"org": {
+					BlunderbussConfig: &BlunderbussConfig{}}}},
+			expected: &Blunderbuss{
+				Orgs: map[string]BlunderbussOrgConfig{"org": {
+					BlunderbussConfig: &BlunderbussConfig{},
+					Repos:             map[string]BlunderbussConfig{"org/repo-2": {}}}}},
+		},
+		{
+			name: "Merging 2 orgs",
+			from: &Blunderbuss{
+				Orgs: map[string]BlunderbussOrgConfig{"org": {
+					Repos: map[string]BlunderbussConfig{"org/repo-1": {}}}}},
+			to: &Blunderbuss{
+				Orgs: map[string]BlunderbussOrgConfig{"org-2": {
+					Repos: map[string]BlunderbussConfig{"org-2/repo-1": {}}}}},
+			expected: &Blunderbuss{
+				Orgs: map[string]BlunderbussOrgConfig{
+					"org": {
+						Repos: map[string]BlunderbussConfig{
+							"org/repo-1": {}}},
+					"org-2": {
+						Repos: map[string]BlunderbussConfig{
+							"org-2/repo-1": {}}}}},
+		},
+		{
+			name: "Merging global config with org/repo config succeeds",
+			from: &Blunderbuss{
+				Orgs: map[string]BlunderbussOrgConfig{"org": {
+					Repos: map[string]BlunderbussConfig{"org/repo-1": {}}}}},
+			to: &Blunderbuss{
+				BlunderbussConfig: &BlunderbussConfig{}},
+			expected: &Blunderbuss{
+				BlunderbussConfig: &BlunderbussConfig{},
+				Orgs: map[string]BlunderbussOrgConfig{"org": {
+					Repos: map[string]BlunderbussConfig{"org/repo-1": {}}}}},
+		},
+		{
+			name: "Merging org/repo config with global config succeeds",
+			from: &Blunderbuss{
+				BlunderbussConfig: &BlunderbussConfig{}},
+			to: &Blunderbuss{
+				Orgs: map[string]BlunderbussOrgConfig{"org": {
+					Repos: map[string]BlunderbussConfig{"org/repo-1": {}}}}},
+			expected: &Blunderbuss{
+				BlunderbussConfig: &BlunderbussConfig{},
+				Orgs: map[string]BlunderbussOrgConfig{"org": {
+					Repos: map[string]BlunderbussConfig{"org/repo-1": {}}}}},
+		},
+		{
+			name:     "Merging identical global configs succeeds",
+			from:     &Blunderbuss{BlunderbussConfig: &BlunderbussConfig{}},
+			to:       &Blunderbuss{BlunderbussConfig: &BlunderbussConfig{}},
+			expected: &Blunderbuss{BlunderbussConfig: &BlunderbussConfig{}},
+		},
+		{
+			name:     "Merging from nil config succeeds",
+			from:     nil,
+			to:       &Blunderbuss{BlunderbussConfig: &BlunderbussConfig{}},
+			expected: &Blunderbuss{BlunderbussConfig: &BlunderbussConfig{}},
+		},
+		{
+			name:     "Merging to nil global config succeeds",
+			from:     &Blunderbuss{BlunderbussConfig: &BlunderbussConfig{}},
+			to:       &Blunderbuss{BlunderbussConfig: nil},
+			expected: &Blunderbuss{BlunderbussConfig: &BlunderbussConfig{}},
+		},
+		{
+			name:     "Merging from config with nil global config succeeds",
+			from:     &Blunderbuss{BlunderbussConfig: nil},
+			to:       &Blunderbuss{BlunderbussConfig: &BlunderbussConfig{}},
+			expected: &Blunderbuss{BlunderbussConfig: &BlunderbussConfig{}},
+		},
+		{
+			name:           "Merging differing global configs fails",
+			from:           &Blunderbuss{BlunderbussConfig: &BlunderbussConfig{MaxReviewerCount: 1}},
+			to:             &Blunderbuss{BlunderbussConfig: &BlunderbussConfig{MaxReviewerCount: 2}},
+			expectedErrMsg: "global configurations for blunderbuss do not match",
+		},
+		{
+			name: "Merging identical organization configs succeeds",
+			from: &Blunderbuss{
+				Orgs: map[string]BlunderbussOrgConfig{"org": {BlunderbussConfig: &BlunderbussConfig{}}}},
+			to: &Blunderbuss{
+				Orgs: map[string]BlunderbussOrgConfig{"org": {BlunderbussConfig: &BlunderbussConfig{}}}},
+			expected: &Blunderbuss{
+				Orgs: map[string]BlunderbussOrgConfig{"org": {BlunderbussConfig: &BlunderbussConfig{}}}},
+		},
+		{
+			name: "Merging differing organization configs fails",
+			from: &Blunderbuss{
+				Orgs: map[string]BlunderbussOrgConfig{"org": {BlunderbussConfig: &BlunderbussConfig{MaxReviewerCount: 1}}}},
+			to: &Blunderbuss{
+				Orgs: map[string]BlunderbussOrgConfig{"org": {BlunderbussConfig: &BlunderbussConfig{MaxReviewerCount: 2}}}},
+			expectedErrMsg: "found conflicting config for blunderbuss.orgs[\"org\"]",
+		},
+		{
+			name: "Merging identical repository configs succeeds",
+			from: &Blunderbuss{
+				Orgs: map[string]BlunderbussOrgConfig{"org": {
+					Repos: map[string]BlunderbussConfig{"org/repo-1": {}}}}},
+			to: &Blunderbuss{
+				Orgs: map[string]BlunderbussOrgConfig{"org": {
+					Repos: map[string]BlunderbussConfig{"org/repo-1": {}}}}},
+			expected: &Blunderbuss{
+				Orgs: map[string]BlunderbussOrgConfig{"org": {
+					Repos: map[string]BlunderbussConfig{"org/repo-1": {}}}}},
+		},
+		{
+			name: "Merging differing repository configs fails",
+			from: &Blunderbuss{
+				Orgs: map[string]BlunderbussOrgConfig{"org": {
+					Repos: map[string]BlunderbussConfig{"org/repo-1": {
+						MaxReviewerCount: 1}}}}},
+			to: &Blunderbuss{
+				Orgs: map[string]BlunderbussOrgConfig{"org": {
+					Repos: map[string]BlunderbussConfig{"org/repo-1": {
+						MaxReviewerCount: 2}}}}},
+			expectedErrMsg: "found conflicting config for blunderbuss.orgs[\"org\"].repos[\"org/repo-1\"]",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var errMsg string
+			err := tc.to.mergeFrom(tc.from)
+			if err != nil {
+				errMsg = err.Error()
+			}
+			if tc.expectedErrMsg != errMsg {
+				t.Fatalf("expected error message %q, got %q", tc.expectedErrMsg, errMsg)
+			}
+			if err != nil {
+				return
+			}
+
+			if diff := cmp.Diff(tc.expected, tc.to); diff != "" {
+				t.Errorf("expected config differs from actual: %s", diff)
+			}
+		})
+	}
+}
+
 func TestBugzillaMergeFrom(t *testing.T) {
 	t.Parallel()
 
@@ -2065,6 +2334,7 @@ func TestHasConfigFor(t *testing.T) {
 				fuzzedConfig.Triggers = nil
 				fuzzedConfig.Welcome = nil
 				fuzzedConfig.ExternalPlugins = nil
+				fuzzedConfig.Blunderbuss = Blunderbuss{}
 				return fuzzedConfig, !reflect.DeepEqual(fuzzedConfig, &Configuration{}), nil, nil
 			},
 		},
@@ -2291,6 +2561,20 @@ func TestMergeFrom(t *testing.T) {
 				{Repos: []string{"foo/bar"}},
 				{Repos: []string{"foo/baz"}},
 			}},
+		},
+		{
+			name: "Blunderbuss config gets merged",
+			in: Configuration{Blunderbuss: Blunderbuss{
+				Orgs: map[string]BlunderbussOrgConfig{"foo": {
+					Repos: map[string]BlunderbussConfig{"foo/bar": {}}}}}},
+			supplementalConfigs: []Configuration{{Blunderbuss: Blunderbuss{
+				Orgs: map[string]BlunderbussOrgConfig{"foo": {
+					Repos: map[string]BlunderbussConfig{"foo/baz": {}}}}}}},
+			expected: Configuration{Blunderbuss: Blunderbuss{
+				Orgs: map[string]BlunderbussOrgConfig{"foo": {
+					Repos: map[string]BlunderbussConfig{
+						"foo/bar": {},
+						"foo/baz": {}}}}}},
 		},
 		{
 			name: "ExternalPlugins get merged",

--- a/pkg/plugins/plugin-config-documented.yaml
+++ b/pkg/plugins/plugin-config-documented.yaml
@@ -443,6 +443,17 @@ help:
     # HelpGuidelinesURL is the URL of the help page, which provides guidance on how and when to use the help wanted and good first issue labels.
     # The default value is "https://git.k8s.io/community/contributors/guide/help-wanted.md".
     help_guidelines_url: ' '
+invalid_commit_msg:
+    - # Checks is a list of check configurations.
+      # Each check can be individually enabled or disabled.
+      checks:
+        - # Disabled indicates whether this check should be skipped.
+          disabled: true
+          # Name is the name of the check (e.g., "fixupPrefix", "issueClosingKeywords").
+          name: ' '
+      # Repos is either of the form org/repos or just org.
+      repos:
+        - ""
 jira:
     # DisabledJiraProjects are projects for which we will never try to create a link,
     # for example including `enterprise` here would disable linking for all issues

--- a/pkg/plugins/plugin-config-documented.yaml
+++ b/pkg/plugins/plugin-config-documented.yaml
@@ -54,6 +54,9 @@ blunderbuss:
     # IgnoreDrafts instructs the plugin to ignore assigning reviewers
     # to the PR that is in Draft state. Default it's false.
     ignore_drafts: true
+    # MaxReviewerCount is the maximum number of reviewers to request
+    # reviews from. Defaults to 0 meaning no limit.
+    max_request_count: 1
     # ReviewerCount is the minimum number of reviewers to request
     # reviews from. Defaults to requesting reviews from 2 reviewers
     request_count: 0
@@ -541,6 +544,8 @@ project_config:
             # to the default column if column name is not provided in the command
             org_default_column_map:
                 "": ""
+            # ID of the github project maintainer team for a give project or org
+            org_maintainers_team_id: 1
             # Repo level configs for github projects; key is repo name
             project_repo_configs:
                 "":
@@ -548,6 +553,8 @@ project_config:
                     # to the default column if column name is not provided in the command
                     repo_default_column_map:
                         "": ""
+                    # ID of the github project maintainer team for a give project or org
+                    repo_maintainers_team_id: 1
 project_manager:
     orgsRepos:
         "":
@@ -571,6 +578,12 @@ release_note:
 repo_milestone:
     "":
         maintainers_friendly_name: ' '
+        # ID of the github team for the milestone maintainers (used for setting status labels)
+        # You can curl the following endpoint in order to determine the github ID of your team
+        # responsible for maintaining the milestones:
+        # curl -H "Authorization: token <token>" https://api.github.com/orgs/<org-name>/teams
+        # Deprecated: use MaintainersTeam instead
+        maintainers_id: 1
         maintainers_team: ' '
 require_matching_label:
     - # Branch is the branch ref of PRs that this config applies to.

--- a/pkg/plugins/plugin-config-documented.yaml
+++ b/pkg/plugins/plugin-config-documented.yaml
@@ -52,28 +52,105 @@ blunderbuss:
     ignore_authors:
         - ""
     # IgnoreDrafts instructs the plugin to ignore assigning reviewers
-    # to the PR that is in Draft state. Default it's false.
+    # to the PR that is in Draft state. Defaults to false.
     ignore_drafts: true
     # MaxReviewerCount is the maximum number of reviewers to request
     # reviews from. Defaults to 0 meaning no limit.
     max_request_count: 1
+    # Orgs allows sharding for organization-specific Blunderbuss settings, provided under keys with
+    # the name of the organization. For repository-specific settings, provide
+    # organization/repository keys under orgs[].repos.
+    orgs:
+        "":
+            # ExcludeApprovers controls whether approvers are considered to be
+            # reviewers. By default, approvers are considered as reviewers if
+            # insufficient reviewers are available. If ExcludeApprovers is true,
+            # approvers will never be considered as reviewers.
+            exclude_approvers: true
+            # IgnoreAuthors skips requesting reviewers for specified users.
+            # This is useful when a bot user or admin opens a PR that will be
+            # merged regardless of approvals.
+            ignore_authors:
+                - ""
+            # IgnoreDrafts instructs the plugin to ignore assigning reviewers
+            # to the PR that is in Draft state. Defaults to false.
+            ignore_drafts: true
+            # MaxReviewerCount is the maximum number of reviewers to request
+            # reviews from. Defaults to 0 meaning no limit.
+            max_request_count: 1
+            # Repos allows sharding for repository-specific Blunderbuss settings, provided under keys using
+            # the format organization/repository.
+            repos:
+                "":
+                    # ExcludeApprovers controls whether approvers are considered to be
+                    # reviewers. By default, approvers are considered as reviewers if
+                    # insufficient reviewers are available. If ExcludeApprovers is true,
+                    # approvers will never be considered as reviewers.
+                    exclude_approvers: true
+                    # IgnoreAuthors skips requesting reviewers for specified users.
+                    # This is useful when a bot user or admin opens a PR that will be
+                    # merged regardless of approvals.
+                    ignore_authors:
+                        - ""
+                    # IgnoreDrafts instructs the plugin to ignore assigning reviewers
+                    # to the PR that is in Draft state. Defaults to false.
+                    ignore_drafts: true
+                    # MaxReviewerCount is the maximum number of reviewers to request
+                    # reviews from. Defaults to 0 meaning no limit.
+                    max_request_count: 1
+                    # ReviewerCount is the minimum number of reviewers to request
+                    # reviews from. Defaults to requesting reviews from 2 reviewers.
+                    request_count: 0
+                    # UseStatusAvailability controls whether blunderbuss will consider GitHub's
+                    # status availability when requesting reviews for users. This will use at one
+                    # additional token per successful reviewer (and potentially more depending on
+                    # how many busy reviewers it had to pass over).
+                    use_status_availability: true
+                    # WaitForStatus specifies whether to wait to request reviews until a status
+                    # check matches the given criteria.
+                    wait_for_status:
+                        # Context name of the context to match on. Defaults to "tide".
+                        context: ' '
+                        # Description regular expression to match the context description. Defaults to
+                        # "Not mergeable. (PullRequest is missing sufficient approving GitHub review\(s\)|Needs (lgtm|approved) label)"
+                        description: ' '
+                        # State is the state we want the context to be in before requesting reviews. Defaults to "pending".
+                        state: ' '
+            # ReviewerCount is the minimum number of reviewers to request
+            # reviews from. Defaults to requesting reviews from 2 reviewers.
+            request_count: 0
+            # UseStatusAvailability controls whether blunderbuss will consider GitHub's
+            # status availability when requesting reviews for users. This will use at one
+            # additional token per successful reviewer (and potentially more depending on
+            # how many busy reviewers it had to pass over).
+            use_status_availability: true
+            # WaitForStatus specifies whether to wait to request reviews until a status
+            # check matches the given criteria.
+            wait_for_status:
+                # Context name of the context to match on. Defaults to "tide".
+                context: ' '
+                # Description regular expression to match the context description. Defaults to
+                # "Not mergeable. (PullRequest is missing sufficient approving GitHub review\(s\)|Needs (lgtm|approved) label)"
+                description: ' '
+                # State is the state we want the context to be in before requesting reviews. Defaults to "pending".
+                state: ' '
     # ReviewerCount is the minimum number of reviewers to request
-    # reviews from. Defaults to requesting reviews from 2 reviewers
+    # reviews from. Defaults to requesting reviews from 2 reviewers.
     request_count: 0
     # UseStatusAvailability controls whether blunderbuss will consider GitHub's
     # status availability when requesting reviews for users. This will use at one
     # additional token per successful reviewer (and potentially more depending on
     # how many busy reviewers it had to pass over).
     use_status_availability: true
-    # WaitForStatus specifies whether to request reviews if the tide status indicates that
-    # the tests have passed but there are insufficient pull request reviews.
+    # WaitForStatus specifies whether to wait to request reviews until a status
+    # check matches the given criteria.
     wait_for_status:
-        # Context name of the context to match on, defaults to "tide"
+        # Context name of the context to match on. Defaults to "tide".
         context: ' '
-        # Description regular expression to match the context description, defaults to
+        # Description regular expression to match the context description. Defaults to
         # "Not mergeable. (PullRequest is missing sufficient approving GitHub review\(s\)|Needs (lgtm|approved) label)"
         description: ' '
-        # State is the state we want the context to be in before requesting reviews, e.g. "pending"
+        # State is the state we want the context to be in before requesting reviews. Defaults to "pending".
         state: ' '
 branch_cleaner:
     # PreservedBranches is a map of org/repo branches

--- a/pkg/plugins/plugins_test.go
+++ b/pkg/plugins/plugins_test.go
@@ -231,9 +231,11 @@ func TestLoad(t *testing.T) {
 	t.Parallel()
 
 	defaultedConfig := func(m ...func(*Configuration)) *Configuration {
+		reviewerCount := 2
 		cfg := &Configuration{
-			Owners:      Owners{LabelsDenyList: []string{"approved", "lgtm"}},
-			Blunderbuss: Blunderbuss{ReviewerCount: func() *int { i := 2; return &i }()},
+			Owners: Owners{LabelsDenyList: []string{"approved", "lgtm"}},
+			Blunderbuss: Blunderbuss{
+				BlunderbussConfig: &BlunderbussConfig{ReviewerCount: &reviewerCount}},
 			CherryPickUnapproved: CherryPickUnapproved{
 				BranchRegexp: "^release-.*$",
 				BranchRe:     regexp.MustCompile("^release-.*$"),


### PR DESCRIPTION
Using a pointer lets sharding determine whether a config had been provided so they can be properly compared. If one is not provided, this also instantiates one in `setDefaults()`, which is called following the sharding logic.

Migrated from:
- https://github.com/kubernetes/test-infra/pull/29405