### PR TITLE
Support retriggering complex workflows

### DIFF
--- a/pkg/github/client_test.go
+++ b/pkg/github/client_test.go
@@ -388,56 +388,107 @@ func TestGetFailedActionRunsByHeadBranch(t *testing.T) {
 		branch  = "main"
 		headSHA = "123abc"
 	)
-	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodGet {
-			t.Errorf("Expected GET method, got %s", r.Method)
-		}
-		expectedPath := fmt.Sprintf("/repos/%s/%s/actions/runs", org, repo)
-		if r.URL.Path != expectedPath {
-			t.Errorf("Expected path %s, got %s", expectedPath, r.URL.Path)
-		}
-
-		// Check query parameters
-		query := r.URL.Query()
-		if query.Get("status") != "failure" {
-			t.Errorf("Expected query parameter status=failure, got %s", query.Get("status"))
-		}
-		expectedEvent := "pull_request OR pull_request_target OR workflow_call"
-		if query.Get("event") != "pull_request OR pull_request_target OR workflow_call" {
-			t.Errorf("Expected query parameter event=%q, got %q", expectedEvent, query.Get("event"))
-		}
-		if query.Get("branch") != branch {
-			t.Errorf("Expected query parameter branch=%s, got %s", branch, query.Get("branch"))
-		}
-
-		// Prepare a response with two runs, one matching and one not matching headSHA.
-		runs := WorkflowRuns{
-			WorkflowRuns: []WorkflowRun{
-				{HeadSha: headSHA},
-				{HeadSha: "otherSHA"},
+	var (
+		failedRun       = WorkflowRun{HeadSha: headSHA, Status: "completed", Conclusion: "failure"}
+		successfulRun   = WorkflowRun{HeadSha: headSHA, Status: "completed", Conclusion: "success"}
+		secondFailedRun = WorkflowRun{HeadSha: headSHA, Status: "completed", Conclusion: "failure"}
+		cancelledRun    = WorkflowRun{HeadSha: headSHA, Status: "completed", Conclusion: "cancelled"}
+	)
+	testCases := []struct {
+		name string
+		// queryResponse is the response from the GitHub API
+		queryResponse WorkflowRuns
+		// expectedRuns is the expected result after filtering the queryResponse
+		expectedRuns []WorkflowRun
+	}{
+		{
+			name: "single matching run",
+			queryResponse: WorkflowRuns{
+				WorkflowRuns: []WorkflowRun{failedRun},
 			},
-		}
-		b, err := json.Marshal(&runs)
-		if err != nil {
-			t.Fatalf("Unexpected error marshalling JSON: %v", err)
-		}
-		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprint(w, string(b))
-	}))
-	defer ts.Close()
-
-	c := getClient(ts.URL)
-	runs, err := c.GetFailedActionRunsByHeadBranch(org, repo, branch, headSHA)
-	if err != nil {
-		t.Errorf("Did not expect error, got %v", err)
+			expectedRuns: []WorkflowRun{failedRun},
+		},
+		{
+			name: "multiple runs, one matching",
+			queryResponse: WorkflowRuns{
+				WorkflowRuns: []WorkflowRun{failedRun, successfulRun},
+			},
+			expectedRuns: []WorkflowRun{failedRun},
+		},
+		{
+			name: "multiple runs, two matching",
+			queryResponse: WorkflowRuns{
+				WorkflowRuns: []WorkflowRun{failedRun, successfulRun, secondFailedRun},
+			},
+			expectedRuns: []WorkflowRun{failedRun, secondFailedRun},
+		},
+		{
+			name: "cancelled run",
+			queryResponse: WorkflowRuns{
+				WorkflowRuns: []WorkflowRun{cancelledRun},
+			},
+			expectedRuns: []WorkflowRun{cancelledRun},
+		},
 	}
 
-	// Only one run should match the headSHA.
-	if len(runs) != 1 {
-		t.Errorf("Expected 1 workflow run, got %d", len(runs))
-	} else if runs[0].HeadSha != headSHA {
-		t.Errorf("Expected headSha %s, got %s", headSHA, runs[0].HeadSha)
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodGet {
+					t.Errorf("Expected GET method, got %s", r.Method)
+				}
+				expectedPath := fmt.Sprintf("/repos/%s/%s/actions/runs", org, repo)
+				if r.URL.Path != expectedPath {
+					t.Errorf("Expected path %s, got %s", expectedPath, r.URL.Path)
+				}
+
+				// Check query parameters
+				query := r.URL.Query()
+				if query.Get("head_sha") != headSHA {
+					t.Errorf("Expected query parameter head_sha=%s, got %s", headSHA, query.Get("head_sha"))
+				}
+				expectedEvent := "pull_request OR pull_request_target OR workflow_call"
+				if query.Get("event") != "pull_request OR pull_request_target OR workflow_call" {
+					t.Errorf("Expected query parameter event=%q, got %q", expectedEvent, query.Get("event"))
+				}
+				if query.Get("branch") != branch {
+					t.Errorf("Expected query parameter branch=%s, got %s", branch, query.Get("branch"))
+				}
+
+				// Prepare a response based on the test case
+				b, err := json.Marshal(&tc.queryResponse)
+				if err != nil {
+					t.Fatalf("Unexpected error marshalling JSON: %v", err)
+				}
+				w.Header().Set("Content-Type", "application/json")
+				fmt.Fprint(w, string(b))
+			}))
+			defer ts.Close()
+
+			c := getClient(ts.URL)
+			runs, err := c.GetFailedActionRunsByHeadBranch(org, repo, branch, headSHA)
+			if err != nil {
+				t.Errorf("Did not expect error, got %v", err)
+			}
+
+			// Check if the returned runs match the expected runs
+			if len(runs) != len(tc.expectedRuns) {
+				t.Errorf("Expected %d runs, got %d", len(tc.expectedRuns), len(runs))
+			}
+			for _, run := range runs {
+				found := false
+				for _, expectedRun := range tc.expectedRuns {
+					if run.Status == expectedRun.Status && run.Conclusion == expectedRun.Conclusion && run.HeadSha == expectedRun.HeadSha {
+						found = true
+					}
+				}
+				if !found {
+					t.Errorf("Run %v not found in expected result %v", run, tc.expectedRuns)
+				}
+			}
+		})
 	}
+
 }
 
 func TestGetPullRequestChanges(t *testing.T) {


### PR DESCRIPTION
Github workflows consisting of multiple workflows do not show up as "failed" in all cases. Sometimes they are instead "cancelled". Additionally, the "status" query parameter is overloaded and includes both the "status" and "conclusion" field from the response. This makes it hard to use and reason about. On the other hand, there is now a query parameter for the head_sha, that we have so far been handling manually.

This commit changes GetFailedActionRunsByHeadBranch to make use of the head_sha parameter and removes the query for "status==failed". Instead, the returned runs are checked for any that have status == completed and conclusion != success.
A unit test is also added.

Fixes: #417 