### PR TITLE
Fix cache mode determination

### DIFF
--- a/pkg/ghcache/coalesce_test.go
+++ b/pkg/ghcache/coalesce_test.go
@@ -28,6 +28,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cjwagner/httpcache"
+
 	"sigs.k8s.io/prow/pkg/github/ghmetrics"
 
 	"k8s.io/apimachinery/pkg/util/diff"
@@ -173,6 +175,7 @@ func TestCacheModeHeader(t *testing.T) {
 	// This should return ModeRevalidated.
 	header := http.Header{}
 	header.Set("Status", "304 Not Modified")
+	header.Set(httpcache.XFromCache, "1")
 	fre.responseHeader = header
 	if resp, err := runRequest(coalescer, "/resource1", true); err != nil {
 		t.Errorf("Failed to run request: %v.", err)

--- a/pkg/ghcache/ghcache.go
+++ b/pkg/ghcache/ghcache.go
@@ -176,7 +176,7 @@ func cacheResponseMode(headers http.Header) CacheResponseMode {
 	if strings.Contains(headers.Get("Cache-Control"), "no-store") {
 		return ModeNoStore
 	}
-	if strings.Contains(headers.Get("Status"), "304 Not Modified") {
+	if strings.Contains(headers.Get(httpcache.XFromCache), "1") {
 		return ModeRevalidated
 	}
 	if headers.Get("X-Conditional-Request") != "" {

--- a/pkg/github/ghmetrics/ghpath.go
+++ b/pkg/github/ghmetrics/ghpath.go
@@ -86,6 +86,10 @@ func repositoryTree() []simplifypath.Node {
 		l("teams"),
 		l("tags"),
 		l("transfer"),
+		l("pages"),
+		l("private-vulnerability-reporting"),
+		l("properties", l("value")),
+		l("code-scanning", l("default-setup")),
 	}
 }
 

--- a/pkg/simplifypath/simplify.go
+++ b/pkg/simplifypath/simplify.go
@@ -45,7 +45,7 @@ func (s *simplifier) Simplify(path string) string {
 	splitPath := strings.Split(path, "/")
 	resolvedPath, matches := resolve(s.tree, splitPath)
 	if !matches {
-		logrus.WithField("path", path).Debug("Path not handled. This is a bug, please open an issue against the kubernetes/test-infra repository with this error message.")
+		logrus.WithField("path", path).Debug("Path not handled. This is a bug, please open an issue against the kubernetes-sigs/prow repository with this error message.")
 		return unmatchedPath
 	}
 	return resolvedPath


### PR DESCRIPTION
This PR fixes 2 things:

- cache mode determination in coalesce.go (https://github.com/kubernetes-sigs/prow/blob/main/pkg/ghcache/coalesce.go#L242)
- add additional paths for repository API calls that we use and triggered a warning in ghproxy and asks to raise an issue with the project

in coalescer RoundTrip method, the cache Mode is determined at the end by inspecting the final response object. However, at this point the response object is not the original 304 response from the GitHub server anymore, but the cache response which has usually a status code of 200. So the method `cacheResponseMode` never returns `ModeRevalidated` but `Changed` which is also reflected in the cache.

This does not seem to have another negative effect afaict apart from being confusing and triggered me to inspect whether ghproxy really correctly cached and revalidates requests. Instead of looking at the status code (which is not reliable anymore at this step of the processing), the fix looks at the `X-From-Cache` header that is set by the `httpcache` package in case a cached version is returned.

A test case had to be adapted to take that change into account correctly.

This is my first go PR so please bear with me. With these fixes ghproxy runs pretty nice for our use-case (https://github.com/eclipse-csi/otterdog)

Thanks a a lot for this very helpful piece of software.