### PR TITLE
Fix cherrypicking to multiple branches in a single comment after a PR was merged

### DIFF
--- a/cmd/external-plugins/cherrypicker/server.go
+++ b/cmd/external-plugins/cherrypicker/server.go
@@ -132,12 +132,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprint(w, "Event received. Have a nice day.")
 
 	if err := s.handleEvent(eventType, eventGUID, payload); err != nil {
-		logrus.WithError(err).Error("Error parsing event.")
+		s.log.WithError(err).Error("Error parsing event.")
 	}
 }
 
 func (s *Server) handleEvent(eventType, eventGUID string, payload []byte) error {
-	l := logrus.WithFields(logrus.Fields{
+	l := s.log.WithFields(logrus.Fields{
 		"event-type":     eventType,
 		github.EventGUID: eventGUID,
 	})
@@ -149,7 +149,7 @@ func (s *Server) handleEvent(eventType, eventGUID string, payload []byte) error 
 		}
 		go func() {
 			if err := s.handleIssueComment(l, ic); err != nil {
-				s.log.WithError(err).WithFields(l.Data).Info("Cherry-pick failed.")
+				l.WithError(err).Info("Cherry-pick failed.")
 			}
 		}()
 	case "pull_request":
@@ -159,11 +159,11 @@ func (s *Server) handleEvent(eventType, eventGUID string, payload []byte) error 
 		}
 		go func() {
 			if err := s.handlePullRequest(l, pr); err != nil {
-				s.log.WithError(err).WithFields(l.Data).Info("Cherry-pick failed.")
+				l.WithError(err).Info("Cherry-pick failed.")
 			}
 		}()
 	default:
-		logrus.Debugf("skipping event of type %q", eventType)
+		l.Debugf("skipping event of type %q", eventType)
 	}
 	return nil
 }

--- a/cmd/external-plugins/cherrypicker/server_test.go
+++ b/cmd/external-plugins/cherrypicker/server_test.go
@@ -349,7 +349,7 @@ func testCherryPickIC(clients localgit.Clients, t *testing.T) {
 		prowAssignments: true,
 	}
 
-	if err := s.handleIssueComment(logrus.NewEntry(logrus.StandardLogger()), ic); err != nil {
+	if _, err := s.handleIssueComment(logrus.NewEntry(logrus.StandardLogger()), ic); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	got := prToString(ghc.prs[0])
@@ -491,7 +491,7 @@ func testCherryPickPR(clients localgit.Clients, t *testing.T) {
 		prowAssignments: false,
 	}
 
-	if err := s.handlePullRequest(logrus.NewEntry(logrus.StandardLogger()), pr); err != nil {
+	if _, err := s.handlePullRequest(logrus.NewEntry(logrus.StandardLogger()), pr); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -626,7 +626,7 @@ func testCherryPickPRAfterMerge(clients localgit.Clients, t *testing.T) {
 		prowAssignments: false,
 	}
 
-	if err := s.handleIssueComment(logger, ic); err != nil {
+	if _, err := s.handleIssueComment(logger, ic); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -719,7 +719,7 @@ func testCherryPickOfCherryPickPR(clients localgit.Clients, t *testing.T) {
 	}
 
 	// Cherry pick master -> release-1.8
-	if err := s.handlePullRequest(logrus.NewEntry(logrus.StandardLogger()), pr); err != nil {
+	if _, err := s.handlePullRequest(logrus.NewEntry(logrus.StandardLogger()), pr); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -727,7 +727,7 @@ func testCherryPickOfCherryPickPR(clients localgit.Clients, t *testing.T) {
 	pr.PullRequest.Base.Ref = "release-1.8"
 	pr.PullRequest.Title = "[release-1.8] This is a fix for Y"
 	ghc.prComments[0].Body = "/cherrypick release-1.6"
-	if err := s.handlePullRequest(logrus.NewEntry(logrus.StandardLogger()), pr); err != nil {
+	if _, err := s.handlePullRequest(logrus.NewEntry(logrus.StandardLogger()), pr); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -735,7 +735,7 @@ func testCherryPickOfCherryPickPR(clients localgit.Clients, t *testing.T) {
 	pr.PullRequest.Base.Ref = "release-1.6"
 	pr.PullRequest.Title = "[release-1.6] This is a fix for Y"
 	ghc.prComments[0].Body = "/cherrypick release-1.5"
-	if err := s.handlePullRequest(logrus.NewEntry(logrus.StandardLogger()), pr); err != nil {
+	if _, err := s.handlePullRequest(logrus.NewEntry(logrus.StandardLogger()), pr); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -907,7 +907,7 @@ func testCherryPickPRWithLabels(clients localgit.Clients, t *testing.T) {
 						labelPrefix:     tc.labelPrefix,
 					}
 
-					if err := s.handlePullRequest(logrus.NewEntry(logrus.StandardLogger()), pr(evt)); err != nil {
+					if _, err := s.handlePullRequest(logrus.NewEntry(logrus.StandardLogger()), pr(evt)); err != nil {
 						t.Fatalf("unexpected error: %v", err)
 					}
 
@@ -1113,7 +1113,7 @@ func testCherryPickPRAssignments(clients localgit.Clients, t *testing.T) {
 			prowAssignments: prowAssignments,
 		}
 
-		if err := s.handleIssueComment(logrus.NewEntry(logrus.StandardLogger()), ic); err != nil {
+		if _, err := s.handleIssueComment(logrus.NewEntry(logrus.StandardLogger()), ic); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 


### PR DESCRIPTION
Previously, the cherrypicker's handleIssueComment() function would only ever process the first branch.

For unmerged PRs this leads to surprising replies that only acknoledge the first branch. However once a PR is merged, the plugin would correctly detect all cherrypick commands and create all desired PRs.

For _merged_ PRs however there is no PR-merged handling and so all but the first cherrypicks get dropped.

This PR adjusts the issue comment handling to also loop over all desired branches and create all PRs. I added a new unit test to verify that functionality.