### PR TITLE
bug: set state to error on retired context

### DIFF
--- a/pkg/statusreconciler/migrator/migrator.go
+++ b/pkg/statusreconciler/migrator/migrator.go
@@ -130,11 +130,10 @@ func copyAction(origContext, newContext string) func(statuses []github.Status, s
 
 // retireAction creates a function that returns a retire action.
 // Specifically the returned function returns a RepoStatus that will update the origContext status
-// to 'success' and set it's description to mark it as retired and replaced by newContext.
+// to error and set it's description to mark it as retired and replaced by newContext.
 // If a non-empty URL is provided to describe why the context was retired, it will be
 // set as the target URL for the context.
 func retireAction(origContext, newContext, targetURL string) func(statuses []github.Status, sha string) []github.Status {
-	stateSuccess := "success"
 	var desc string
 	if newContext == "" {
 		desc = "Context retired without replacement."
@@ -145,7 +144,7 @@ func retireAction(origContext, newContext, targetURL string) func(statuses []git
 		return []github.Status{
 			{
 				Context:     origContext,
-				State:       stateSuccess,
+				State:       github.StatusError,
 				TargetURL:   targetURL,
 				Description: desc,
 			},


### PR DESCRIPTION
When action set description to `Context retired without replacement.` it also sets status to :heavy_check_mark:  which leads to false assumption that job passed while it was not. Below is the example where required job was failing but prow set it's status to passed causing merge and breaking the master builds. 

The generated comment is correct https://github.com/stackrox/stackrox/pull/14800#issuecomment-2761889050
while  status is not

![image (3)](https://github.com/user-attachments/assets/94a79ab1-d363-4d9b-a656-5b091f7553ad)


Refs:
- https://github.com/stackrox/stackrox/pull/14800
- :red_circle: [stackrox-master-gke-nongroovy-e2e-tests](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/stackrox_stackrox/14800/pull-ci-stackrox-stackrox-master-gke-nongroovy-e2e-tests/1905584438360674304)