### PR TITLE
Added a plan struct inside organization

### DIFF
--- a/pkg/github/types.go
+++ b/pkg/github/types.go
@@ -1162,14 +1162,20 @@ type Organization struct {
 	BillingEmail string `json:"billing_email"`
 	Company      string `json:"company"`
 	// Email is publicly visible
-	Email                        string `json:"email"`
-	Location                     string `json:"location"`
-	Name                         string `json:"name"`
-	Description                  string `json:"description"`
-	HasOrganizationProjects      bool   `json:"has_organization_projects"`
-	HasRepositoryProjects        bool   `json:"has_repository_projects"`
-	DefaultRepositoryPermission  string `json:"default_repository_permission"`
-	MembersCanCreateRepositories bool   `json:"members_can_create_repositories"`
+	Email                        string  `json:"email"`
+	Location                     string  `json:"location"`
+	Name                         string  `json:"name"`
+	Description                  string  `json:"description"`
+	HasOrganizationProjects      bool    `json:"has_organization_projects"`
+	HasRepositoryProjects        bool    `json:"has_repository_projects"`
+	DefaultRepositoryPermission  string  `json:"default_repository_permission"`
+	MembersCanCreateRepositories bool    `json:"members_can_create_repositories"`
+	Plan                         OrgPlan `json:"plan"`
+}
+
+// OrgPlan contains the Plan fields for the organization plan (free, gold, silver, medium...)
+type OrgPlan struct {
+	Name string `json:"name"`
 }
 
 // OrgMembership contains Membership fields for user membership in an org.


### PR DESCRIPTION
GitHub no longer allows branch-protection to be set via the API on private repos using the free plan, we need to know the plan type to apply customized logic for some automation we have.

The `plan` property is described on https://docs.github.com/en/rest/orgs/orgs?apiVersion=2022-11-28#get-an-organization