### PR TITLE
Update `gcr.io/k8s-prow/git` base image

### DIFF
--- a/.ko.yaml
+++ b/.ko.yaml
@@ -5,30 +5,30 @@
 # git-custom-k8s-auth should only be used for components that talk to Kubernetes Clusters.
 baseImageOverrides:
   sigs.k8s.io/prow/cmd/branchprotector: gcr.io/k8s-staging-test-infra/alpine:v20240719-47a381b1df
-  sigs.k8s.io/prow/cmd/checkconfig: gcr.io/k8s-prow/git:v20240129-a0a4e743bf
-  sigs.k8s.io/prow/cmd/clonerefs: gcr.io/k8s-prow/git:v20240129-a0a4e743bf
+  sigs.k8s.io/prow/cmd/checkconfig: gcr.io/k8s-prow/git:v20240729-4f255edb07
+  sigs.k8s.io/prow/cmd/clonerefs: gcr.io/k8s-prow/git:v20240729-4f255edb07
   sigs.k8s.io/prow/cmd/config-bootstrapper: gcr.io/k8s-staging-test-infra/git-custom-k8s-auth:v20240719-47a381b1df
   sigs.k8s.io/prow/cmd/deck: gcr.io/k8s-staging-test-infra/git-custom-k8s-auth:v20240719-47a381b1df
   sigs.k8s.io/prow/cmd/exporter: gcr.io/k8s-staging-test-infra/alpine:v20240719-47a381b1df
   sigs.k8s.io/prow/cmd/crier: gcr.io/k8s-staging-test-infra/git-custom-k8s-auth:v20240719-47a381b1df
-  sigs.k8s.io/prow/cmd/entrypoint: gcr.io/k8s-prow/git:v20240129-a0a4e743bf
-  sigs.k8s.io/prow/cmd/gangway: gcr.io/k8s-prow/git:v20240129-a0a4e743bf
-  sigs.k8s.io/prow/cmd/generic-autobumper: gcr.io/k8s-prow/git:v20240129-a0a4e743bf
-  sigs.k8s.io/prow/cmd/gerrit: gcr.io/k8s-prow/git:v20240129-a0a4e743bf
+  sigs.k8s.io/prow/cmd/entrypoint: gcr.io/k8s-prow/git:v20240729-4f255edb07
+  sigs.k8s.io/prow/cmd/gangway: gcr.io/k8s-prow/git:v20240729-4f255edb07
+  sigs.k8s.io/prow/cmd/generic-autobumper: gcr.io/k8s-prow/git:v20240729-4f255edb07
+  sigs.k8s.io/prow/cmd/gerrit: gcr.io/k8s-prow/git:v20240729-4f255edb07
   sigs.k8s.io/prow/cmd/gcsupload: gcr.io/k8s-staging-test-infra/alpine:v20240719-47a381b1df
   sigs.k8s.io/prow/cmd/hook: gcr.io/k8s-staging-test-infra/git-custom-k8s-auth:v20240719-47a381b1df
   sigs.k8s.io/prow/cmd/hmac: gcr.io/k8s-staging-test-infra/alpine:v20240719-47a381b1df
   sigs.k8s.io/prow/cmd/horologium: gcr.io/k8s-staging-test-infra/alpine:v20240719-47a381b1df
-  sigs.k8s.io/prow/cmd/initupload: gcr.io/k8s-prow/git:v20240129-a0a4e743bf
+  sigs.k8s.io/prow/cmd/initupload: gcr.io/k8s-prow/git:v20240729-4f255edb07
   sigs.k8s.io/prow/cmd/invitations-accepter: gcr.io/k8s-staging-test-infra/alpine:v20240719-47a381b1df
