### PR TITLE
Update label assignments in OWNERS files to labels migrated from k/test-infra

### DIFF
--- a/cmd/branchprotector/OWNERS
+++ b/cmd/branchprotector/OWNERS
@@ -1,4 +1,4 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 labels:
- - area/prow/branchprotector
+ - area/branchprotector

--- a/cmd/clonerefs/OWNERS
+++ b/cmd/clonerefs/OWNERS
@@ -5,5 +5,4 @@ reviewers:
 approvers:
 - stevekuznetsov
 labels:
- - area/prow/clonerefs
- - area/prow/pod-utilities
+ - area/podutils/clonerefs

--- a/cmd/config-bootstrapper/OWNERS
+++ b/cmd/config-bootstrapper/OWNERS
@@ -6,5 +6,3 @@ reviewers:
 approvers:
 - chases2
 - stevekuznetsov
-labels:
- - area/prow/config-bootstrapper

--- a/cmd/crier/OWNERS
+++ b/cmd/crier/OWNERS
@@ -8,4 +8,4 @@ emeritus_approvers:
 - fejta
 - krzyzacy
 labels:
-- area/prow/crier
+- area/crier

--- a/cmd/deck/OWNERS
+++ b/cmd/deck/OWNERS
@@ -10,4 +10,4 @@ emeritus_approvers:
 - Katharine
 - mpherman2
 labels:
- - area/prow/deck
+ - area/deck

--- a/cmd/entrypoint/OWNERS
+++ b/cmd/entrypoint/OWNERS
@@ -5,5 +5,4 @@ reviewers:
 approvers:
 - stevekuznetsov
 labels:
- - area/prow/entrypoint
- - area/prow/pod-utilities
+ - area/podutils/entrypoint

--- a/cmd/gangway/OWNERS
+++ b/cmd/gangway/OWNERS
@@ -1,4 +1,4 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 labels:
- - area/prow/phony
+ - area/gangway

--- a/cmd/gcsupload/OWNERS
+++ b/cmd/gcsupload/OWNERS
@@ -5,5 +5,4 @@ reviewers:
 approvers:
 - stevekuznetsov
 labels:
- - area/prow/gcsupload
- - area/prow/pod-utilities
+ - area/podutils/gcsupload

--- a/cmd/generic-autobumper/OWNERS
+++ b/cmd/generic-autobumper/OWNERS
@@ -5,4 +5,4 @@ emeritus_approvers:
 - chaodaiG
 - mpherman2
 labels:
- - area/prow/hook
+ - area/hook

--- a/cmd/gerrit/OWNERS
+++ b/cmd/gerrit/OWNERS
@@ -10,4 +10,4 @@ emeritus_approvers:
 - fejta
 - krzyzacy
 labels:
-- area/prow/gerrit
+- area/gerrit

--- a/cmd/hmac/OWNERS
+++ b/cmd/hmac/OWNERS
@@ -1,4 +1,4 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 labels:
- - area/prow/hook
+ - area/hook

--- a/cmd/hook/OWNERS
+++ b/cmd/hook/OWNERS
@@ -5,4 +5,4 @@ reviewers:
 approvers:
 - cjwagner
 labels:
- - area/prow/hook
+ - area/hook

--- a/cmd/horologium/OWNERS
+++ b/cmd/horologium/OWNERS
@@ -8,4 +8,4 @@ emeritus_approvers:
 - chaodaiG
 - fejta
 labels:
-- area/prow/horologium
+- area/horologium

--- a/cmd/initupload/OWNERS
+++ b/cmd/initupload/OWNERS
@@ -5,5 +5,4 @@ reviewers:
 approvers:
 - stevekuznetsov
 labels:
- - area/prow/initupload
- - area/prow/pod-utilities
+ - area/podutils/initupload

--- a/cmd/jenkins-operator/OWNERS
+++ b/cmd/jenkins-operator/OWNERS
@@ -1,4 +1,4 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 labels:
- - area/prow/jenkins-operator
+ - area/jenkins-operator

--- a/cmd/mkpod/OWNERS
+++ b/cmd/mkpod/OWNERS
@@ -4,5 +4,3 @@ reviewers:
 - stevekuznetsov
 approvers:
 - stevekuznetsov
-labels:
- - area/prow/mkpod

--- a/cmd/moonraker/OWNERS
+++ b/cmd/moonraker/OWNERS
@@ -1,4 +1,4 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 labels:
- - area/prow/mkpj
+ - area/moonraker

--- a/cmd/peribolos/OWNERS
+++ b/cmd/peribolos/OWNERS
@@ -13,4 +13,4 @@ approvers:
 - nikhita
 - Priyankasaggu11929
 labels:
- - area/prow/peribolos
+ - area/peribolos

--- a/cmd/prow-controller-manager/OWNERS
+++ b/cmd/prow-controller-manager/OWNERS
@@ -7,4 +7,4 @@ approvers:
 emeritus_approvers:
 - chaodaiG
 labels:
- - area/prow/plank
+ - area/prowcm

--- a/cmd/sidecar/OWNERS
+++ b/cmd/sidecar/OWNERS
@@ -5,5 +5,4 @@ reviewers:
 approvers:
 - stevekuznetsov
 labels:
- - area/prow/sidecar
- - area/prow/pod-utilities
+ - area/podutils/sidecar

--- a/cmd/sinker/OWNERS
+++ b/cmd/sinker/OWNERS
@@ -1,4 +1,4 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 labels:
- - area/prow/sinker
+ - area/sinker

--- a/cmd/status-reconciler/OWNERS
+++ b/cmd/status-reconciler/OWNERS
@@ -5,4 +5,4 @@ reviewers:
 approvers:
 - stevekuznetsov
 labels:
