### PR TITLE
fix error shadowing in `sinker` integration test

### DIFF
--- a/test/integration/test/sinker_test.go
+++ b/test/integration/test/sinker_test.go
@@ -287,7 +287,7 @@ func TestDeletePod(t *testing.T) {
 			var scheduled_for_deletion bool
 			_ = wait.PollUntilContextTimeout(ctx, time.Second, 1*time.Minute, true, func(ctx context.Context) (bool, error) {
 				pods := &corev1.PodList{}
-				err := kubeClient.List(ctx, pods, ctrlruntimeclient.InNamespace(testpodNamespace))
+				err = kubeClient.List(ctx, pods, ctrlruntimeclient.InNamespace(testpodNamespace))
 				if err != nil {
 					return false, err
 				}


### PR DESCRIPTION
Follows up on https://github.com/kubernetes-sigs/prow/pull/383 to not shadow the `err` var so that the test will properly fail when it should