-  sigs.k8s.io/prow/cmd/jenkins-operator: gcr.io/k8s-prow/git:v20240129-a0a4e743bf
-  sigs.k8s.io/prow/cmd/moonraker: gcr.io/k8s-prow/git:v20240129-a0a4e743bf
+  sigs.k8s.io/prow/cmd/jenkins-operator: gcr.io/k8s-prow/git:v20240729-4f255edb07
+  sigs.k8s.io/prow/cmd/moonraker: gcr.io/k8s-prow/git:v20240729-4f255edb07
   sigs.k8s.io/prow/cmd/peribolos: gcr.io/k8s-staging-test-infra/alpine:v20240719-47a381b1df
-  sigs.k8s.io/prow/cmd/sidecar: gcr.io/k8s-prow/git:v20240129-a0a4e743bf
+  sigs.k8s.io/prow/cmd/sidecar: gcr.io/k8s-prow/git:v20240729-4f255edb07
   sigs.k8s.io/prow/cmd/sinker: gcr.io/k8s-staging-test-infra/git-custom-k8s-auth:v20240719-47a381b1df
   sigs.k8s.io/prow/cmd/status-reconciler: gcr.io/k8s-staging-test-infra/alpine:v20240719-47a381b1df
-  sigs.k8s.io/prow/cmd/sub: gcr.io/k8s-prow/git:v20240129-a0a4e743bf
-  sigs.k8s.io/prow/cmd/tide: gcr.io/k8s-prow/git:v20240129-a0a4e743bf
+  sigs.k8s.io/prow/cmd/sub: gcr.io/k8s-prow/git:v20240729-4f255edb07
+  sigs.k8s.io/prow/cmd/tide: gcr.io/k8s-prow/git:v20240729-4f255edb07
   sigs.k8s.io/prow/cmd/tot: gcr.io/k8s-staging-test-infra/alpine:v20240719-47a381b1df
   sigs.k8s.io/prow/cmd/prow-controller-manager: gcr.io/k8s-staging-test-infra/git-custom-k8s-auth:v20240719-47a381b1df
   sigs.k8s.io/prow/cmd/admission: gcr.io/k8s-staging-test-infra/alpine:v20240719-47a381b1df
@@ -38,13 +38,13 @@ baseImageOverrides:
   sigs.k8s.io/prow/cmd/pipeline: gcr.io/k8s-staging-test-infra/alpine:v20240719-47a381b1df
   # external
   sigs.k8s.io/prow/cmd/external-plugins/needs-rebase: gcr.io/k8s-staging-test-infra/alpine:v20240719-47a381b1df
-  sigs.k8s.io/prow/cmd/external-plugins/cherrypicker: gcr.io/k8s-prow/git:v20240129-a0a4e743bf
+  sigs.k8s.io/prow/cmd/external-plugins/cherrypicker: gcr.io/k8s-prow/git:v20240729-4f255edb07
   sigs.k8s.io/prow/cmd/external-plugins/refresh: gcr.io/k8s-staging-test-infra/alpine:v20240719-47a381b1df
   sigs.k8s.io/prow/cmd/ghproxy: gcr.io/k8s-staging-test-infra/alpine:v20240719-47a381b1df
 
   # prow integration test
   sigs.k8s.io/prow/test/integration/cmd/fakeghserver: gcr.io/k8s-staging-test-infra/alpine:v20240719-47a381b1df
-  sigs.k8s.io/prow/test/integration/cmd/fakegitserver: gcr.io/k8s-prow/git:v20240129-a0a4e743bf
+  sigs.k8s.io/prow/test/integration/cmd/fakegitserver: gcr.io/k8s-prow/git:v20240729-4f255edb07
   sigs.k8s.io/prow/test/integration/cmd/fakepubsub: google/cloud-sdk:389.0.0
   sigs.k8s.io/prow/test/integration/cmd/fakegcsserver: gcr.io/k8s-staging-test-infra/alpine:v20240719-47a381b1df
 


### PR DESCRIPTION
This PR updates `gcr.io/k8s-prow/git:v20240129-a0a4e743bf` base images to `gcr.io/k8s-prow/git:v20240729-4f255edb07` which is the latest version.
The current version include [CVE-2024-6387](https://security.alpinelinux.org/vuln/CVE-2024-6387). While sshd is not started in the context, it still triggers security incidents in our scanners.
