### PR TITLE
Allow Passing AWS Session Token

### DIFF
--- a/pkg/io/providers/aws.go
+++ b/pkg/io/providers/aws.go
@@ -59,7 +59,7 @@ func newS3Client(ctx context.Context, creds *S3Credentials) (*s3.Client, error) 
 		opts = append(opts, config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
 			creds.AccessKey,
 			creds.SecretKey,
-			"",
+			creds.SessionToken,
 		)))
 	}
 	opts = append(opts,

--- a/pkg/io/providers/providers.go
+++ b/pkg/io/providers/providers.go
@@ -98,6 +98,7 @@ type S3Credentials struct {
 	S3ForcePathStyle bool   `json:"s3_force_path_style"`
 	AccessKey        string `json:"access_key"`
 	SecretKey        string `json:"secret_key"`
+	SessionToken     string `json:"session_token"`
 }
 
 // HasStorageProviderPrefix returns true if the given string starts with


### PR DESCRIPTION
At the moment we don't allow passing in an aws session token for the s3 provider... temporary tokens require that the session token also be provided with the access and secret keys. Without this change we don't allow temporary s3 tokens (tokens that start with `ASIA` instead of `AKIA`.