### PR TITLE
Config to automatically Re-trigger failed periodics

### DIFF
--- a/cmd/horologium/main_test.go
+++ b/cmd/horologium/main_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"flag"
 	"reflect"
+	"strconv"
 	"testing"
 	"time"
 
@@ -30,9 +31,11 @@ import (
 	fakectrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	prowapi "sigs.k8s.io/prow/pkg/apis/prowjobs/v1"
+	v1 "sigs.k8s.io/prow/pkg/apis/prowjobs/v1"
 	"sigs.k8s.io/prow/pkg/config"
 	"sigs.k8s.io/prow/pkg/flagutil"
 	configflagutil "sigs.k8s.io/prow/pkg/flagutil/config"
+	"sigs.k8s.io/prow/pkg/kube"
 )
 
 type fakeCron struct {
@@ -60,9 +63,14 @@ func TestSync(t *testing.T) {
 	testcases := []struct {
 		testName string
 
-		jobName         string
-		jobComplete     bool
-		jobStartTimeAgo time.Duration
+		jobName                  string
+		jobComplete              bool
+		jobStartTimeAgo          time.Duration
+		retry                    *config.Retry
+		state                    prowapi.ProwJobState
+		interval                 time.Duration
+		retryLabelNumber         int
+		expectedRetryLabelNumber int
 
 		shouldStart bool
 	}{
@@ -105,50 +113,171 @@ func TestSync(t *testing.T) {
 			jobStartTimeAgo: time.Second,
 			shouldStart:     false,
 		},
+		{
+			testName:        "old, complete job",
+			jobName:         "j",
+			jobComplete:     true,
+			jobStartTimeAgo: time.Hour,
+			shouldStart:     true,
+		},
+		{
+			testName:                 "complete job meant to be re-run",
+			jobName:                  "j",
+			jobComplete:              true,
+			jobStartTimeAgo:          time.Minute,
+			shouldStart:              true,
+			state:                    v1.FailureState,
+			retry:                    &config.Retry{Attempts: 3},
+			interval:                 time.Minute,
+			retryLabelNumber:         1,
+			expectedRetryLabelNumber: 2,
+		},
+		{
+			testName:         "failed job but horologium limit is reached",
+			jobName:          "j",
+			jobComplete:      true,
+			jobStartTimeAgo:  time.Minute,
+			shouldStart:      false,
+			state:            v1.FailureState,
+			retry:            &config.Retry{Attempts: 13},
+			interval:         time.Minute,
+			retryLabelNumber: 10,
+		},
+		{
+			testName:         "running job not meant to be re-run",
+			jobName:          "j",
+			jobComplete:      false,
+			jobStartTimeAgo:  time.Minute,
+			shouldStart:      false,
+			state:            v1.PendingState,
+			retry:            &config.Retry{RunAll: true, Attempts: 3},
+			interval:         time.Minute,
+			retryLabelNumber: 1,
+		},
+		{
+			testName:                 "complete job meant to be re-run even if success state",
+			jobName:                  "j",
+			jobComplete:              true,
+			jobStartTimeAgo:          time.Minute,
+			shouldStart:              true,
+			state:                    v1.SuccessState,
+			retry:                    &config.Retry{RunAll: true, Attempts: 3},
+			interval:                 time.Minute,
+			retryLabelNumber:         1,
+			expectedRetryLabelNumber: 2,
+		},
+		{
+			testName:                 "complete job meant to be re-run after 2 attempts",
+			jobName:                  "j",
+			jobComplete:              true,
+			jobStartTimeAgo:          time.Minute,
+			shouldStart:              true,
+			state:                    v1.SuccessState,
+			retry:                    &config.Retry{RunAll: true, Attempts: 3},
+			interval:                 time.Minute,
+			retryLabelNumber:         1,
+			expectedRetryLabelNumber: 2,
+		},
+		{
+			testName:         "complete job not meant to be re-run after 3 attempts",
+			jobName:          "j",
+			jobComplete:      true,
+			jobStartTimeAgo:  time.Minute,
+			shouldStart:      false,
+			state:            v1.SuccessState,
+			retry:            &config.Retry{RunAll: true, Attempts: 3},
+			interval:         time.Minute,
+			retryLabelNumber: 3,
+		},
+		{
+			testName:         "complete job not meant to be re-run with until_success after success state",
+			jobName:          "j",
+			jobComplete:      true,
+			jobStartTimeAgo:  time.Minute,
+			shouldStart:      false,
+			state:            v1.SuccessState,
+			retry:            &config.Retry{Attempts: 3},
+			interval:         time.Minute,
+			retryLabelNumber: 2,
+		},
 	}
 	for _, tc := range testcases {
-		cfg := config.Config{
-			ProwConfig: config.ProwConfig{
-				ProwJobNamespace: "prowjobs",
-			},
-			JobConfig: config.JobConfig{
-				Periodics: []config.Periodic{{JobBase: config.JobBase{Name: "j"}}},
-			},
-		}
-		cfg.Periodics[0].SetInterval(time.Minute)
-
-		var jobs []client.Object
-		now := time.Now()
-		if tc.jobName != "" {
-			job := &prowapi.ProwJob{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "with-interval",
-					Namespace: "prowjobs",
+		t.Run(tc.testName, func(t *testing.T) {
+			cfg := config.Config{
+				ProwConfig: config.ProwConfig{
+					ProwJobNamespace: "prowjobs",
 				},
-				Spec: prowapi.ProwJobSpec{
-					Type: prowapi.PeriodicJob,
-					Job:  tc.jobName,
-				},
-				Status: prowapi.ProwJobStatus{
-					StartTime: metav1.NewTime(now.Add(-tc.jobStartTimeAgo)),
+				JobConfig: config.JobConfig{
+					Periodics: []config.Periodic{{JobBase: config.JobBase{Name: "j"}, Retry: tc.retry}},
 				},
 			}
-			complete := metav1.NewTime(now.Add(-time.Millisecond))
-			if tc.jobComplete {
-				job.Status.CompletionTime = &complete
+			cfg.Periodics[0].SetInterval(time.Minute * 30)
+			if cfg.JobConfig.Periodics[0].Retry != nil {
+				tc.retry.SetInterval(tc.interval)
 			}
-			jobs = append(jobs, job)
-		}
-		fakeProwJobClient := newCreateTrackingClient(jobs)
-		fc := &fakeCron{}
-		if err := sync(fakeProwJobClient, &cfg, fc, now); err != nil {
-			t.Fatalf("For case %s, didn't expect error: %v", tc.testName, err)
-		}
 
-		sawCreation := fakeProwJobClient.sawCreate
-		if tc.shouldStart != sawCreation {
-			t.Errorf("For case %s, did the wrong thing.", tc.testName)
-		}
+			var jobs []client.Object
+			now := time.Now()
+			if tc.jobName != "" {
+				job := &prowapi.ProwJob{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "with-interval",
+						Namespace: "prowjobs",
+					},
+					Spec: prowapi.ProwJobSpec{
+						Type: prowapi.PeriodicJob,
+						Job:  tc.jobName,
+					},
+					Status: prowapi.ProwJobStatus{
+						StartTime: metav1.NewTime(now.Add(-tc.jobStartTimeAgo)),
+						State:     tc.state,
+					},
+				}
+				complete := metav1.NewTime(now.Add(-time.Millisecond))
+				if tc.jobComplete {
+					job.Status.CompletionTime = &complete
+				}
+				jobs = append(jobs, job)
+				if tc.retryLabelNumber != 0 {
+					if job.Labels == nil {
+						job.Labels = make(map[string]string)
+					}
+					job.Labels[kube.ReRunLabel] = strconv.Itoa(tc.retryLabelNumber)
+				}
+			}
+
+			fakeProwJobClient := newCreateTrackingClient(jobs)
+			fc := &fakeCron{}
+			if err := sync(fakeProwJobClient, &cfg, fc, now); err != nil {
+				t.Fatalf("Didn't expect error: %v", err)
+			}
+
+			sawCreation := fakeProwJobClient.sawCreate
+			if tc.shouldStart != sawCreation {
+				t.Errorf("Did the wrong thing. Expected sawCreation: %v, got: %v", tc.shouldStart, sawCreation)
+			}
+			if sawCreation {
+				pj, ok := fakeProwJobClient.created[0].(*v1.ProwJob)
+				if !ok {
+					t.Error("Failed to convert created object to *v1.ProwJob")
+					return
+				}
+
+				if tc.retryLabelNumber > 0 {
+					countLabel, exists := pj.Labels[kube.ReRunLabel]
+					if !exists {
+						t.Errorf("Expected label %s to exist", kube.ReRunLabel)
+					} else {
+						count, err := strconv.Atoi(countLabel)
+						if err != nil {
+							t.Errorf("Failed to convert label value: %v", err)
+						} else if count != tc.expectedRetryLabelNumber {
+							t.Errorf("Expected retry label value %d, but got %d", tc.expectedRetryLabelNumber, count)
+						}
+					}
+				}
+			}
+		})
 	}
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -2435,6 +2435,14 @@ func (c Config) validatePeriodics(periodics []Periodic) error {
 			periodics[j].interval = d
 		}
 
+		if p.Retry != nil {
+			d, err := time.ParseDuration(periodics[j].Retry.Interval)
+			if err != nil {
+				errs = append(errs, fmt.Errorf("cannot parse Retry duration for %s: %w", periodics[j].Name, err))
+			}
+			periodics[j].interval = d
+		}
+
 		if p.MinimumInterval != "" {
 			d, err := time.ParseDuration(periodics[j].MinimumInterval)
 			if err != nil {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -8206,6 +8206,13 @@ func TestValidatePeriodics(t *testing.T) {
 			expectedError: "cannot parse duration for a: time: invalid duration \"hello\"",
 		},
 		{
+			name: "Invalid Retry interval",
+			periodics: []Periodic{
+				{JobBase: JobBase{Name: "a"}, Retry: &Retry{Interval: "hello"}, Interval: "6h"},
+			},
+			expectedError: "cannot parse Retry duration for a: time: invalid duration \"hello\"",
+		},
+		{
 			name: "Invalid minimum_interval",
 			periodics: []Periodic{
 				{JobBase: JobBase{Name: "a"}, MinimumInterval: "hello"},
@@ -8219,6 +8226,15 @@ func TestValidatePeriodics(t *testing.T) {
 			},
 			expected: []Periodic{
 				{JobBase: JobBase{Name: "a"}, Interval: "10ns", interval: time.Duration(10)},
+			},
+		},
+		{
+			name: "Sets Retrigger Failed interval",
+			periodics: []Periodic{
+				{JobBase: JobBase{Name: "a"}, Retry: &Retry{Interval: "10ns"}, Interval: "6h"},
+			},
+			expected: []Periodic{
+				{JobBase: JobBase{Name: "a"}, Retry: &Retry{Interval: "10ns"}, interval: time.Duration(10), Interval: "6h"},
 			},
 		},
 		{

--- a/pkg/config/jobs.go
+++ b/pkg/config/jobs.go
@@ -266,6 +266,19 @@ type Postsubmit struct {
 	JenkinsSpec *JenkinsSpec `json:"jenkins_spec,omitempty"`
 }
 
+// Retry defines the configuration for retrying failed prowjobs.
+type Retry struct {
+	// RunAll retries will not stop on first successful run
+	// (failed job will always cause Attempts retries to be executed)
+	RunAll bool `json:"run_all,omitempty"`
+	// Attempts specifies the maximum number of retry attempts allowed.
+	Attempts int `json:"attempts,omitempty"`
+	// Interval defines the wait duration between consecutive retry attempts.
+	Interval string `json:"interval,omitempty"`
+
+	interval time.Duration
+}
+
 // Periodic runs on a timer.
 type Periodic struct {
 	JobBase
@@ -282,6 +295,8 @@ type Periodic struct {
 	// Tags for config entries
 	Tags []string `json:"tags,omitempty"`
 
+	Retry *Retry `json:"retry,omitempty"`
+
 	interval         time.Duration
 	minimum_interval time.Duration
 }
@@ -291,6 +306,16 @@ type JenkinsSpec struct {
 	// Job is managed by the GH branch source plugin
 	// and requires a specific path
 	GitHubBranchSourceJob bool `json:"github_branch_source_job,omitempty"`
+}
+
+// SetInterval updates interval, the frequency duration it runs.
+func (r *Retry) SetInterval(d time.Duration) {
+	r.interval = d
+}
+
+// GetInterval returns interval, the frequency duration it runs.
+func (r *Retry) GetInterval() time.Duration {
+	return r.interval
 }
 
 // SetInterval updates interval, the frequency duration it runs.

--- a/pkg/kube/prowjob.go
+++ b/pkg/kube/prowjob.go
@@ -69,6 +69,9 @@ const (
 	// IsOptionalLabel is added in resources created by prow and
 	// carries the Optional from a Presubmit job.
 	IsOptionalLabel = "prow.k8s.io/is-optional"
+	// ReRunLabel is added in periodics that are configured to be
+	// re-runned several times, value starts from 0 and it's increased on re-run
+	ReRunLabel = "prow.k8s.io/re-run"
 
 	// Gerrit related labels that are used by Prow
 


### PR DESCRIPTION
This PR introduces a new configuration field (along with the functionality in horologium component) for ProwJobs to support automatically re-triggering periodic jobs based on a specified policy. The new `retrigger-failed-run` field allows retrying a failed periodic job with customizable settings for the number of attempts and the interval between retries.

Example usage:
```
retrigger-failed-run:
  until_success: true
  attempts: 3
  interval: 6h
```

`until_success: true` alows to stop if success state is reached. Set to `false` it triggers until `attempts` reached.
sloves https://github.com/kubernetes-sigs/prow/issues/268