### PR TITLE
fix: respect s3 custom endpoint config in aws sdk

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -188,13 +188,13 @@ require (
 )
 
 require (
+	github.com/aws/aws-sdk-go-v2 v1.32.4
 	github.com/aws/aws-sdk-go-v2/config v1.27.27
 	github.com/aws/aws-sdk-go-v2/credentials v1.17.27
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.66.3
 )
 
 require (
-	github.com/aws/aws-sdk-go-v2 v1.32.4 // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.6.6 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.16.11 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.17.10 // indirect

--- a/pkg/io/providers/aws.go
+++ b/pkg/io/providers/aws.go
@@ -40,19 +40,30 @@ func getS3Bucket(ctx context.Context, creds []byte, bucketName string) (*blob.Bu
 	if err := json.Unmarshal(creds, s3Creds); err != nil {
 		return nil, fmt.Errorf("error getting S3 credentials from JSON: %w", err)
 	}
+	client, err := newS3Client(ctx, s3Creds)
+	if err != nil {
+		return nil, fmt.Errorf("error creating s3 client: %w", err)
+	}
+	bkt, err := s3blob.OpenBucketV2(ctx, client, bucketName, nil)
+	if err != nil {
+		return nil, fmt.Errorf("error opening S3 bucket: %w", err)
+	}
+	return bkt, nil
+}
 
+func newS3Client(ctx context.Context, creds *s3Credentials) (*s3.Client, error) {
 	var opts []func(*config.LoadOptions) error
 
 	// Use the default credential chain if no credentials are specified
-	if s3Creds.AccessKey != "" && s3Creds.SecretKey != "" {
+	if creds.AccessKey != "" && creds.SecretKey != "" {
 		opts = append(opts, config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
-			s3Creds.AccessKey,
-			s3Creds.SecretKey,
+			creds.AccessKey,
+			creds.SecretKey,
 			"",
 		)))
 	}
 	opts = append(opts,
-		config.WithRegion(s3Creds.Region),
+		config.WithRegion(creds.Region),
 	)
 
 	cfg, err := config.LoadDefaultConfig(ctx, opts...)
@@ -62,26 +73,20 @@ func getS3Bucket(ctx context.Context, creds []byte, bucketName string) (*blob.Bu
 
 	s3Opts := []func(o *s3.Options){
 		func(o *s3.Options) {
-			o.UsePathStyle = s3Creds.S3ForcePathStyle
+			o.UsePathStyle = creds.S3ForcePathStyle
 			o.HTTPClient = awshttp.NewBuildableClient().WithTransportOptions(func(t *http.Transport) {
 				if t.TLSClientConfig == nil {
 					t.TLSClientConfig = &tls.Config{}
 				}
-				t.TLSClientConfig.InsecureSkipVerify = s3Creds.Insecure
+				t.TLSClientConfig.InsecureSkipVerify = creds.Insecure
 			})
 		},
 	}
-	if s3Creds.Endpoint != "" {
+	if creds.Endpoint != "" {
 		s3Opts = append(s3Opts, func(o *s3.Options) {
-			o.BaseEndpoint = &s3Creds.Endpoint
+			o.BaseEndpoint = &creds.Endpoint
 		})
 	}
 
-	client := s3.NewFromConfig(cfg, s3Opts...)
-
-	bkt, err := s3blob.OpenBucketV2(ctx, client, bucketName, nil)
-	if err != nil {
-		return nil, fmt.Errorf("error opening S3 bucket: %w", err)
-	}
-	return bkt, nil
+	return s3.NewFromConfig(cfg, s3Opts...), nil
 }

--- a/pkg/io/providers/aws_test.go
+++ b/pkg/io/providers/aws_test.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package providers
+
+import (
+	"context"
+	"testing"
+
+	awshttp "github.com/aws/aws-sdk-go-v2/aws/transport/http"
+)
+
+func Test_newS3Client(t *testing.T) {
+	tests := []struct {
+		name  string
+		creds s3Credentials
+	}{
+		{
+			name: "only accesskey and secretkey set",
+			creds: s3Credentials{
+				AccessKey: "foo",
+				SecretKey: "bar",
+			},
+		},
+		{
+			name: "all options set ",
+			creds: s3Credentials{
+				AccessKey:        "foo",
+				SecretKey:        "bar",
+				Endpoint:         "https://foobar.com",
+				Region:           "eu01",
+				Insecure:         true,
+				S3ForcePathStyle: true,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			got, err := newS3Client(ctx, &tt.creds)
+			if err != nil {
+				t.Errorf("newS3Client() error = %v,", err)
+				return
+			}
+			s3opts := got.Options()
+			awsCreds, err := s3opts.Credentials.Retrieve(ctx)
+			if err != nil {
+				t.Errorf("get aws credentials error = %v,", err)
+				return
+			}
+			if awsCreds.AccessKeyID != tt.creds.AccessKey {
+				t.Errorf("want AccessKey %s, got %s", tt.creds.AccessKey, awsCreds.AccessKeyID)
+			}
+			if awsCreds.SecretAccessKey != tt.creds.SecretKey {
+				t.Errorf("want SecretKey %s, got %s", tt.creds.SecretKey, awsCreds.SecretAccessKey)
+			}
+
+			httpClient, ok := s3opts.HTTPClient.(*awshttp.BuildableClient)
+			if !ok {
+				t.Errorf("s3 HTTPClient is not a awshttp.BuildableClient, got %T", s3opts.HTTPClient)
+				return
+			}
+			tlsConfig := httpClient.GetTransport().TLSClientConfig
+			if tlsConfig == nil {
+				t.Error("tlsConfig of s3 httpClient transport is nil")
+				return
+			}
+			if tlsConfig.InsecureSkipVerify != tt.creds.Insecure {
+				t.Errorf("want tlsConfig.InsecureSkipVerify %v, got %v", tt.creds.Insecure, tlsConfig.InsecureSkipVerify)
+			}
+
+			if s3opts.Region != tt.creds.Region {
+				t.Errorf("want Region in s3 options %v, got %v", tt.creds.Region, s3opts.Region)
+			}
+			if s3opts.UsePathStyle != tt.creds.S3ForcePathStyle {
+				t.Errorf("want UsePathStyle in s3 options %v, got %v", tt.creds.S3ForcePathStyle, s3opts.UsePathStyle)
+			}
+			if tt.creds.Endpoint != "" {
+				if s3opts.BaseEndpoint == nil {
+					t.Error("BaseEndpoint in s3 options should be set, got nil")
+					return
+				}
+				if *s3opts.BaseEndpoint != tt.creds.Endpoint {
+					t.Errorf("want BaseEndpoint in s3 options %s, got %s", tt.creds.Endpoint, *s3opts.BaseEndpoint)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Commit https://github.com/kubernetes-sigs/prow/commit/77dc7b725f136fed43a3c01e90a70d3f89ae92f2 introduced breaking changes for users of prow that don't use AWS S3 since the endpoint field is not respected anymore.

This PR ensures that custom endpoints for S3 storage is respected as well as the insecure field.
