### PR TITLE
Consolidate revival logic in case pod is in an unknown, evicted or unreachable state, limit the number of revivals to 3

### DIFF
--- a/config/prow/cluster/prowjob-crd/prowjob_customresourcedefinition.yaml
+++ b/config/prow/cluster/prowjob-crd/prowjob_customresourcedefinition.yaml
@@ -9788,6 +9788,10 @@ spec:
                   PrevReportStates stores the previous reported prowjob state per reporter
                   So crier won't make duplicated report attempt
                 type: object
+              revivalCount:
+                description: Amount of times the Pod was revived from an unexpected
+                  stop.
+                type: integer
               startTime:
                 description: StartTime is equal to the creation time of the ProwJob
                 format: date-time

--- a/config/prow/cluster/prowjob-crd/prowjob_customresourcedefinition.yaml
+++ b/config/prow/cluster/prowjob-crd/prowjob_customresourcedefinition.yaml
@@ -9780,6 +9780,12 @@ spec:
                   plank. This field should always be the same as
                   the ProwJob.ObjectMeta.Name field.
                 type: string
+              pod_revival_count:
+                description: |-
+                  PodRevivalCount applies only to ProwJobs fulfilled by
+                  plank. This field shows the amount of times the
+                  Pod was recreated due to an unexpected stop.
+                type: integer
               prev_report_states:
                 additionalProperties:
                   description: ProwJobState specifies whether the job is running
@@ -9788,10 +9794,6 @@ spec:
                   PrevReportStates stores the previous reported prowjob state per reporter
                   So crier won't make duplicated report attempt
                 type: object
-              revivalCount:
-                description: Amount of times the Pod was revived from an unexpected
-                  stop.
-                type: integer
               startTime:
                 description: StartTime is equal to the creation time of the ProwJob
                 format: date-time

