### PR TITLE
add workflow_call triggered workflows to failed workflow search

### DIFF
--- a/pkg/github/client.go
+++ b/pkg/github/client.go
@@ -2056,8 +2056,9 @@ func (c *client) GetFailedActionRunsByHeadBranch(org, repo, branchName, headSHA 
 	}
 	query := u.Query()
 	query.Add("status", "failure")
-	// setting the OR condition to get both PR and PR target workflows
-	query.Add("event", "pull_request OR pull_request_target")
+	// setting the OR condition to get both PR and PR target workflows, as well
+	// as workflows called via another workflow using workflow_call (matrix workflows)
+	query.Add("event", "pull_request OR pull_request_target OR workflow_call")
 	query.Add("branch", branchName)
 	u.RawQuery = query.Encode()
 


### PR DESCRIPTION
We want to rerun workflows that we're triggered by `workflow_call` with Prow's `/retest` keyword, when `trigger_github_workflows: true` is enabled in plugin config.

Fixes: #276 