### PR TITLE
`github client`: add function for updating a CheckRun, and return ID when creating one

### DIFF
--- a/pkg/plugins/override/override.go
+++ b/pkg/plugins/override/override.go
@@ -61,7 +61,7 @@ type githubClient interface {
 	ListTeams(org string) ([]github.Team, error)
 	ListTeamMembersBySlug(org, teamSlug, role string) ([]github.TeamMember, error)
 	ListCheckRuns(org, repo, ref string) (*github.CheckRunList, error)
-	CreateCheckRun(org, repo string, checkRun github.CheckRun) error
+	CreateCheckRun(org, repo string, checkRun github.CheckRun) (int64, error)
 	UsesAppAuth() bool
 }
 
@@ -121,7 +121,7 @@ func (c client) ListCheckRuns(org, teamSlug, role string) (*github.CheckRunList,
 	return c.ghc.ListCheckRuns(org, teamSlug, role)
 }
 
-func (c client) CreateCheckRun(org, repo string, checkRun github.CheckRun) error {
+func (c client) CreateCheckRun(org, repo string, checkRun github.CheckRun) (int64, error) {
 	return c.ghc.CreateCheckRun(org, repo, checkRun)
 }
 
@@ -543,7 +543,7 @@ If you are trying to override a checkrun that has a space in it, you must put a 
 						Summary: fmt.Sprintf("Prow has received override command for the %s checkrun.", checkrun.Context),
 					},
 				}
-				if err := oc.CreateCheckRun(org, repo, prowOverrideCR); err != nil {
+				if _, err := oc.CreateCheckRun(org, repo, prowOverrideCR); err != nil {
 					resp := fmt.Sprintf("cannot create prow-override CheckRun %v", prowOverrideCR)
 					log.WithError(err).Warn(resp)
 					return oc.CreateComment(org, repo, number, plugins.FormatResponseRaw(e.Body, e.HTMLURL, user, resp))

--- a/pkg/plugins/override/override_test.go
+++ b/pkg/plugins/override/override_test.go
@@ -217,7 +217,7 @@ func (c *fakeClient) ListCheckRuns(org, repo, ref string) (*github.CheckRunList,
 	return &github.CheckRunList{}, nil
 }
 
-func (c *fakeClient) CreateCheckRun(org, repo string, checkRun github.CheckRun) error {
+func (c *fakeClient) CreateCheckRun(org, repo string, checkRun github.CheckRun) (int64, error) {
 	for _, checkrun := range c.checkruns.CheckRuns {
 		if checkrun.CompletedAt == "" {
 			continue
@@ -240,7 +240,7 @@ func (c *fakeClient) CreateCheckRun(org, repo string, checkRun github.CheckRun) 
 			c.checkruns.CheckRuns = append(c.checkruns.CheckRuns, prowOverrideCR)
 		}
 	}
-	return nil
+	return checkRun.ID, nil
 }
 
 func (c *fakeClient) GetBranchProtection(org, repo, branch string) (*github.BranchProtection, error) {


### PR DESCRIPTION
`OpenShift` CI needs to be able to update `CheckRuns` utilizing the GH client. These changes help to facilitate that.