### PR TITLE
Removed Prometheus broken link

### DIFF
--- a/site/content/en/docs/overview/_index.md
+++ b/site/content/en/docs/overview/_index.md
@@ -102,7 +102,6 @@ Prow is used by the following organizations and projects:
 * [Jetstack](https://prow.build-infra.jetstack.net/)
 * [Kyma](https://status.build.kyma-project.io/)
 * [Metal³](https://prow.apps.test.metal3.io/)
-* [Prometheus](http://prombench.prometheus.io/)
 * [Caicloud](https://github.com/caicloud)
 * [Kubeflow](https://github.com/kubeflow)
 * [Azure AKS Engine](https://github.com/Azure/aks-engine/tree/master/.prowci)


### PR DESCRIPTION
The docs had broken link for Prometheus on [Prow in the wild](https://docs.prow.k8s.io/docs/overview/#prow-in-the-wild) section.

Since Prometheus doesn't even run Prow jobs in their CI, This PR focusses on removing the link altogether as discussed [here](https://github.com/kubernetes-sigs/prow/issues/348#issuecomment-2584557175).