### PR TITLE
Remove a category label `needs-*` when the user is defining one

### DIFF
--- a/pkg/plugins/label/label_test.go
+++ b/pkg/plugins/label/label_test.go
@@ -758,6 +758,38 @@ func TestHandleComment(t *testing.T) {
 			action:                github.GenericCommentActionCreated,
 			expectedRemovedLabels: formatWithPRInfo("restricted-label"),
 		},
+		{
+			name:                  "Remove triage category via /triage command",
+			body:                  "/triage needs-information",
+			repoLabels:            []string{"area/infra", "triage/needs-information", "needs-triage"},
+			issueLabels:           []string{"area/infra", "needs-triage"},
+			expectedNewLabels:     formatWithPRInfo("triage/needs-information"),
+			expectedRemovedLabels: formatWithPRInfo("needs-triage"),
+			commenter:             orgMember,
+			action:                github.GenericCommentActionCreated,
+		},
+		{
+			name:                  "Remove triage category via /label command",
+			body:                  "/label triage/needs-information",
+			extraLabels:           []string{"triage/needs-information"},
+			repoLabels:            []string{"triage/needs-information", "needs-triage"},
+			issueLabels:           []string{"needs-triage"},
+			expectedNewLabels:     formatWithPRInfo("triage/needs-information"),
+			expectedRemovedLabels: formatWithPRInfo("needs-triage"),
+			commenter:             orgMember,
+			action:                github.GenericCommentActionCreated,
+		},
+		{
+			name:                  "Nonstandard needs-* label, do not remove",
+			body:                  "/label fake/whatever",
+			extraLabels:           []string{"fake/whatever"},
+			repoLabels:            []string{"needs-fake", "fake/whatever"},
+			issueLabels:           []string{"needs-fake"},
+			expectedNewLabels:     formatWithPRInfo("fake/whatever"),
+			expectedRemovedLabels: []string{},
+			commenter:             orgMember,
+			action:                github.GenericCommentActionCreated,
+		},
 	}
 
 	for _, tc := range testcases {


### PR DESCRIPTION
These are the available `needs-*` categories that can be applied to an issue (see [here](https://github.com/kubernetes-sigs/prow/blob/aae1f05957ef15eb73500e0d1d3c7f01db6bdabd/pkg/plugins/label/label.go#L40)):
```
needs-kind, needs-priority, needs-sig, needs-triage
```
When an issue has one of those, as `needs-triage`, and the user is defining that category like so:
```
/triage unresolved
```
then the `needs-triage` will be removed.