### PR TITLE
Additional func to retrieve default branch of an org/repo

### DIFF
--- a/cmd/generic-autobumper/bumper/bumper.go
+++ b/cmd/generic-autobumper/bumper/bumper.go
@@ -681,6 +681,23 @@ func getLastBumpCommit(gerritAuthor, commitTag string) (string, error) {
 	return outBuf.String(), nil
 }
 
+type GithubClient interface {
+	GetRepo(ctx context.Context, org, repo string) (*github.Repo, error)
+}
+
+// getDefaultBranch retrieves the default branch name of a given repository
+// using the provided GitHub client. It fetches the repository details and
+// extracts the default branch. It returns a string representing the default
+// branch name and error if the repository details cannot be retrieved.
+func getDefaultBranch(gc GithubClient, org, repo string) (string, error) {
+	ctx := context.Background()
+	repository, err := gc.GetRepo(ctx, org, repo)
+	if err != nil {
+		return "", fmt.Errorf("failed to get repository details for %s/%s: %w", org, repo, err)
+	}
+	return repository.DefaultBranch, nil
+}
+
 // getChangeId generates a change ID for the gerrit PR that is deterministic
 // rather than being random as is normally preferable.
 // In particular this chooses a change ID by hashing the last commit by the

--- a/cmd/generic-autobumper/bumper/bumper_test.go
+++ b/cmd/generic-autobumper/bumper/bumper_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package bumper
 
 import (
+	"context"
+	"errors"
 	"os"
 	"path"
 	"path/filepath"
@@ -24,6 +26,7 @@ import (
 	"testing"
 
 	"sigs.k8s.io/prow/pkg/config/secret"
+	"sigs.k8s.io/prow/pkg/github"
 )
 
 func TestValidateOptions(t *testing.T) {
@@ -333,6 +336,61 @@ func TestCDToRootDir(t *testing.T) {
 				if !strings.HasSuffix(afterDir, tc.expectedResDir) {
 					t.Errorf("Expected to switch to %q but was switched to: %q", tc.expectedResDir, afterDir)
 				}
+			}
+		})
+	}
+}
+
+type fakedGithubClient struct {
+	repo *github.Repo
+	err  error
+}
+
+func (f *fakedGithubClient) GetRepo(ctx context.Context, org, repo string) (*github.Repo, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.repo, nil
+}
+
+func TestGetDefaultBranch(t *testing.T) {
+	testCases := []struct {
+		name           string
+		client         GithubClient
+		org            string
+		repo           string
+		expectedBranch string
+		expectedError  bool
+	}{
+		{
+			name: "Successful retrieval",
+			client: &fakedGithubClient{
+				repo: &github.Repo{DefaultBranch: "main"},
+			},
+			org:            "test-org",
+			repo:           "test-repo",
+			expectedBranch: "main",
+			expectedError:  false,
+		},
+		{
+			name: "Github API failure",
+			client: &fakedGithubClient{
+				err: errors.New("Github API error"),
+			},
+			org:           "test-org",
+			repo:          "test-repo",
+			expectedError: true,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			branch, err := getDefaultBranch(tc.client, tc.org, tc.repo)
+			if tc.expectedError && err == nil {
+				t.Errorf("Expected to get an error but the result is nil")
+			} else if !tc.expectedError && err != nil {
+				t.Errorf("Expected to not get an error but got one: %v", err)
+			} else if branch != tc.expectedBranch {
+				t.Errorf("Expected branch %q, but got %q", tc.expectedBranch, branch)
 			}
 		})
 	}


### PR DESCRIPTION
Changes:

- Added a new getDefaultBranch function to fetch a repo's default branch via Github client
- Introduced a simple GithubClient interface for easier testing
- Added unit tests to cover both success and error cases.