--- a/pkg/apis/prowjobs/v1/types.go
+++ b/pkg/apis/prowjobs/v1/types.go
@@ -1098,6 +1098,8 @@ type ProwJobStatus struct {
 	PendingTime *metav1.Time `json:"pendingTime,omitempty"`
 	// CompletionTime is the timestamp for when the job goes to a final state
 	CompletionTime *metav1.Time `json:"completionTime,omitempty"`
+	// Amount of times the Pod was revived from an unexpected stop.
+	RevivalCount int `json:"revivalCount,omitempty"`
 	// +kubebuilder:validation:Enum=scheduling;triggered;pending;success;failure;aborted;error
 	// +kubebuilder:validation:Required
 	State       ProwJobState `json:"state,omitempty"`

--- a/pkg/apis/prowjobs/v1/types.go
+++ b/pkg/apis/prowjobs/v1/types.go
@@ -1098,14 +1098,16 @@ type ProwJobStatus struct {
 	PendingTime *metav1.Time `json:"pendingTime,omitempty"`
 	// CompletionTime is the timestamp for when the job goes to a final state
 	CompletionTime *metav1.Time `json:"completionTime,omitempty"`
-	// Amount of times the Pod was revived from an unexpected stop.
-	RevivalCount int `json:"revivalCount,omitempty"`
 	// +kubebuilder:validation:Enum=scheduling;triggered;pending;success;failure;aborted;error
 	// +kubebuilder:validation:Required
 	State       ProwJobState `json:"state,omitempty"`
 	Description string       `json:"description,omitempty"`
 	URL         string       `json:"url,omitempty"`
 
+	// PodRevivalCount applies only to ProwJobs fulfilled by
+	// plank. This field shows the amount of times the
+	// Pod was recreated due to an unexpected stop.
+	PodRevivalCount int `json:"pod_revival_count,omitempty"`
 	// PodName applies only to ProwJobs fulfilled by
 	// plank. This field should always be the same as
 	// the ProwJob.ObjectMeta.Name field.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -655,6 +655,12 @@ type Plank struct {
 	// stuck in an unscheduled state. Defaults to 5 minutes.
 	PodUnscheduledTimeout *metav1.Duration `json:"pod_unscheduled_timeout,omitempty"`
 
+	// MaxRevivals is the maximum number of times a prowjob will be retried in case of an
+	// unexpected stop of the job before being marked as failed. Generally a job is stopped
+	// unexpectedly due to the underlying Node being terminated, evicted or becoming unreachable.
+	// Defaults to 3. A value of 0 means no retries.
+	MaxRevivals *int `json:"max_revivals,omitempty"`
+
 	// DefaultDecorationConfigs holds the default decoration config for specific values.
 	//
 	// Each entry in the slice specifies Repo and Cluster regexp filter fields to
@@ -2501,6 +2507,11 @@ func parseProwConfig(c *Config) error {
 
 	if c.Plank.PodUnscheduledTimeout == nil {
 		c.Plank.PodUnscheduledTimeout = &metav1.Duration{Duration: 5 * time.Minute}
+	}
+
+	if c.Plank.MaxRevivals == nil {
+		maxRetries := 3
+		c.Plank.MaxRevivals = &maxRetries
 	}
 
 	if err := c.Gerrit.DefaultAndValidate(); err != nil {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -8426,6 +8426,7 @@ moonraker:
   client_timeout: 10m0s
 plank:
   max_goroutines: 20
+  max_revivals: 3
   pod_pending_timeout: 10m0s
   pod_running_timeout: 48h0m0s
   pod_unscheduled_timeout: 5m0s
@@ -8510,6 +8511,7 @@ moonraker:
   client_timeout: 10m0s
 plank:
   max_goroutines: 20
+  max_revivals: 3
   pod_pending_timeout: 10m0s
   pod_running_timeout: 48h0m0s
   pod_unscheduled_timeout: 5m0s
@@ -8587,6 +8589,7 @@ moonraker:
   client_timeout: 10m0s
 plank:
   max_goroutines: 20
+  max_revivals: 3
   pod_pending_timeout: 10m0s
   pod_running_timeout: 48h0m0s
   pod_unscheduled_timeout: 5m0s
@@ -8669,6 +8672,7 @@ moonraker:
   client_timeout: 10m0s
 plank:
   max_goroutines: 20
+  max_revivals: 3
   pod_pending_timeout: 10m0s
   pod_running_timeout: 48h0m0s
   pod_unscheduled_timeout: 5m0s

--- a/pkg/config/prow-config-documented.yaml
+++ b/pkg/config/prow-config-documented.yaml
@@ -1301,6 +1301,11 @@ plank:
     # JobURLPrefixDisableAppendStorageProvider disables that the storageProvider is
     # automatically appended to the JobURLPrefix.
     jobURLPrefixDisableAppendStorageProvider: true
+    # MaxRevivals is the maximum number of times a prowjob will be retried in case of an
+    # unexpected stop of the job before being marked as failed. Generally a job is stopped
+    # unexpectedly due to the underlying Node being terminated, evicted or becoming unreachable.
+    # Defaults to 3. A value of 0 means no retries.
+    max_revivals: 0
     # PodPendingTimeout defines how long the controller will wait to perform a garbage
     # collection on pending pods. Defaults to 10 minutes.
     pod_pending_timeout: 0s

--- a/pkg/plank/controller_test.go
+++ b/pkg/plank/controller_test.go
@@ -1194,9 +1194,9 @@ func TestSyncPendingJob(t *testing.T) {
 					PodSpec: &v1.PodSpec{Containers: []v1.Container{{Name: "test-name", Env: []v1.EnvVar{}}}},
 				},
 				Status: prowapi.ProwJobStatus{
-					RevivalCount: maxRevivals,
-					State:        prowapi.PendingState,
-					PodName:      "boop-42",
+					PodRevivalCount: maxRevivals,
+					State:           prowapi.PendingState,
+					PodName:         "boop-42",
 				},
 			},
 			Pods: []v1.Pod{

--- a/pkg/plank/controller_test.go
+++ b/pkg/plank/controller_test.go
@@ -65,6 +65,8 @@ const (
 	podDeletionPreventionFinalizer = "keep-from-vanishing"
 )
 
+var maxRevivals = 3
+
 func newFakeConfigAgent(t *testing.T, maxConcurrency int, queueCapacities map[string]int) *fca {
 	presubmits := []config.Presubmit{
 		{
@@ -106,6 +108,7 @@ func newFakeConfigAgent(t *testing.T, maxConcurrency int, queueCapacities map[st
 					PodPendingTimeout:     &metav1.Duration{Duration: podPendingTimeout},
 					PodRunningTimeout:     &metav1.Duration{Duration: podRunningTimeout},
 					PodUnscheduledTimeout: &metav1.Duration{Duration: podUnscheduledTimeout},
+					MaxRevivals:           &maxRevivals,
 				},
 			},
 			JobConfig: config.JobConfig{
@@ -1177,6 +1180,74 @@ func TestSyncPendingJob(t *testing.T) {
 			},
 			ExpectedComplete: true,
 			ExpectedState:    prowapi.ErrorState,
+			ExpectedNumPods:  1,
+			ExpectedURL:      "boop-42/error",
+		},
+		{
+			Name: "don't delete evicted pod w/ revivalCount == maxRevivals, complete PJ instead",
+			PJ: prowapi.ProwJob{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "boop-42",
+					Namespace: "prowjobs",
+				},
+				Spec: prowapi.ProwJobSpec{
+					PodSpec: &v1.PodSpec{Containers: []v1.Container{{Name: "test-name", Env: []v1.EnvVar{}}}},
+				},
+				Status: prowapi.ProwJobStatus{
+					RevivalCount: maxRevivals,
+					State:        prowapi.PendingState,
+					PodName:      "boop-42",
+				},
+			},
+			Pods: []v1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "boop-42",
+						Namespace: "pods",
+					},
+					Status: v1.PodStatus{
+						Phase:  v1.PodFailed,
+						Reason: Evicted,
+					},
+				},
+			},
+			ExpectedComplete: true,
+			ExpectedState:    prowapi.ErrorState,
+			ExpectedNumPods:  1,
+			ExpectedURL:      "boop-42/error",
+		},
+		{
+			// TODO: this test case tests the current behavior, but the behavior
+			// is non-ideal: the pod execution did not fail, instead the node on which
+			// the pod was running terminated
+			Name: "a terminated pod is handled as-if it failed",
+			PJ: prowapi.ProwJob{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "boop-42",
+					Namespace: "prowjobs",
+				},
+				Spec: prowapi.ProwJobSpec{
+					PodSpec: &v1.PodSpec{Containers: []v1.Container{{Name: "test-name", Env: []v1.EnvVar{}}}},
+				},
+				Status: prowapi.ProwJobStatus{
+					State:   prowapi.PendingState,
+					PodName: "boop-42",
+				},
+			},
+			Pods: []v1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "boop-42",
+						Namespace: "pods",
+					},
+					Status: v1.PodStatus{
+						Phase:  v1.PodFailed,
+						Reason: Terminated,
+					},
+				},
+			},
+			ExpectedComplete: true,
+			ExpectedState:    prowapi.FailureState,
 			ExpectedNumPods:  1,
 			ExpectedURL:      "boop-42/error",
 		},

