### PR TITLE
(spyglass/lenses/html) add allow-forms to sandbox

### DIFF
--- a/pkg/spyglass/lenses/html/template.html
+++ b/pkg/spyglass/lenses/html/template.html
@@ -13,7 +13,7 @@
     {{/* Do _not_ hide this by default, that will break inner javascript that dynamically resizes. Hiding post-render is ok, so we hide on first resize request */}}
     <tr class="initial" id="{{.ID}}-tr">
       <td colspan="2" style="border: 0px; padding: 0px;">
-        <iframe srcdoc="{{.Content}}" title="{{.Filename}}" sandbox="allow-scripts allow-popups allow-same-origin" id="{{.ID}}" width="100%" scrolling="no"></iframe>
+        <iframe srcdoc="{{.Content}}" title="{{.Filename}}" sandbox="allow-scripts allow-popups allow-same-origin allow-forms" id="{{.ID}}" width="100%" scrolling="no"></iframe>
       </td>
     </tr>
     {{end}}

--- a/pkg/spyglass/lenses/html/testdata/TestRenderBody_Simple-0.yaml
+++ b/pkg/spyglass/lenses/html/testdata/TestRenderBody_Simple-0.yaml
@@ -21,7 +21,7 @@ window.addEventListener(&quot;load&quot;, function(){
     var config = { attributes: true, childList: true, characterData: true, subtree:true}; // PT2
     observer.observe(window.document, config);                                            // PT3
 });
-</script>" title="file.html" sandbox="allow-scripts allow-popups allow-same-origin" id="file.html-0" width="100%" scrolling="no"></iframe>
+</script>" title="file.html" sandbox="allow-scripts allow-popups allow-same-origin allow-forms" id="file.html-0" width="100%" scrolling="no"></iframe>
       </td>
     </tr>
     

--- a/pkg/spyglass/lenses/html/testdata/TestRenderBody_With_description-0.yaml
+++ b/pkg/spyglass/lenses/html/testdata/TestRenderBody_With_description-0.yaml
@@ -21,7 +21,7 @@ window.addEventListener(&quot;load&quot;, function(){
     var config = { attributes: true, childList: true, characterData: true, subtree:true}; // PT2
     observer.observe(window.document, config);                                            // PT3
 });
-</script>" title="file.html" sandbox="allow-scripts allow-popups allow-same-origin" id="file.html-0" width="100%" scrolling="no"></iframe>
+</script>" title="file.html" sandbox="allow-scripts allow-popups allow-same-origin allow-forms" id="file.html-0" width="100%" scrolling="no"></iframe>
       </td>
     </tr>
     

--- a/pkg/spyglass/lenses/html/testdata/TestRenderBody_With_description_and_title-0.yaml
+++ b/pkg/spyglass/lenses/html/testdata/TestRenderBody_With_description_and_title-0.yaml
@@ -21,7 +21,7 @@ window.addEventListener(&quot;load&quot;, function(){
     var config = { attributes: true, childList: true, characterData: true, subtree:true}; // PT2
     observer.observe(window.document, config);                                            // PT3
 });
-</script>" title="file.html" sandbox="allow-scripts allow-popups allow-same-origin" id="file.html-0" width="100%" scrolling="no"></iframe>
+</script>" title="file.html" sandbox="allow-scripts allow-popups allow-same-origin allow-forms" id="file.html-0" width="100%" scrolling="no"></iframe>
       </td>
     </tr>
     

--- a/pkg/spyglass/lenses/html/testdata/TestRenderBody_With_multiple_of_same_name-0.yaml
+++ b/pkg/spyglass/lenses/html/testdata/TestRenderBody_With_multiple_of_same_name-0.yaml
@@ -21,7 +21,7 @@ window.addEventListener(&quot;load&quot;, function(){
     var config = { attributes: true, childList: true, characterData: true, subtree:true}; // PT2
     observer.observe(window.document, config);                                            // PT3
 });
-</script>" title="file.html" sandbox="allow-scripts allow-popups allow-same-origin" id="file.html-0" width="100%" scrolling="no"></iframe>
+</script>" title="file.html" sandbox="allow-scripts allow-popups allow-same-origin allow-forms" id="file.html-0" width="100%" scrolling="no"></iframe>
       </td>
     </tr>
     

