### PR TITLE
Fallback to config in external strategy

### DIFF
--- a/pkg/scheduler/reconciler.go
+++ b/pkg/scheduler/reconciler.go
@@ -53,7 +53,7 @@ func Add(mgr controllerruntime.Manager, cfg config.Getter, numWorkers int) error
 	return nil
 }
 
-type StrategyGetter func(cfg *config.Config) strategy.Interface
+type StrategyGetter func(cfg *config.Config, log *logrus.Entry) strategy.Interface
 
 type Reconciler struct {
 	pjClient    client.Client
@@ -82,7 +82,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	// if we're reconciling a job having a different agent (or no agent at all) applying
 	// the passthrough strategy may be the safest approach.
 	if pj.Spec.Agent == prowv1.KubernetesAgent || pj.Spec.Agent == prowv1.TektonAgent {
-		result, err = r.strategy(r.cfg()).Schedule(ctx, pj)
+		result, err = r.strategy(r.cfg(), log).Schedule(ctx, pj)
 	} else {
 		result, err = r.passthrough.Schedule(ctx, pj)
 	}

--- a/pkg/scheduler/reconciler_test.go
+++ b/pkg/scheduler/reconciler_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/sirupsen/logrus"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -173,7 +174,7 @@ func TestReconcile(t *testing.T) {
 
 			r := scheduler.NewReconciler(pjClient,
 				func() *config.Config { return nil },
-				func(_ *config.Config) strategy.Interface {
+				func(_ *config.Config, _ *logrus.Entry) strategy.Interface {
 					return &fakeStrategy{cluster: tc.cluster, err: tc.schedulingError}
 				})
 			_, err := r.Reconcile(context.TODO(), tc.request)

--- a/pkg/scheduler/strategy/default.go
+++ b/pkg/scheduler/strategy/default.go
@@ -19,6 +19,7 @@ package strategy
 import (
 	"context"
 
+	"github.com/sirupsen/logrus"
 	prowv1 "sigs.k8s.io/prow/pkg/apis/prowjobs/v1"
 	"sigs.k8s.io/prow/pkg/config"
 )
@@ -36,12 +37,12 @@ type Interface interface {
 
 // Get gets a scheduling strategy in accordance to configuration. It defaults
 // to Passthrough strategy if none has been configured.
-func Get(cfg *config.Config) Interface {
+func Get(cfg *config.Config, log *logrus.Entry) Interface {
 	if cfg.Scheduler.Failover != nil {
 		return NewFailover(*cfg.Scheduler.Failover)
 	}
 	if cfg.Scheduler.External != nil {
-		return NewExternal(*cfg.Scheduler.External)
+		return NewExternal(*cfg.Scheduler.External, log)
 	}
 	return &Passthrough{}
 }


### PR DESCRIPTION
Fallback to cluster configured in the config file when unsuccessfull with scheduling for external strategy