### PR TITLE
Fix `sinker's` flaky integration test

### DIFF
--- a/test/integration/test/sinker_test.go
+++ b/test/integration/test/sinker_test.go
@@ -285,7 +285,7 @@ func TestDeletePod(t *testing.T) {
 			// Make sure pod is deleted.
 			t.Logf("Wait for sinker deleting pod or timeout in 1 minute: %s", pod.Name)
 			var scheduled_for_deletion bool
-			err = wait.PollUntilContextTimeout(ctx, time.Second, 1*time.Minute, true, func(ctx context.Context) (bool, error) {
+			_ = wait.PollUntilContextTimeout(ctx, time.Second, 1*time.Minute, true, func(ctx context.Context) (bool, error) {
 				pods := &corev1.PodList{}
 				err := kubeClient.List(ctx, pods, ctrlruntimeclient.InNamespace(testpodNamespace))
 				if err != nil {
@@ -302,7 +302,7 @@ func TestDeletePod(t *testing.T) {
 				return scheduled_for_deletion, nil
 			})
 			// Check for the error of `List` call.
-			if err != nil && !wait.Interrupted(err) {
+			if err != nil {
 				t.Fatal(err)
 			}
 			t.Logf("Pod %s scheduled for deletion: %v", pod.Name, scheduled_for_deletion)


### PR DESCRIPTION
There is a flake in the `Sinker` integration test that looks like the following:
```
=== FAIL: test/integration/test TestDeletePod/running-pod (60.04s)
    sinker_test.go:246: Creating client for cluster: kind-kind-prow-integration
    sinker_test.go:263: Creating prowjob: running-pod-67fbb1f581d3c62bfffda7cdd410491a
    sinker_test.go:267: Finished creating prowjob: running-pod-67fbb1f581d3c62bfffda7cdd410491a
    sinker_test.go:271: Creating pod: running-pod-67fbb1f581d3c62bfffda7cdd410491a
    sinker_test.go:275: Finished creating pod: running-pod-67fbb1f581d3c62bfffda7cdd410491a
    sinker_test.go:286: Wait for sinker deleting pod or timeout in 1 minute: running-pod-67fbb1f581d3c62bfffda7cdd410491a
    sinker_test.go:306: client rate limiter Wait returned an error: rate: Wait(n=1) would exceed context deadline
=== FAIL: test/integration/test TestDeletePod (0.00s)
```

The following line points to the issue:
```
client rate limiter Wait returned an error: rate: Wait(n=1) would exceed context deadline
```
That tells us that there is a deadline, that will be exceeded prior to the wait timeout we have just set to `1m`. I believe that this is due to a race condition within the `time` package. We are noticing it frequently here, specifically, because we actually expect to hit the timeout with a few of these test cases.

The fix here simply ignores the errors coming from `PollUntilContextTimeout`, as we had done prior to https://github.com/kubernetes-sigs/prow/pull/262/commits/6c290be6d3b18042be29e7285372f98a70a40026.

Replaces: https://github.com/kubernetes-sigs/prow/pull/373

Fixes: https://github.com/kubernetes-sigs/prow/issues/309