### PR TITLE
`blunderbuss`: allow `request_count` to be set to '0' effectively disabling functionality

### DIFF
--- a/pkg/plugins/blunderbuss/blunderbuss.go
+++ b/pkg/plugins/blunderbuss/blunderbuss.go
@@ -148,6 +148,9 @@ func handlePullRequest(ghc githubClient, roc repoownersClient, log *logrus.Entry
 	if !(action == github.PullRequestActionOpened || action == github.PullRequestActionReadyForReview) || assign.CCRegexp.MatchString(pr.Body) {
 		return nil
 	}
+	if config.ReviewerCount != nil && *config.ReviewerCount == 0 {
+		return nil
+	}
 	if pr.Draft && config.IgnoreDrafts {
 		// ignore Draft PR when IgnoreDrafts is true
 		return nil
@@ -188,6 +191,10 @@ func handleGenericCommentEvent(pc plugins.Agent, ce github.GenericCommentEvent) 
 
 func handleGenericComment(ghc githubClient, roc repoownersClient, log *logrus.Entry, config plugins.Blunderbuss, action github.GenericCommentEventAction, isPR bool, prNumber int, issueState string, repo *github.Repo, body string) error {
 	if action != github.GenericCommentActionCreated || !isPR || issueState == "closed" {
+		return nil
+	}
+
+	if config.ReviewerCount != nil && *config.ReviewerCount == 0 {
 		return nil
 	}
 

--- a/pkg/plugins/blunderbuss/blunderbuss_test.go
+++ b/pkg/plugins/blunderbuss/blunderbuss_test.go
@@ -637,6 +637,13 @@ func TestHandlePullRequest(t *testing.T) {
 			filesChanged:  []string{"a.go"},
 			ignoreAuthors: []string{"author"},
 		},
+		{
+			name:          "PR opened, but request_count set to 0",
+			action:        github.PullRequestActionOpened,
+			body:          "/auto-cc",
+			filesChanged:  []string{"a.go"},
+			reviewerCount: 0,
+		},
 	}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -733,6 +740,15 @@ func TestHandleGenericComment(t *testing.T) {
 			isPR:          false,
 			body:          "/auto-cc",
 			reviewerCount: 1,
+		},
+		{
+			name:          "comment with a valid command, but request_count set to 0 doesn't trigger auto-assignment",
+			action:        github.GenericCommentActionCreated,
+			issueState:    "open",
+			isPR:          true,
+			body:          "/auto-cc",
+			filesChanged:  []string{"a.go"},
+			reviewerCount: 0,
 		},
 	}
 	for _, tc := range testcases {

--- a/pkg/plugins/config.go
+++ b/pkg/plugins/config.go
@@ -1183,8 +1183,8 @@ func validateExternalPlugins(pluginMap map[string][]ExternalPlugin) error {
 }
 
 func validateBlunderbuss(b *Blunderbuss) error {
-	if b.ReviewerCount != nil && *b.ReviewerCount < 1 {
-		return fmt.Errorf("invalid request_count: %v (needs to be positive)", *b.ReviewerCount)
+	if b.ReviewerCount != nil && *b.ReviewerCount < 0 {
+		return fmt.Errorf("invalid request_count: %v (cannot be negative)", *b.ReviewerCount)
 	}
 	return nil
 }


### PR DESCRIPTION
There is a situation where a repository doesn't want `blunderbuss`, but it is configured at the org level. Since there is no way to exclude the plugin from functioning on the repo, we must have some way to disable the functionality assigning reviewers. We can do this by allowing `request_count` to be `0`

For: https://issues.redhat.com/browse/DPTP-4164