### PR TITLE
add /test-by-label to run all jobs matching a label selector

### DIFF
--- a/pkg/plugins/trigger/generic-comment.go
+++ b/pkg/plugins/trigger/generic-comment.go
@@ -61,6 +61,7 @@ func handleGenericComment(c Client, trigger plugins.Trigger, gc github.GenericCo
 		!pjutil.RetestRequiredRe.MatchString(gc.Body) &&
 		!pjutil.OkToTestRe.MatchString(gc.Body) &&
 		!pjutil.TestAllRe.MatchString(gc.Body) &&
+		!pjutil.TestByLabelsRe.MatchString(gc.Body) &&
 		!pjutil.MayNeedHelpComment(gc.Body) {
 		matched := false
 		for _, presubmit := range presubmits {
@@ -191,6 +192,8 @@ type GitHubClient interface {
 //   - if we got a /test all or an /ok-to-test, we want to consider any job
 //     that doesn't explicitly require a human trigger comment; jobs will
 //     default to not run unless we can determine that they should
+//   - if we got a /test-by-label selector, it work the same as "/test all", but
+//     restricted to those jobs matching the given label selector
 //
 // If a comment that we get matches more than one of the above patterns, we
 // consider the set of matching presubmits the union of the results from the

--- a/pkg/plugins/trigger/trigger.go
+++ b/pkg/plugins/trigger/trigger.go
@@ -129,6 +129,13 @@ func helpProvider(config *plugins.Configuration, enabledRepos []config.OrgRepo) 
 		Examples:    []string{"/test all", "/test pull-bazel-test"},
 	})
 	pluginHelp.AddCommand(pluginhelp.Command{
+		Usage:       "/test-by-label label=selector",
+		Description: "Manually starts all jobs matching the given label selector.",
+		Featured:    true,
+		WhoCanUse:   "Anyone can trigger this command on a trusted PR.",
+		Examples:    []string{"/test-by-label provider=kubevirt", "/test-by-label release=31"},
+	})
+	pluginHelp.AddCommand(pluginhelp.Command{
 		Usage:       "/retest",
 		Description: "Rerun test jobs that have failed.",
 		Featured:    true,


### PR DESCRIPTION
This PR adds a new command, `/test-by-label`, which works the same as `/test all`, but restricts the result to the Prowjobs matching the given label selector. So you can do `/test-by-label provider=kubevirt`, for example.