### PR TITLE
(spyglass) allow configuration of sandbox permissions per lense - try 2

### DIFF
--- a/cmd/checkconfig/testdata/combined.yaml
+++ b/cmd/checkconfig/testdata/combined.yaml
@@ -23,6 +23,10 @@ deck:
           - (FAIL|Failure \[)\b
           - panic\b
           - ^E\d{4} \d\d:\d\d:\d\d\.\d\d\d]
+          iframe_sandbox_permissions:
+          - allow-scripts
+          - allow-popups
+          - allow-popups-to-escape-sandbox
       required_files:
       - build-log.txt
     - lens:

--- a/cmd/deck/main.go
+++ b/cmd/deck/main.go
@@ -1671,6 +1671,11 @@ func defaultLensRemoteConfig(lfc *config.LensFileConfig) error {
 		lfc.RemoteConfig.HideTitle = &hideTitle
 	}
 
+	if lfc.RemoteConfig.IframeSandboxPermissions == nil {
+		permissions := lens.Config().IframeSandboxPermissions
+		lfc.RemoteConfig.IframeSandboxPermissions = &permissions
+	}
+
 	return nil
 }
 

--- a/cmd/deck/main_test.go
+++ b/cmd/deck/main_test.go
@@ -979,6 +979,9 @@ func verifyCfgHasRemoteForLens(lensName string) func(*config.Config, error) erro
 			if lens.RemoteConfig.HideTitle == nil {
 				return errors.New("expected HideTitle to be set")
 			}
+			if lens.RemoteConfig.IframeSandboxPermissions == nil {
+				return errors.New("expected IFrameSandboxPermissions to be set")
+			}
 		}
 
 		if !found {
@@ -988,6 +991,11 @@ func verifyCfgHasRemoteForLens(lensName string) func(*config.Config, error) erro
 		return nil
 	}
 
