### PR TITLE
Revert "`deck`: don't serve the ready endpoint until immediately prior to starting the server"

### DIFF
--- a/cmd/deck/main.go
+++ b/cmd/deck/main.go
@@ -460,6 +460,9 @@ func main() {
 		mux = prodOnlyMain(cfg, pluginAgent, authCfgGetter, githubClient, o, mux)
 	}
 
+	// signal to the world that we're ready
+	health.ServeReady()
+
 	// cookie secret will be used for CSRF protection and should be exactly 32 bytes
 	// we sometimes accept different lengths to stay backwards compatible
 	var csrfToken []byte
@@ -504,8 +507,6 @@ func main() {
 	}
 	// setup done, actually start the server
 	server := &http.Server{Addr: ":8080", Handler: traceHandler(mux)}
-	// signal to the world that we're ready
-	health.ServeReady()
 	interrupts.ListenAndServe(server, 5*time.Second)
 }
 

--- a/test/integration/config/prow/cluster/deck_tenant_deployment.yaml
+++ b/test/integration/config/prow/cluster/deck_tenant_deployment.yaml
@@ -46,6 +46,7 @@ spec:
         args:
         - --tide-url=http://tide/
         - --hook-url=http://hook:8888/plugin-help
+        - --oauth-url=/github-login
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config
         - --spyglass=true
@@ -54,7 +55,7 @@ spec:
         - --github-token-path=/etc/github/oauth
         - --github-endpoint=http://fakeghserver
         - --github-oauth-config-file=/etc/githuboauth/secret
-        - --allow-insecure
+        - --cookie-secret=/etc/cookie/secret
         - --plugin-config=/etc/plugins/plugins.yaml
         env:
         # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
@@ -63,6 +64,9 @@ spec:
         volumeMounts:
         - name: oauth-config
           mountPath: /etc/githuboauth
+          readOnly: true
+        - name: cookie-secret
+          mountPath: /etc/cookie
           readOnly: true
         - mountPath: /etc/kubeconfig
           name: kubeconfig
@@ -99,6 +103,9 @@ spec:
       - name: oauth-token
         secret:
           secretName: oauth-token
+      - name: cookie-secret
+        secret:
+          secretName: cookie
       - name: kubeconfig
         secret:
           defaultMode: 420


### PR DESCRIPTION
Reverts kubernetes-sigs/prow#308

https://github.com/kubernetes-sigs/prow/pull/308#issuecomment-2457656048

> Stephen Goeddel
>  3 minutes ago
> New deck never becomes ready. I am going to try some additional logging with a locally built version, but will most likely reverting the bump (and the PR)