### PR TITLE
Add jmguzik to approvers list

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -6,6 +6,7 @@ approvers:
   - droslean
   - krzyzacy
   - smg247
+  - jmguzik
 emeritus_approvers:
   - alvaroaleman
   - cblecker


### PR DESCRIPTION
Prow is a crucial part of OpenShift CI, likely the largest Prow instance. Recently, several approvers became emeritus. As a longtime Prow reviewer and OpenShift CI maintainer, I value Prow and want to help keep it running, so I request to be added as an approver.

I can't promise I will be the most active reviewer/approver, but I will try my best to keep the project running.