--- a/pkg/plank/reconciler.go
+++ b/pkg/plank/reconciler.go
@@ -477,15 +477,15 @@ func (r *reconciler) syncPendingJob(ctx context.Context, pj *prowv1.ProwJob) (*r
 			pj.SetComplete()
 			pj.Status.State = prowv1.ErrorState
 			pj.Status.Description = "Job pod was evicted by the cluster."
-		case pj.Status.RevivalCount >= *r.config().Plank.MaxRevivals:
+		case pj.Status.PodRevivalCount >= *r.config().Plank.MaxRevivals:
 			// MaxRevivals is reached, complete the PJ and mark it as errored.
 			r.log.WithField("unexpected-stop-cause", podUnexpectedStopCause).WithFields(pjutil.ProwJobFields(pj)).Info("Pod Node reached max retries, fail job.")
 			pj.SetComplete()
 			pj.Status.State = prowv1.ErrorState
-			pj.Status.Description = fmt.Sprintf("Job pod reached max revivals (%d) after being stopped unexpectedly (%s)", pj.Status.RevivalCount, podUnexpectedStopCause)
+			pj.Status.Description = fmt.Sprintf("Job pod reached max revivals (%d) after being stopped unexpectedly (%s)", pj.Status.PodRevivalCount, podUnexpectedStopCause)
 		default:
 			// Update the revival count and delete the pod so it gets recreated in the next resync.
-			pj.Status.RevivalCount++
+			pj.Status.PodRevivalCount++
 			r.log.
 				WithField("unexpected-stop-cause", podUnexpectedStopCause).
 				WithFields(pjutil.ProwJobFields(pj)).


### PR DESCRIPTION
Consolidates the revival logic in `pkg/plank/reconciler.go` and limits the number of times we "revive" to 3 before we fail the prowjob.
Revival happens in case the pod is in an unknown, evicted or unreachable state.

**Future work:** in a follow-up PR, I'll add support for handling pods that are in a terminated state (the node on which the pod was running was shut-down).

REVIEWER NOTE: "revival" might not be a good term, feel free to suggest a different name