--- a/pkg/spyglass/lenses/html/testdata/TestRenderBody_With_multiple_of_same_name-1.yaml
+++ b/pkg/spyglass/lenses/html/testdata/TestRenderBody_With_multiple_of_same_name-1.yaml
@@ -21,7 +21,7 @@ window.addEventListener(&quot;load&quot;, function(){
     var config = { attributes: true, childList: true, characterData: true, subtree:true}; // PT2
     observer.observe(window.document, config);                                            // PT3
 });
-</script>" title="file.html" sandbox="allow-scripts allow-popups allow-same-origin" id="file.html-0" width="100%" scrolling="no"></iframe>
+</script>" title="file.html" sandbox="allow-scripts allow-popups allow-same-origin allow-forms" id="file.html-0" width="100%" scrolling="no"></iframe>
       </td>
     </tr>
     

--- a/pkg/spyglass/lenses/html/testdata/TestRenderBody_With_quotes-0.yaml
+++ b/pkg/spyglass/lenses/html/testdata/TestRenderBody_With_quotes-0.yaml
@@ -21,7 +21,7 @@ window.addEventListener(&quot;load&quot;, function(){
     var config = { attributes: true, childList: true, characterData: true, subtree:true}; // PT2
     observer.observe(window.document, config);                                            // PT3
 });
-</script>" title="file.html" sandbox="allow-scripts allow-popups allow-same-origin" id="file.html-0" width="100%" scrolling="no"></iframe>
+</script>" title="file.html" sandbox="allow-scripts allow-popups allow-same-origin allow-forms" id="file.html-0" width="100%" scrolling="no"></iframe>
       </td>
     </tr>
     

--- a/pkg/spyglass/lenses/html/testdata/TestRenderBody_With_title-0.yaml
+++ b/pkg/spyglass/lenses/html/testdata/TestRenderBody_With_title-0.yaml
@@ -21,7 +21,7 @@ window.addEventListener(&quot;load&quot;, function(){
     var config = { attributes: true, childList: true, characterData: true, subtree:true}; // PT2
     observer.observe(window.document, config);                                            // PT3
 });
-</script>" title="file.html" sandbox="allow-scripts allow-popups allow-same-origin" id="file.html-0" width="100%" scrolling="no"></iframe>
+</script>" title="file.html" sandbox="allow-scripts allow-popups allow-same-origin allow-forms" id="file.html-0" width="100%" scrolling="no"></iframe>
       </td>
     </tr>
     

--- a/site/content/en/docs/spyglass/architecture.md
+++ b/site/content/en/docs/spyglass/architecture.md
@@ -29,7 +29,7 @@ future they can live elsewhere. Spyglass lenses have the following responsibilit
 - Rendering HTML for human consumption
 
 Lens frontends are run in sandboxed iframes (currently `sandbox="allow-scripts allow-top-navigation
-allow-popups allow-same-origin"`), which ensures that they can only interact with the world via the
+allow-popups allow-same-origin allow-forms"`), which ensures that they can only interact with the world via the
 intended API. In particular, this prevents lenses from interacting with other Deck pseudo-APIs or with
 the core spyglass page.
 


### PR DESCRIPTION
This adds allow-forms to the iframe sandbox.

> Blocked form submission to '' because the form's frame is sandboxed
and the 'allow-forms' permission is not set.

This allow's us to click the `<a href=link-to-buildbuddy-invocation target=_blank>` which links to streaming build results on buildbuddy, as we use bazel with remote builders on buildbuddy.io and the buil-logs uploaded to S3 only contains this hyperlink.

With this change we allow chrome to handle the login process at buildbuddy.io which requires a form-post to handle login over SSO.

https://web.dev/articles/sandboxed-iframes

Original lens PR: https://github.com/kubernetes/test-infra/pull/10208

Later changes that are similar to this one:

allow same-origin: https://github.com/kubernetes-sigs/prow/commit/b9a016753cd4bb426a5e809659941fffa1d2ad60
allow popups: https://github.com/kubernetes/test-infra/pull/23069