### PR TITLE
`tide`: allow for optional contexts to be defined via regex

### DIFF
--- a/pkg/config/prow-config-documented.yaml
+++ b/pkg/config/prow-config-documented.yaml
@@ -1448,12 +1448,18 @@ tide:
         from-branch-protection: false
         optional-contexts:
             - ""
+        # Contexts that match any of the regex values in OptionalRegexContexts will be optional
+        optional-regex-contexts:
+            - ""
         # GitHub Orgs
         orgs:
             "":
                 # Infer required and optional jobs from Branch Protection configuration
                 from-branch-protection: false
                 optional-contexts:
+                    - ""
+                # Contexts that match any of the regex values in OptionalRegexContexts will be optional
+                optional-regex-contexts:
                     - ""
                 # Overwrite `pending` contexts with `success` when a PR is merged in a batch.
                 # This prevents PRs from being blocked by branch-protection rules if batches contexts are successful but PR context is still pending.
@@ -1465,6 +1471,9 @@ tide:
                                 # Infer required and optional jobs from Branch Protection configuration
                                 from-branch-protection: false
                                 optional-contexts:
+                                    - ""
+                                # Contexts that match any of the regex values in OptionalRegexContexts will be optional
+                                optional-regex-contexts:
                                     - ""
                                 # Overwrite `pending` contexts with `success` when a PR is merged in a batch.
                                 # This prevents PRs from being blocked by branch-protection rules if batches contexts are successful but PR context is still pending.
@@ -1478,6 +1487,9 @@ tide:
                         # Infer required and optional jobs from Branch Protection configuration
                         from-branch-protection: false
                         optional-contexts:
+                            - ""
+                        # Contexts that match any of the regex values in OptionalRegexContexts will be optional
+                        optional-regex-contexts:
                             - ""
                         # Overwrite `pending` contexts with `success` when a PR is merged in a batch.
                         # This prevents PRs from being blocked by branch-protection rules if batches contexts are successful but PR context is still pending.

--- a/pkg/config/tide.go
+++ b/pkg/config/tide.go
@@ -840,7 +840,7 @@ func (cp *TideContextPolicy) Validate() error {
 	for _, contextRegex := range cp.OptionalRegexContexts {
 		re, err := regexp.Compile(contextRegex)
 		if err != nil {
-			return fmt.Errorf("optional context regex %q doesn't comipile: %w", contextRegex, err)
+			return fmt.Errorf("optional context regex %q doesn't compile: %w", contextRegex, err)
 		}
 		for _, context := range cp.RequiredContexts {
 			if re.MatchString(context) {

--- a/pkg/config/tide.go
+++ b/pkg/config/tide.go
@@ -162,6 +162,8 @@ type TideContextPolicy struct {
 	RequiredContexts          []string `json:"required-contexts,omitempty"`
 	RequiredIfPresentContexts []string `json:"required-if-present-contexts,omitempty"`
 	OptionalContexts          []string `json:"optional-contexts,omitempty"`
+	// Contexts that match any of the regex values in OptionalRegexContexts will be optional
+	OptionalRegexContexts []string `json:"optional-regex-contexts,omitempty"`
 	// Infer required and optional jobs from Branch Protection configuration
 	FromBranchProtection *bool `json:"from-branch-protection,omitempty"`
 	// Overwrite `pending` contexts with `success` when a PR is merged in a batch.
@@ -823,7 +825,8 @@ func (tq *TideQuery) Validate() error {
 	return nil
 }
 
-// Validate returns an error if any contexts are listed more than once in the config.
+// Validate returns an error if any contexts are listed more than once in the config
+// or if the optional regex contexts don't compile properly
 func (cp *TideContextPolicy) Validate() error {
 	if inter := sets.New[string](cp.RequiredContexts...).Intersection(sets.New[string](cp.OptionalContexts...)); inter.Len() > 0 {
 		return fmt.Errorf("contexts %s are defined as required and optional", strings.Join(sets.List(inter), ", "))
@@ -833,6 +836,22 @@ func (cp *TideContextPolicy) Validate() error {
 	}
 	if inter := sets.New[string](cp.OptionalContexts...).Intersection(sets.New[string](cp.RequiredIfPresentContexts...)); inter.Len() > 0 {
 		return fmt.Errorf("contexts %s are defined as optional and required if present", strings.Join(sets.List(inter), ", "))
+	}
+	for _, contextRegex := range cp.OptionalRegexContexts {
+		re, err := regexp.Compile(contextRegex)
+		if err != nil {
+			return fmt.Errorf("optional context regex %q doesn't comipile: %w", contextRegex, err)
+		}
+		for _, context := range cp.RequiredContexts {
+			if re.MatchString(context) {
+				return fmt.Errorf("optional context regex %q matches required context %s", contextRegex, context)
+			}
+		}
+		for _, context := range cp.RequiredIfPresentContexts {
+			if re.MatchString(context) {
+				return fmt.Errorf("optional context regex %q matches required if present context %s", contextRegex, context)
+			}
+		}
 	}
 	return nil
 }
@@ -939,6 +958,12 @@ func (c Config) GetTideContextPolicy(gitClient git.ClientFactory, org, repo, bra
 func (cp *TideContextPolicy) IsOptional(c string) bool {
 	if sets.New[string](cp.OptionalContexts...).Has(c) {
 		return true
+	}
+	for _, regexContext := range cp.OptionalRegexContexts {
+		re := regexp.MustCompile(regexContext)
+		if re.MatchString(c) {
+			return true
+		}
 	}
 	if sets.New[string](cp.RequiredContexts...).Has(c) {
 		return false


### PR DESCRIPTION
OpenShift is developing a new external prow plugin that will create GitHub `check_runs`. These will have a consistent naming scheme, and we would like `tide` to ignore them. This new field will allow for this.