### PR TITLE
PR comment for empty aliases, handle other cases.

### DIFF
--- a/pkg/plugins/verify-owners/verify-owners.go
+++ b/pkg/plugins/verify-owners/verify-owners.go
@@ -276,6 +276,22 @@ func handle(ghc githubClient, gc git.ClientFactory, roc repoownersClient, log *l
 		return err
 	}
 
+	// Check if OWNERS_ALIASES has empty aliases, then add a warning comment
+	// suggesting users to not have empty aliases.
+	if len(repoAliases) > 0 {
+		numberOfEmptyAliases := 0
+		for _, owners := range repoAliases {
+			if len(owners) == 0 {
+				numberOfEmptyAliases++
+			}
+		}
+		if numberOfEmptyAliases > 0 {
+			if err := ghc.CreateComment(org, repo, number, "There are empty aliases in OWNER_ALIASES, cleanup is advised."); err != nil {
+				return err
+			}
+		}
+	}
+
 	// Check if OWNERS files have the correct config and if they do,
 	// check if all newly added owners are trusted users.
 	oc, err := roc.LoadRepoOwners(org, repo, pr.Base.Ref)

--- a/pkg/repoowners/repoowners_test.go
+++ b/pkg/repoowners/repoowners_test.go
@@ -1427,3 +1427,105 @@ func TestRepoOwners_AllReviewers(t *testing.T) {
 		t.Errorf("Expected reviewers: %v\tFound reviewers: %v ", expectedReviewers, sets.List(foundReviewers))
 	}
 }
+
+func TestParseAliasesConfig(t *testing.T) {
+	tests := []struct {
+		name              string
+		input             string
+		expected          RepoAliases
+		wantErr           bool
+		errContainsRegexp string
+	}{
+		{
+			name: "valid aliases",
+			input: `
+aliases:
+  team1:
+    - alice
+    - bob
+  team2:
+    - nikhilnishad
+`,
+			expected: RepoAliases{
+				"team1": sets.New[string]("alice", "bob"),
+				"team2": sets.New[string]("nikhilnishad"),
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid aliases in flow style mapping syntax",
+			input: `
+aliases:
+  team1: {alice, bob}
+`,
+			expected: RepoAliases{
+				"team1": sets.New[string]("alice", "bob"),
+			},
+			wantErr: false,
+		},
+		{
+			name: "empty alias group with braces",
+			input: `
+aliases:
+  empty-alias-group-with-braces: {}
+`,
+			expected: RepoAliases{
+				"empty-alias-group-with-braces": sets.New[string](),
+			},
+			wantErr: false,
+		},
+		{
+			name: "empty alias group",
+			input: `
+aliases:
+  empty-alias-group:
+`,
+			expected: RepoAliases{
+				"empty-alias-group": sets.New[string](),
+			},
+			wantErr: false,
+		},
+		{
+			name: "incorrect indentation in alias groups",
+			input: `
+aliases:
+  alias-group-1:
+    - user1
+    alias-group-2:
+    - user2
+`,
+			expected:          RepoAliases{},
+			wantErr:           true,
+			errContainsRegexp: "error converting YAML",
+		},
+		{
+			name: "incorrect representation of alias group list",
+			input: `
+aliases:
+  alias-group-1: ""
+`,
+			expected:          RepoAliases{},
+			wantErr:           true,
+			errContainsRegexp: "must contain a list of members",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseAliasesConfig([]byte(tt.input))
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ParseAliasesConfig() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if err != nil {
+				matched, _ := regexp.MatchString(tt.errContainsRegexp, err.Error())
+				if !matched {
+					t.Errorf("ParseAliasesConfig() error = %v, expected to contain %v", err, tt.errContainsRegexp)
+				}
+			}
+			if !reflect.DeepEqual(got, tt.expected) {
+				t.Errorf("ParseAliasesConfig() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #360

Handle cases as discussed in the issue. Add a PR comment for cases where aliases are empty instead of throwing errors. This is because lot of existing users have empty aliases and their approvals were broken.