### PR TITLE
Update create-build-cluster.sh to have mandatory package auto install

### DIFF
--- a/pkg/create-build-cluster.sh
+++ b/pkg/create-build-cluster.sh
@@ -142,6 +142,8 @@ function pause() {
 
 authed=""
 function getClusterCreds() {
+  echo "Ensuring gke-gcloud-auth-plugin is installed"
+  gcloud components install gke-gcloud-auth-plugin --quiet
   if [[ -z "${authed}" ]]; then
     gcloud container clusters get-credentials --project="${PROJECT}" --zone="${ZONE}" "${CLUSTER}"
     authed="true"


### PR DESCRIPTION
Currently create-build-cluster.sh will fail after the cluster is made, due to not being able to authenticate with the cluster correctly. 