### PR TITLE
[scheduler] include the pj labels on the external strategy

### DIFF
--- a/pkg/scheduler/strategy/external.go
+++ b/pkg/scheduler/strategy/external.go
@@ -31,7 +31,8 @@ import (
 
 // SchedulingRequest represents the incoming request structure
 type SchedulingRequest struct {
-	Job string `json:"job"`
+	Job    string            `json:"job"`
+	Labels map[string]string `json:"labels"`
 }
 
 // SchedulingResponse represents the response structure
@@ -100,7 +101,12 @@ func (e *External) Schedule(_ context.Context, pj *prowv1.ProwJob) (Result, erro
 		return Result(entry.r), nil
 	}
 
-	resp, err := query(e.cfg.URL, SchedulingRequest{Job: pj.Spec.Job})
+	req := SchedulingRequest{Job: pj.Spec.Job}
+	if pj.Labels != nil {
+		req.Labels = pj.Labels
+	}
+
+	resp, err := query(e.cfg.URL, req)
 	if err != nil {
 		e.log.WithField("job", pj.Spec.Job).WithField("cluster", pj.Spec.Cluster).Warn("scheduling failed, using Spec.Cluster entry")
 		return Result{Cluster: pj.Spec.Cluster}, nil

--- a/pkg/scheduler/strategy/external_test.go
+++ b/pkg/scheduler/strategy/external_test.go
@@ -53,6 +53,26 @@ func TestExternalSchedule(t *testing.T) {
 		{
 			name: "cache hit, valid entry",
 			pj: &prowv1.ProwJob{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"test-label": "test-value"},
+				},
+				Spec: prowv1.ProwJobSpec{Job: "test-job"},
+			},
+			cache: map[string]*cacheEntry{
+				"test-job": {
+					r:         SchedulingResponse{Cluster: "cluster-1"},
+					timestamp: time.Now(),
+				},
+			},
+			response:    SchedulingResponse{Cluster: "cluster-1"},
+			statusCode:  http.StatusOK,
+			want:        Result{Cluster: "cluster-1"},
+			wantErr:     false,
+			mockCleanup: false,
+		},
+		{
+			name: "cache hit, valid entry, no labels",
+			pj: &prowv1.ProwJob{
 				Spec: prowv1.ProwJobSpec{Job: "test-job"},
 			},
 			cache: map[string]*cacheEntry{
@@ -70,6 +90,9 @@ func TestExternalSchedule(t *testing.T) {
 		{
 			name: "cache miss, fetch from REST API",
 			pj: &prowv1.ProwJob{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"test-label": "test-value"},
+				},
 				Spec: prowv1.ProwJobSpec{Job: "test-job-2"},
 			},
 			cache:       map[string]*cacheEntry{},
@@ -99,6 +122,9 @@ func TestExternalSchedule(t *testing.T) {
 		{
 			name: "allback to configured Spec.Cluster entry",
 			pj: &prowv1.ProwJob{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"test-label": "test-value"},
+				},
 				Spec: prowv1.ProwJobSpec{Job: "test-job-4", Cluster: "cluster-99"},
 			},
 			cache:       map[string]*cacheEntry{},


### PR DESCRIPTION
The external strategy sends only the job name as a request. With this change, the prowjob's labels are also included.


/cc @danilo-gemoli @jmguzik 
Signed-off-by: Nikolaos Moraitis <nmoraiti@redhat.com>