### PR TITLE
Move some approvers to emeritus.

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,13 +1,14 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-  - alvaroaleman
-  - cblecker
-  - cjwagner
-  - stevekuznetsov
   - petr-muller
-  - timwangmusic
   - matthyx
   - droslean
   - krzyzacy
   - smg247
+emeritus_approvers:
+  - alvaroaleman
+  - cblecker
+  - cjwagner
+  - stevekuznetsov
+  - timwangmusic


### PR DESCRIPTION
Thanks y'all for previous contributions! Moving less active folks to emeritus to clean up the approvers list.

Follow-up to https://github.com/kubernetes-sigs/prow/pull/336.