### PR TITLE
Respect newline in command examples in command-help

### DIFF
--- a/cmd/deck/static/style.css
+++ b/cmd/deck/static/style.css
@@ -509,6 +509,7 @@ span.label:not(.merge-table-label):hover {
 }
 
 .command-examples {
+    white-space: pre;
     background-color: #e5e5e5;
     border-radius: 2px;
     box-shadow: 1px 1px 2px #ededed;


### PR DESCRIPTION
Currently, the command-help page renders multiline command examples (the
only example I've seen is for /release-note-edit) on one line, which is
confusing for users.

Change the style to respect newline in the source.

Link: https://developer.mozilla.org/en-US/docs/Web/CSS/white-space


Before: 
![image](https://github.com/user-attachments/assets/b97c021b-f44e-4cd9-964e-3acab7d99818)

After:
![image](https://github.com/user-attachments/assets/964c31fe-15af-4325-b711-4123285f9a41)

