### PR TITLE
(spyglass/lenses) allow configuration sandbox permissions

### DIFF
--- a/cmd/checkconfig/testdata/combined.yaml
+++ b/cmd/checkconfig/testdata/combined.yaml
@@ -23,6 +23,10 @@ deck:
           - (FAIL|Failure \[)\b
           - panic\b
           - ^E\d{4} \d\d:\d\d:\d\d\.\d\d\d]
+          iframe_sandbox_permissions:
+          - allow-scripts
+          - allow-popups
+          - allow-popups-to-escape-sandbox
       required_files:
       - build-log.txt
     - lens:

--- a/cmd/deck/template/spyglass.html
+++ b/cmd/deck/template/spyglass.html
@@ -43,7 +43,7 @@
     <div class="mdl-card__title lens-title"><h3 class="mdl-card__title-text">{{$config.Title}}</h3></div>
     <div id="{{$config.Name}}-view-container" class="lens-view-content mdl-card__supporting-text">
       <img src="/static/kubernetes-wheel.svg?v={{deckVersion}}" alt="loading spinner" class="loading-spinner is-active lens-card-loading" id="{{$config.Name}}-loading">
-      <iframe class="lens-container" style="visibility: hidden;" id="iframe-{{$index}}" sandbox="allow-scripts allow-top-navigation allow-popups allow-same-origin" data-lens-index="{{$index}}" data-lens-name="{{$config.Name}}"{{if $config.HideTitle}} data-hide-title="true"{{end}}></iframe>
+      <iframe class="lens-container" style="visibility: hidden;" id="iframe-{{$index}}" sandbox="{{$config.IframeSandboxPermissions}}" data-lens-index="{{$index}}" data-lens-name="{{$config.Name}}"{{if $config.HideTitle}} data-hide-title="true"{{end}}></iframe>
     </div>
   </div>
   {{end}}

--- a/pkg/spyglass/lenses/buildlog/lens.go
+++ b/pkg/spyglass/lenses/buildlog/lens.go
@@ -50,10 +50,11 @@ const (
 var defaultHighlightLineLengthMax = 10000 // Default maximum length of a line worth highlighting
 
 type config struct {
-	HighlightRegexes   []string         `json:"highlight_regexes"`
-	HideRawLog         bool             `json:"hide_raw_log,omitempty"`
-	Highlighter        *highlightConfig `json:"highlighter,omitempty"`
-	HighlightLengthMax *int             `json:"highlight_line_length_max,omitempty"`
+	HighlightRegexes         []string         `json:"highlight_regexes"`
+	HideRawLog               bool             `json:"hide_raw_log,omitempty"`
+	Highlighter              *highlightConfig `json:"highlighter,omitempty"`
+	HighlightLengthMax       *int             `json:"highlight_line_length_max,omitempty"`
+	IframeSandboxPermissions []string         `json:"iframe_sandbox_permissions,omitempty"`
 }
 
 type highlightConfig struct {
@@ -68,10 +69,11 @@ type highlightConfig struct {
 }
 
 type parsedConfig struct {
-	highlightRegex     *regexp.Regexp
-	showRawLog         bool
-	highlighter        *highlightConfig
-	highlightLengthMax int
+	highlightRegex           *regexp.Regexp
+	showRawLog               bool
+	highlighter              *highlightConfig
+	highlightLengthMax       int
+	IframeSandboxPermissions string
 }
 
 var _ api.Lens = Lens{}
@@ -96,6 +98,17 @@ func (lens Lens) Header(artifacts []api.Artifact, resourceDir string, config jso
 // defaultErrRE matches keywords and glog error messages.
 // It is only used if highlight_regexes is not specified in the lens config.
 var defaultErrRE = regexp.MustCompile(`timed out|ERROR:|(FAIL|Failure \[)\b|panic\b|^E\d{4} \d\d:\d\d:\d\d\.\d\d\d]`)
+
+// defaultSandboxPermissions is the default value for iframe_sandbox_permissions lense config if it is not specified.
+var defaultSandboxPermissions = strings.Join(
+	[]string{
+		"allow-scripts",
+		"allow-top-navigation",
+		"allow-popups",
+		"allow-same-origin",
+	},
+	" ",
+)
 
 func init() {
 	lenses.RegisterLens(Lens{})
@@ -170,8 +183,9 @@ type buildLogsView struct {
 
 func getConfig(rawConfig json.RawMessage) parsedConfig {
 	conf := parsedConfig{
-		highlightRegex: defaultErrRE,
-		showRawLog:     true,
+		highlightRegex:           defaultErrRE,
+		showRawLog:               true,
+		IframeSandboxPermissions: defaultSandboxPermissions,
 	}
 
 	// No config at all is fine.
@@ -189,6 +203,13 @@ func getConfig(rawConfig json.RawMessage) parsedConfig {
 		conf.highlighter = nil
 	}
 	conf.showRawLog = !c.HideRawLog
+
+	if c.IframeSandboxPermissions == nil {
+		conf.IframeSandboxPermissions = defaultSandboxPermissions
+	} else {
+		conf.IframeSandboxPermissions = strings.Join(c.IframeSandboxPermissions, " ")
+	}
+
 	if len(c.HighlightRegexes) == 0 {
 		return conf
 	}

--- a/pkg/spyglass/lenses/buildlog/lens_test.go
+++ b/pkg/spyglass/lenses/buildlog/lens_test.go
@@ -34,7 +34,8 @@ import (
 
 func TestGetConfig(t *testing.T) {
 	def := parsedConfig{
-		showRawLog: true,
+		showRawLog:               true,
+		IframeSandboxPermissions: defaultSandboxPermissions,
 	}
 	cases := []struct {
 		name string
@@ -59,6 +60,14 @@ func TestGetConfig(t *testing.T) {
 					Endpoint: "service",
 					Pin:      true,
 				}
+				return d
+			}(),
+		}, {
+			name: "configure iframe sandbox permissions",
+			raw:  `{"iframe_sandbox_permissions": ["allow-scripts", "allow-downloads"]}`,
+			want: func() parsedConfig {
+				d := def
+				d.IframeSandboxPermissions = "allow-scripts allow-downloads"
 				return d
 			}(),
 		},

--- a/pkg/spyglass/lenses/buildlog/lens_test.go
+++ b/pkg/spyglass/lenses/buildlog/lens_test.go
@@ -70,6 +70,14 @@ func TestGetConfig(t *testing.T) {
 				d.IframeSandboxPermissions = "allow-scripts allow-downloads"
 				return d
 			}(),
+		}, {
+			name: "empty iframe sandbox permissions does not return default permissions",
+			raw:  `{"iframe_sandbox_permissions": []}`,
+			want: func() parsedConfig {
+				d := def
+				d.IframeSandboxPermissions = ""
+				return d
+			}(),
 		},
 	}
 


### PR DESCRIPTION
This provides the ability to configure iframe sandbox permissions pr lense. This allows the operator of the prow installation to define which permissions it trust to each lense.

PR comes from the ideas and discussions in
https://github.com/kubernetes-sigs/prow/pull/294