+}
+
+// TODO norrs: catch https://github.com/kubernetes-sigs/prow/issues/369
+func TestSpyglassConfigNorrsCreatesDefaultIframeSandboxPermissions(t *testing.T) {
+	t.Fatalf("unfinished test")
 }
 
 func TestSpyglassConfigDefaulting(t *testing.T) {

--- a/cmd/deck/template/spyglass.html
+++ b/cmd/deck/template/spyglass.html
@@ -43,7 +43,7 @@
     <div class="mdl-card__title lens-title"><h3 class="mdl-card__title-text">{{$config.Title}}</h3></div>
     <div id="{{$config.Name}}-view-container" class="lens-view-content mdl-card__supporting-text">
       <img src="/static/kubernetes-wheel.svg?v={{deckVersion}}" alt="loading spinner" class="loading-spinner is-active lens-card-loading" id="{{$config.Name}}-loading">
-      <iframe class="lens-container" style="visibility: hidden;" id="iframe-{{$index}}" sandbox="allow-scripts allow-top-navigation allow-popups allow-same-origin" data-lens-index="{{$index}}" data-lens-name="{{$config.Name}}"{{if $config.HideTitle}} data-hide-title="true"{{end}}></iframe>
+      <iframe class="lens-container" style="visibility: hidden;" id="iframe-{{$index}}" sandbox="{{$config.IframeSandboxPermissions}}" data-lens-index="{{$index}}" data-lens-name="{{$config.Name}}"{{if $config.HideTitle}} data-hide-title="true"{{end}}></iframe>
     </div>
   </div>
   {{end}}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1135,6 +1135,8 @@ type LensRemoteConfig struct {
 	Priority *uint `json:"priority"`
 	// HideTitle defines if we will keep showing the title after lens loads.
 	HideTitle *bool `json:"hide_title"`
+	// Iframe sandbox permissions to be configured for the lens's iframe.
+	IframeSandboxPermissions *[]string `json:"iframe_sandbox_permissions"`
 }
 
 // Spyglass holds config for Spyglass.

--- a/pkg/spyglass/lenses/buildlog/lens.go
+++ b/pkg/spyglass/lenses/buildlog/lens.go
@@ -84,9 +84,10 @@ type Lens struct{}
 // Config returns the lens's configuration.
 func (lens Lens) Config() lenses.LensConfig {
 	return lenses.LensConfig{
-		Name:     name,
-		Title:    title,
-		Priority: priority,
+		Name:                     name,
+		Title:                    title,
+		Priority:                 priority,
+		IframeSandboxPermissions: lenses.DefaultSandboxPermissions,
 	}
 }
 
@@ -99,16 +100,8 @@ func (lens Lens) Header(artifacts []api.Artifact, resourceDir string, config jso
 // It is only used if highlight_regexes is not specified in the lens config.
 var defaultErrRE = regexp.MustCompile(`timed out|ERROR:|(FAIL|Failure \[)\b|panic\b|^E\d{4} \d\d:\d\d:\d\d\.\d\d\d]`)
 
-// defaultSandboxPermissions is the default value for iframe_sandbox_permissions lense config if it is not specified.
-var defaultSandboxPermissions = strings.Join(
-	[]string{
-		"allow-scripts",
-		"allow-top-navigation",
-		"allow-popups",
-		"allow-same-origin",
-	},
-	" ",
-)
+// see defaultSandboxPermissions - this is string version for the html.
+var defaultIframeSandboxPermissionsString = strings.Join(lenses.DefaultSandboxPermissions, " ")
 
 func init() {
 	lenses.RegisterLens(Lens{})
@@ -185,7 +178,7 @@ func getConfig(rawConfig json.RawMessage) parsedConfig {
 	conf := parsedConfig{
 		highlightRegex:           defaultErrRE,
 		showRawLog:               true,
-		IframeSandboxPermissions: defaultSandboxPermissions,
+		IframeSandboxPermissions: defaultIframeSandboxPermissionsString,
 	}
 
 	// No config at all is fine.
@@ -205,7 +198,7 @@ func getConfig(rawConfig json.RawMessage) parsedConfig {
 	conf.showRawLog = !c.HideRawLog
 
 	if c.IframeSandboxPermissions == nil {
-		conf.IframeSandboxPermissions = defaultSandboxPermissions
+		conf.IframeSandboxPermissions = defaultIframeSandboxPermissionsString
 	} else {
 		conf.IframeSandboxPermissions = strings.Join(c.IframeSandboxPermissions, " ")
 	}

--- a/pkg/spyglass/lenses/buildlog/lens.go
+++ b/pkg/spyglass/lenses/buildlog/lens.go
@@ -50,10 +50,11 @@ const (
 var defaultHighlightLineLengthMax = 10000 // Default maximum length of a line worth highlighting
 
 type config struct {
-	HighlightRegexes   []string         `json:"highlight_regexes"`
-	HideRawLog         bool             `json:"hide_raw_log,omitempty"`
-	Highlighter        *highlightConfig `json:"highlighter,omitempty"`
-	HighlightLengthMax *int             `json:"highlight_line_length_max,omitempty"`
+	HighlightRegexes         []string         `json:"highlight_regexes"`
+	HideRawLog               bool             `json:"hide_raw_log,omitempty"`
+	Highlighter              *highlightConfig `json:"highlighter,omitempty"`
+	HighlightLengthMax       *int             `json:"highlight_line_length_max,omitempty"`
+	IframeSandboxPermissions []string         `json:"iframe_sandbox_permissions,omitempty"`
 }
 
 type highlightConfig struct {
@@ -68,10 +69,11 @@ type highlightConfig struct {
 }
 
 type parsedConfig struct {
-	highlightRegex     *regexp.Regexp
-	showRawLog         bool
-	highlighter        *highlightConfig
-	highlightLengthMax int
+	highlightRegex           *regexp.Regexp
+	showRawLog               bool
+	highlighter              *highlightConfig
+	highlightLengthMax       int
+	IframeSandboxPermissions string
 }
 
 var _ api.Lens = Lens{}
@@ -96,6 +98,17 @@ func (lens Lens) Header(artifacts []api.Artifact, resourceDir string, config jso
 // defaultErrRE matches keywords and glog error messages.
 // It is only used if highlight_regexes is not specified in the lens config.
 var defaultErrRE = regexp.MustCompile(`timed out|ERROR:|(FAIL|Failure \[)\b|panic\b|^E\d{4} \d\d:\d\d:\d\d\.\d\d\d]`)
+
+// defaultSandboxPermissions is the default value for iframe_sandbox_permissions lense config if it is not specified.
+var defaultSandboxPermissions = strings.Join(
+	[]string{
+		"allow-scripts",
+		"allow-top-navigation",
+		"allow-popups",
+		"allow-same-origin",
+	},
+	" ",
+)
 
 func init() {
 	lenses.RegisterLens(Lens{})
@@ -170,8 +183,9 @@ type buildLogsView struct {
 
 func getConfig(rawConfig json.RawMessage) parsedConfig {
 	conf := parsedConfig{
-		highlightRegex: defaultErrRE,
-		showRawLog:     true,
+		highlightRegex:           defaultErrRE,
+		showRawLog:               true,
+		IframeSandboxPermissions: defaultSandboxPermissions,
 	}
 
 	// No config at all is fine.
@@ -189,6 +203,13 @@ func getConfig(rawConfig json.RawMessage) parsedConfig {
 		conf.highlighter = nil
 	}
 	conf.showRawLog = !c.HideRawLog
+
+	if c.IframeSandboxPermissions == nil {
+		conf.IframeSandboxPermissions = defaultSandboxPermissions
+	} else {
+		conf.IframeSandboxPermissions = strings.Join(c.IframeSandboxPermissions, " ")
+	}
+
 	if len(c.HighlightRegexes) == 0 {
 		return conf
 	}

--- a/pkg/spyglass/lenses/buildlog/lens_test.go
+++ b/pkg/spyglass/lenses/buildlog/lens_test.go
@@ -34,7 +34,8 @@ import (
 
 func TestGetConfig(t *testing.T) {
 	def := parsedConfig{
-		showRawLog: true,
+		showRawLog:               true,
+		IframeSandboxPermissions: defaultSandboxPermissions,
 	}
 	cases := []struct {
 		name string
@@ -59,6 +60,14 @@ func TestGetConfig(t *testing.T) {
 					Endpoint: "service",
 					Pin:      true,
 				}
+				return d
+			}(),
+		}, {
+			name: "configure iframe sandbox permissions",
+			raw:  `{"iframe_sandbox_permissions": ["allow-scripts", "allow-downloads"]}`,
+			want: func() parsedConfig {
+				d := def
+				d.IframeSandboxPermissions = "allow-scripts allow-downloads"
 				return d
 			}(),
 		},

--- a/pkg/spyglass/lenses/buildlog/lens_test.go
+++ b/pkg/spyglass/lenses/buildlog/lens_test.go
@@ -70,6 +70,14 @@ func TestGetConfig(t *testing.T) {
 				d.IframeSandboxPermissions = "allow-scripts allow-downloads"
 				return d
 			}(),
+		}, {
+			name: "empty iframe sandbox permissions does not return default permissions",
+			raw:  `{"iframe_sandbox_permissions": []}`,
+			want: func() parsedConfig {
+				d := def
+				d.IframeSandboxPermissions = ""
+				return d
+			}(),
 		},
 	}
 

--- a/pkg/spyglass/lenses/buildlog/lens_test.go
+++ b/pkg/spyglass/lenses/buildlog/lens_test.go
@@ -35,7 +35,7 @@ import (
 func TestGetConfig(t *testing.T) {
 	def := parsedConfig{
 		showRawLog:               true,
-		IframeSandboxPermissions: defaultSandboxPermissions,
+		IframeSandboxPermissions: defaultIframeSandboxPermissionsString,
 	}
 	cases := []struct {
 		name string

--- a/pkg/spyglass/lenses/coverage/coverage.go
+++ b/pkg/spyglass/lenses/coverage/coverage.go
@@ -50,9 +50,10 @@ type Lens struct{}
 // Config returns the lens's configuration.
 func (lens Lens) Config() lenses.LensConfig {
 	return lenses.LensConfig{
-		Name:     name,
-		Title:    title,
-		Priority: priority,
+		Name:                     name,
+		Title:                    title,
+		Priority:                 priority,
+		IframeSandboxPermissions: lenses.DefaultSandboxPermissions,
 	}
 }
 

--- a/pkg/spyglass/lenses/html/html.go
+++ b/pkg/spyglass/lenses/html/html.go
@@ -49,10 +49,11 @@ type document struct {
 // Config returns the lens's configuration.
 func (lens Lens) Config() lenses.LensConfig {
 	return lenses.LensConfig{
-		Name:      "html",
-		Title:     "HTML",
-		Priority:  3,
-		HideTitle: true,
+		Name:                     "html",
+		Title:                    "HTML",
+		Priority:                 3,
+		HideTitle:                true,
+		IframeSandboxPermissions: lenses.DefaultSandboxPermissions,
 	}
 }
 

--- a/pkg/spyglass/lenses/junit/lens.go
+++ b/pkg/spyglass/lenses/junit/lens.go
@@ -63,9 +63,10 @@ type JVD struct {
 // Config returns the lens's configuration.
 func (lens Lens) Config() lenses.LensConfig {
 	return lenses.LensConfig{
-		Name:     name,
-		Title:    title,
-		Priority: priority,
+		Name:                     name,
+		Title:                    title,
+		Priority:                 priority,
+		IframeSandboxPermissions: lenses.DefaultSandboxPermissions,
 	}
 }
 

--- a/pkg/spyglass/lenses/lenses.go
+++ b/pkg/spyglass/lenses/lenses.go
@@ -51,6 +51,14 @@ var (
 	ErrContextUnsupported = errors.New("artifact does not support context operations")
 )
 
+// DefaultSandboxPermissions is the default value for iframe_sandbox_permissions lense config if it is not specified
+var DefaultSandboxPermissions = []string{
+	"allow-scripts",
+	"allow-top-navigation",
+	"allow-popups",
+	"allow-same-origin",
+}
+
 type LensConfig struct {
 	// Name is the name of the lens. It must match the package name.
 	Name string
@@ -60,6 +68,8 @@ type LensConfig struct {
 	Priority uint
 	// HideTitle will hide the lens title after loading if set to true.
 	HideTitle bool
+	// Iframe sandbox permissions to be configured for the lens's iframe.
+	IframeSandboxPermissions []string
 }
 
 // Lens defines the interface that lenses are required to implement in order to be used by Spyglass.

--- a/pkg/spyglass/lenses/links/links.go
+++ b/pkg/spyglass/lenses/links/links.go
@@ -53,9 +53,10 @@ type Lens struct{}
 // Config returns the lens's configuration.
 func (lens Lens) Config() lenses.LensConfig {
 	return lenses.LensConfig{
-		Name:     name,
-		Title:    title,
-		Priority: priority,
+		Name:                     name,
+		Title:                    title,
+		Priority:                 priority,
+		IframeSandboxPermissions: lenses.DefaultSandboxPermissions,
 	}
 }
 

--- a/pkg/spyglass/lenses/metadata/lens.go
+++ b/pkg/spyglass/lenses/metadata/lens.go
@@ -56,10 +56,11 @@ func init() {
 // Config returns the lens's configuration.
 func (lens Lens) Config() lenses.LensConfig {
 	return lenses.LensConfig{
-		Title:     title,
-		Name:      name,
-		Priority:  priority,
-		HideTitle: true,
+		Title:                    title,
+		Name:                     name,
+		Priority:                 priority,
+		HideTitle:                true,
+		IframeSandboxPermissions: lenses.DefaultSandboxPermissions,
 	}
 }
 

--- a/pkg/spyglass/lenses/podinfo/podinfo.go
+++ b/pkg/spyglass/lenses/podinfo/podinfo.go
@@ -66,9 +66,10 @@ type Lens struct{}
 // Config returns the lens's configuration.
 func (lens Lens) Config() lenses.LensConfig {
 	return lenses.LensConfig{
-		Name:     name,
-		Title:    title,
-		Priority: priority,
+		Name:                     name,
+		Title:                    title,
+		Priority:                 priority,
+		IframeSandboxPermissions: lenses.DefaultSandboxPermissions,
 	}
 }
 

--- a/pkg/spyglass/lenses/restcoverage/restcoverage.go
+++ b/pkg/spyglass/lenses/restcoverage/restcoverage.go
@@ -91,9 +91,10 @@ func init() {
 // Config returns the lens's configuration.
 func (lens Lens) Config() lenses.LensConfig {
 	return lenses.LensConfig{
-		Title:    "REST API coverage report",
-		Name:     "restcoverage",
-		Priority: 0,
+		Title:                    "REST API coverage report",
+		Name:                     "restcoverage",
+		Priority:                 0,
+		IframeSandboxPermissions: lenses.DefaultSandboxPermissions,
 	}
 }
 

--- a/pkg/spyglass/spyglass.go
+++ b/pkg/spyglass/spyglass.go
@@ -169,6 +169,12 @@ func getLensConfig(lensFileConfig config.LensFileConfig) (LensConfig, error) {
 		if lensFileConfig.RemoteConfig.HideTitle != nil {
 			lc.HideTitle = *lensFileConfig.RemoteConfig.HideTitle
 		}
+		if lensFileConfig.RemoteConfig.IframeSandboxPermissions != nil {
+			lc.IframeSandboxPermissions = *lensFileConfig.RemoteConfig.IframeSandboxPermissions
+		} else {
+			// we do not want to break existing remote config which doesn't have iframeSandboxPermissions set.
+			lc.IframeSandboxPermissions = lenses.DefaultSandboxPermissions
+		}
 		return lensConfigWrapper{lc}, nil
 	}
 	return nil, fmt.Errorf("could not find lens")


### PR DESCRIPTION
WIP: This is a try 2 after this caused things to go boooom ( https://github.com/kubernetes-sigs/prow/pull/371 , https://github.com/kubernetes-sigs/prow/issues/369 ) and natural follow up for https://github.com/kubernetes-sigs/prow/pull/296/files 

This is not ready for review, just leaving it as draft to not loose track of it. Force-pushes will appear in branch.. 