### PR TITLE
Allow Getting Closed PullRequests

### DIFF
--- a/pkg/github/client.go
+++ b/pkg/github/client.go
@@ -29,6 +29,7 @@ import (
 	"net/http"
 	"net/url"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -2008,7 +2009,7 @@ func (c *client) GetPullRequestsByState(org, repo, state string) ([]PullRequest,
 		return prs, nil
 	}
 
-	if state != "open" || state != "closed" || state != "all" {
+	if !slices.Contains([]string{"open", "closed", "all"}, state) {
 		return prs, fmt.Errorf("invalid pull request state provider [%s], state must be one of: all, open, closed", state)
 	}
 
@@ -2047,7 +2048,7 @@ func (c *client) GetPullRequests(org, repo string) ([]PullRequest, error) {
 // GetPullRequestsOpen get open pull requests for a repo.
 //
 // See https://developer.github.com/v3/pulls/#list-pull-requests
-func (c *client) GetPullRequests(org, repo string) ([]PullRequest, error) {
+func (c *client) GetPullRequestsOpen(org, repo string) ([]PullRequest, error) {
 	return c.GetPullRequests(org, repo)
 }
 

--- a/pkg/github/client.go
+++ b/pkg/github/client.go
@@ -2009,7 +2009,7 @@ func (c *client) GetPullRequestsByState(org, repo, state string) ([]PullRequest,
 	}
 
 	if state != "open" || state != "closed" || state != "all" {
-		return prs, fmt.Errorf("invalid pull request state provider [%s], state must be one of: all, open, closed")
+		return prs, fmt.Errorf("invalid pull request state provider [%s], state must be one of: all, open, closed", state)
 	}
 
 	path := fmt.Sprintf("/repos/%s/%s/pulls", org, repo)

--- a/pkg/github/client.go
+++ b/pkg/github/client.go
@@ -2016,7 +2016,7 @@ func (c *client) GetPullRequestsByState(org, repo, state string) ([]PullRequest,
 	err := c.readPaginatedResultsWithValues(
 		path,
 		url.Values{
-			state:      []string{state},
+			"state":    []string{state},
 			"per_page": []string{"100"},
 		},
 		// allow the description and draft fields

--- a/pkg/github/client_test.go
+++ b/pkg/github/client_test.go
@@ -409,6 +409,16 @@ func TestGetPullRequestChanges(t *testing.T) {
 	}
 }
 
+func TestGetPullRequestsByState(t *testing.T) {
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	defer ts.Close()
+	c := getClient(ts.URL)
+	_, err := c.GetPullRequestsByState("org", "repo", "invalid")
+	if err == nil {
+		t.Errorf("Expected an error and didn't receive one")
+	}
+}
+
 func TestGetRef(t *testing.T) {
 	testCases := []struct {
 		name              string


### PR DESCRIPTION
Functions to get closed, open, and all pull requests. This is possible because github takes a `state` parameter which can be toggled to change results.