- - area/prow/status-reconciler
+ - area/status-reconciler

--- a/cmd/sub/OWNERS
+++ b/cmd/sub/OWNERS
@@ -9,4 +9,4 @@ emeritus_approvers:
 - listx
 - sebastienvas
 labels:
-- area/prow/pubsub
+- area/pubsub

--- a/cmd/tide/OWNERS
+++ b/cmd/tide/OWNERS
@@ -7,4 +7,4 @@ approvers:
 emeritus_approvers:
 - chaodaiG
 labels:
- - area/prow/tide
+ - area/tide

--- a/pkg/clonerefs/OWNERS
+++ b/pkg/clonerefs/OWNERS
@@ -5,5 +5,4 @@ reviewers:
 approvers:
 - stevekuznetsov
 labels:
- - area/prow/clonerefs
- - area/prow/pod-utilities
+ - area/podutils/clonerefs

--- a/pkg/crier/OWNERS
+++ b/pkg/crier/OWNERS
@@ -9,4 +9,4 @@ emeritus_approvers:
 - krzyzacy
 - Katharine
 labels:
-- area/prow/crier
+- area/crier

--- a/pkg/deck/OWNERS
+++ b/pkg/deck/OWNERS
@@ -9,4 +9,4 @@ emeritus_approvers:
 - chaodaiG
 - mpherman2
 labels:
- - area/prow/deck
+ - area/deck

--- a/pkg/entrypoint/OWNERS
+++ b/pkg/entrypoint/OWNERS
@@ -5,5 +5,4 @@ reviewers:
 approvers:
 - stevekuznetsov
 labels:
- - area/prow/entrypoint
- - area/prow/pod-utilities
+ - area/podutils/entrypoint

--- a/pkg/gangway/OWNERS
+++ b/pkg/gangway/OWNERS
@@ -1,4 +1,4 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 labels:
- - area/prow/tot
+ - area/gangway

--- a/pkg/gcsupload/OWNERS
+++ b/pkg/gcsupload/OWNERS
@@ -5,5 +5,4 @@ reviewers:
 approvers:
 - stevekuznetsov
 labels:
- - area/prow/gcsupload
- - area/prow/pod-utilities
+ - area/podutils/gcsupload

--- a/pkg/gerrit/OWNERS
+++ b/pkg/gerrit/OWNERS
@@ -9,4 +9,4 @@ emeritus_approvers:
 - fejta
 - Katharine
 labels:
-- area/prow/gerrit
+- area/gerrit

--- a/pkg/hook/OWNERS
+++ b/pkg/hook/OWNERS
@@ -5,4 +5,4 @@ reviewers:
 approvers:
 - cjwagner
 labels:
- - area/prow/hook
+ - area/hook

--- a/pkg/initupload/OWNERS
+++ b/pkg/initupload/OWNERS
@@ -5,5 +5,4 @@ reviewers:
 approvers:
 - stevekuznetsov
 labels:
- - area/prow/initupload
- - area/prow/pod-utilities
+ - area/podutils/initupload

--- a/pkg/jenkins/OWNERS
+++ b/pkg/jenkins/OWNERS
@@ -1,4 +1,4 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 labels:
- - area/prow/jenkins-operator
+ - area/jenkins-operator

--- a/pkg/moonraker/OWNERS
+++ b/pkg/moonraker/OWNERS
@@ -1,4 +1,4 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 labels:
- - area/prow/phony
+ - area/moonraker

--- a/pkg/plank/OWNERS
+++ b/pkg/plank/OWNERS
@@ -6,5 +6,3 @@ approvers:
 - cjwagner
 emeritus_approvers:
 - chaodaiG
-labels:
- - area/prow/plank

--- a/pkg/plugins/OWNERS
+++ b/pkg/plugins/OWNERS
@@ -12,4 +12,4 @@ required_reviewers:
 approvers:
 - cjwagner
 labels:
-  - area/prow/plugins
+  - area/plugins

--- a/pkg/pod-utils/OWNERS
+++ b/pkg/pod-utils/OWNERS
@@ -8,4 +8,4 @@ approvers:
 - stevekuznetsov
 
 labels:
- - area/prow/pod-utilities
+ - area/pod-utilities

--- a/pkg/pubsub/OWNERS
+++ b/pkg/pubsub/OWNERS
@@ -10,4 +10,4 @@ emeritus_approvers:
 - sebastienvas
 - yutongz
 labels:
-- area/prow/pubsub
+- area/pubsub

--- a/pkg/sidecar/OWNERS
+++ b/pkg/sidecar/OWNERS
@@ -5,5 +5,4 @@ reviewers:
 approvers:
 - stevekuznetsov
 labels:
- - area/prow/sidecar
- - area/prow/pod-utilities
+ - area/podutils/sidecar

--- a/pkg/spyglass/OWNERS
+++ b/pkg/spyglass/OWNERS
@@ -12,4 +12,4 @@ emeritus_approvers:
 - mpherman2
 - paulangton
 labels:
- - area/prow/spyglass
+ - area/spyglass

--- a/pkg/statusreconciler/OWNERS
+++ b/pkg/statusreconciler/OWNERS
@@ -5,4 +5,4 @@ reviewers:
 approvers:
 - stevekuznetsov
 labels:
- - area/prow/status-reconciler
+ - area/status-reconciler

--- a/pkg/tide/OWNERS
+++ b/pkg/tide/OWNERS
@@ -7,4 +7,4 @@ approvers:
 emeritus_approvers:
 - chaodaiG
 labels:
- - area/prow/tide
+ - area/tide


### PR DESCRIPTION
This will match the labels movement that happened on https://github.com/kubernetes/test-infra/pull/34479

Also, created OWNERS for `gangway` and `moonraker`.