### PR TITLE
Using material design for other tables as well

### DIFF
--- a/cmd/deck/static/common/common.ts
+++ b/cmd/deck/static/common/common.ts
@@ -19,6 +19,7 @@ export namespace cell {
 
   export function text(content: string): HTMLTableDataCellElement {
     const c = document.createElement("td");
+    c.classList.add("mdl-data-table__cell--non-numeric");
     c.appendChild(document.createTextNode(content));
     return c;
   }
@@ -40,6 +41,7 @@ export namespace cell {
 
   export function link(displayText: string, url: string): HTMLTableDataCellElement {
     const c = document.createElement("td");
+    c.classList.add("mdl-data-table__cell--non-numeric");
     const a = document.createElement("a");
     a.href = url;
     a.appendChild(document.createTextNode(displayText));
@@ -49,6 +51,7 @@ export namespace cell {
 
   export function state(s: ProwJobState): HTMLTableDataCellElement {
     const c = document.createElement("td");
+    c.classList.add("mdl-data-table__cell--non-numeric");
     if (!s) {
       c.appendChild(document.createTextNode(""));
       return c;
@@ -99,6 +102,7 @@ export namespace cell {
 
   export function commitRevision(repo: string, ref: string, SHA: string, pushCommitLink: string): HTMLTableDataCellElement {
     const c = document.createElement("td");
+    c.classList.add("mdl-data-table__cell--non-numeric");
     const bl = document.createElement("a");
     bl.href = pushCommitLink;
     if (!bl.href) {
@@ -111,6 +115,7 @@ export namespace cell {
 
   export function prRevision(repo: string, pull: Pull): HTMLTableDataCellElement {
     const td = document.createElement("td");
+    td.classList.add("mdl-data-table__cell--non-numeric");
     addPRRevision(td, repo, pull);
     return td;
   }

--- a/cmd/deck/static/prow/prow.ts
+++ b/cmd/deck/static/prow/prow.ts
@@ -675,7 +675,9 @@ function redraw(fz: FuzzySearch, pushState = true): void {
     // Started column
     r.appendChild(cell.time(i.toString(), moment.unix(started)));
     // Duration column
-    r.appendChild(cell.text(durationStr));
+    const duration = cell.text(durationStr)
+    duration.classList.remove("mdl-data-table__cell--non-numeric");
+    r.appendChild(duration);
     builds.appendChild(r);
   }
 
@@ -778,6 +780,7 @@ function batchRevisionCell(build: ProwJob): HTMLTableDataCellElement {
   const {refs: {org = "", repo = "", pulls = []} = {}} = build.spec;
 
   const c = document.createElement("td");
+  c.classList.add("mdl-data-table__cell--non-numeric");
   if (!pulls.length) {
     return c;
   }
@@ -921,6 +924,7 @@ function createSpyglassCell(url: string): HTMLTableDataCellElement {
   const i = icon.create('visibility', 'View in Spyglass');
   i.href = url;
   const c = document.createElement('td');
+  c.classList.add("mdl-data-table__cell--non-numeric");
   c.appendChild(i);
   return c;
 }

--- a/cmd/deck/static/style.css
+++ b/cmd/deck/static/style.css
@@ -95,7 +95,7 @@ article {
     margin: 8px;
 }
 
-table {
+table#job-histogram {
     background: #fff;
     border-radius: 2px;
     box-shadow: 0 0 4px #e0e0e0;
@@ -103,29 +103,42 @@ table {
     width: 100%;
 }
 
-tr {
-    border-top: 1px solid #f4f4f4;
+.mdl-data-table {
+    font-size: 15px;
+    white-space: normal;
+    width: 100%;
 }
 
-tr.changed {
+.mdl-data-table th {
+	font-size: 15px;
+	color: #585858;
+}
+
+.mdl-data-table tr {
+    border-top: 1px solid rgba(0,0,0,.12);
+}
+
+.mdl-data-table tr.changed {
     border-top: 1px solid #a4a4a4;
 }
-
-td:first-child, th:first-child {
-    padding-left: 16px;
+.mdl-data-table td {
+    border: 0;
 }
 
-td:last-child, th:last-child {
-    padding-right: 16px;
+.mdl-data-table tbody tr {
+    transition-duration: 0s;
 }
 
-td, th {
-    text-align: left;
+.mdl-data-table th, .mdl-data-table td {
     padding: 8px;
 }
 
-th {
-    color: #333;
+.mdl-data-table th:first-of-type, .mdl-data-table td:first-of-type {
+    padding-left: 24px;
+}
+
+..mdl-data-table th:last-of-type, .mdl-data-table td:last-of-type {
+    padding-right: 24px;
 }
 
 .hidden {

--- a/cmd/deck/template/base.html
+++ b/cmd/deck/template/base.html
@@ -26,11 +26,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
   {{end}}
   <title>{{block "title" .Arguments}}Prow{{ end }}</title>
+  <link rel="stylesheet" href="https://code.getmdl.io/1.3.0/material.indigo-pink.min.css">
   <link rel="stylesheet" type="text/css" href="/static/style.css?v={{deckVersion}}">
   <link rel="stylesheet" type="text/css" href="/static/extensions/style.css?v={{deckVersion}}">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:400,700">
   <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
-  <link rel="stylesheet" href="https://code.getmdl.io/1.3.0/material.indigo-pink.min.css">
   <script type="text/javascript" src="/static/extensions/script.js?v={{deckVersion}}"></script>
   <script defer src="https://code.getmdl.io/1.3.0/material.min.js"></script>
   {{block "scripts" .Arguments}}{{end}}

--- a/cmd/deck/template/index.html
+++ b/cmd/deck/template/index.html
@@ -60,18 +60,18 @@
   </aside>
   <article>
     <div class="table-container">
-      <table id="builds">
+      <table id="builds" class="mdl-data-table mdl-js-data-table mdl-shadow--2dp">
         <thead>
         <tr>
-          <th class="icon-cell-32">State</th>
-          <th class="icon-cell-32">Log</th>
-          <th class="icon-cell-32">Rerun</th>
-          <th class="icon-cell-32">Abort</th>
-          <th>Job YML</th>
-          <th>Repository</th>
-          <th>Revision</th>
-          <th>Spyglass</th>
-          <th>Job</th>
+          <th class="mdl-data-table__cell--non-numeric">State</th>
+          <th class="mdl-data-table__cell--non-numeric">Log</th>
+          <th class="mdl-data-table__cell--non-numeric">Rerun</th>
+          <th class="mdl-data-table__cell--non-numeric">Abort</th>
+          <th class="mdl-data-table__cell--non-numeric">YAML</th>
+          <th class="mdl-data-table__cell--non-numeric">Repository</th>
+          <th class="mdl-data-table__cell--non-numeric">Revision</th>
+          <th class="mdl-data-table__cell--non-numeric">Spyglass</th>
+          <th class="mdl-data-table__cell--non-numeric">Job</th>
           <th>Scheduled</th>
           <th>Duration</th>
         </tr>

--- a/cmd/deck/template/tide-history.html
+++ b/cmd/deck/template/tide-history.html
@@ -27,16 +27,16 @@
   </aside>
   <article>
     <div class="table-container">
-      <table id="records">
+      <table id="records" class="mdl-data-table mdl-js-data-table mdl-shadow--2dp">
         <thead>
         <tr>
           <th></th> <!-- State icon -->
-          <th>Pool</th>
-          <th>Base Commit</th>
-          <th>Action</th>
-          <th>Target</th>
+          <th class="mdl-data-table__cell--non-numeric">Pool</th>
+          <th class="mdl-data-table__cell--non-numeric">Base Commit</th>
+          <th class="mdl-data-table__cell--non-numeric">Action</th>
+          <th class="mdl-data-table__cell--non-numeric">Target</th>
           <th>Time</th>
-          <th>Error</th>
+          <th class="mdl-data-table__cell--non-numeric">Error</th>
         </tr>
         </thead>
         <tbody>

--- a/cmd/deck/template/tide.html
+++ b/cmd/deck/template/tide.html
@@ -21,7 +21,7 @@
 </article>
 <article>
   <div class="table-container">
-    <table id="pools">
+    <table id="pools" class="mdl-data-table mdl-js-data-table mdl-shadow--2dp">
       <thead>
         <th></th>
         <th>Repo</th>


### PR DESCRIPTION
What do you thing about adding the "default" material style for tables - used on https://prow.k8s.io/command-help - for other tables as well?

This let the appearance more appealing and modern and also give a visual feedback on what line we are with the mouse - very helpful.

This also shrink the font to 13px against the original 16px, I modified it to 15px.

Also, changed the `Job YML` title to `YAML` so the cell doesn't break.

A demo can be viewed [here](https://deck-material.apps.ci.l2s4.p1.openshiftapps.com/) but will be disabled sooner or later.

As a reference for the future, this is the version without style:
![deck-no-style](https://github.com/user-attachments/assets/c5ebfd11-34a3-48e7-8acd-d147a034925b)

This is the version with style and line feedback:
![deck-material](https://github.com/user-attachments/assets/c36497fa-1ce3-4852-ae51-a17efb261aed)