### PR TITLE
feat: add ghproxy valkey/redis ACL support

### DIFF
--- a/cmd/ghproxy/ghproxy.go
+++ b/cmd/ghproxy/ghproxy.go
@@ -29,6 +29,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/prow/pkg/config/secret"
 	"sigs.k8s.io/prow/pkg/pjutil/pprof"
 
 	"sigs.k8s.io/prow/pkg/apptokenequalizer"
@@ -93,9 +94,9 @@ type options struct {
 	sizeGB                                 int
 	diskCacheDisableAuthHeaderPartitioning bool
 
-	redisAddress  string
-	redisUsername string
-	redisPassword string
+	redisAddress    string
+	redisUsername   string
+	redisSecretFile string
 
 	port           int
 	upstream       string
@@ -135,6 +136,21 @@ func (o *options) validate() error {
 	if err != nil {
 		return fmt.Errorf("failed to parse upstream URL: %w", err)
 	}
+
+	// If username is provided, password must also be provided
+	if o.redisUsername != "" && o.redisSecretFile == "" {
+		return errors.New("redis username requires a secret file")
+	}
+
+	// If any credentials are provided, redis address must be specified
+	if (o.redisUsername != "" || o.redisSecretFile != "") && o.redisAddress == "" {
+		return errors.New("redis credentials must be specified together with redis address")
+	}
+	// Start the secret agent.
+	if err := secret.Add(o.redisSecretFile); err != nil {
+		logrus.WithError(err).Fatal("Error starting secrets agent.")
+	}
+
 	o.upstreamParsed = upstreamURL
 	return nil
 }
@@ -145,8 +161,8 @@ func flagOptions() *options {
 	flag.IntVar(&o.sizeGB, "cache-sizeGB", 0, "Cache size in GB per unique token if using a disk cache.")
 	flag.BoolVar(&o.diskCacheDisableAuthHeaderPartitioning, "legacy-disable-disk-cache-partitions-by-auth-header", true, "Whether to disable partitioning a disk cache by auth header. Disabling this will start a new cache at $cache_dir/$sha256sum_of_authorization_header for each unique authorization header. Bigger setups are advise to manually warm this up from an existing cache. This option will be removed and set to `false` in the future")
 	flag.StringVar(&o.redisAddress, "redis-address", "", "Redis address if using a redis cache e.g. localhost:6379.")
-	flag.StringVar(&o.redisUsername, "redis-usersname", "", "Redis username")
-	flag.StringVar(&o.redisPassword, "redis-password", "", "Redis password")
+	flag.StringVar(&o.redisUsername, "redis-username", "", "Redis username")
+	flag.StringVar(&o.redisSecretFile, "redis-secret-file", "", "Path to a Redis secrets file")
 	flag.IntVar(&o.port, "port", 8888, "Port to listen on.")
 	flag.StringVar(&o.upstream, "upstream", "https://api.github.com", "Scheme, host, and base path of reverse proxy upstream.")
 	flag.IntVar(&o.maxConcurrency, "concurrency", 25, "Maximum number of concurrent in-flight requests to GitHub.")
@@ -206,7 +222,7 @@ func proxy(o *options, upstreamTransport http.RoundTripper, diskCachePruneInterv
 	var cache http.RoundTripper
 	throttlingTimes := ghcache.NewRequestThrottlingTimes(o.requestThrottlingTime, o.requestThrottlingTimeV4, o.requestThrottlingTimeForGET, o.requestThrottlingMaxDelayTime, o.requestThrottlingMaxDelayTimeV4)
 	if o.redisAddress != "" {
-		cache = ghcache.NewRedisCache(apptokenequalizer.New(upstreamTransport), o.redisAddress, o.redisUsername, o.redisPassword, o.maxConcurrency, throttlingTimes)
+		cache = ghcache.NewRedisCache(apptokenequalizer.New(upstreamTransport), o.redisAddress, o.redisUsername, o.redisSecretFile, o.maxConcurrency, throttlingTimes)
 	} else if o.dir == "" {
 		cache = ghcache.NewMemCache(apptokenequalizer.New(upstreamTransport), o.maxConcurrency, throttlingTimes)
 	} else {

--- a/cmd/ghproxy/ghproxy.go
+++ b/cmd/ghproxy/ghproxy.go
@@ -146,10 +146,6 @@ func (o *options) validate() error {
 	if (o.redisUsername != "" || o.redisSecretFile != "") && o.redisAddress == "" {
 		return errors.New("redis credentials must be specified together with redis address")
 	}
-	// Start the secret agent.
-	if err := secret.Add(o.redisSecretFile); err != nil {
-		logrus.WithError(err).Fatal("Error starting secrets agent.")
-	}
 
 	o.upstreamParsed = upstreamURL
 	return nil
@@ -187,6 +183,12 @@ func main() {
 	flag.Parse()
 	if err := o.validate(); err != nil {
 		logrus.WithError(err).Fatal("Invalid arguments.")
+	}
+
+	if o.redisSecretFile != "" {
+		if err := secret.Add(o.redisSecretFile); err != nil {
+			logrus.WithError(err).Fatal("Error starting secrets agent.")
+		}
 	}
 
 	if o.diskCacheDisableAuthHeaderPartitioning {

--- a/pkg/ghcache/ghcache.go
+++ b/pkg/ghcache/ghcache.go
@@ -49,6 +49,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sync/semaphore"
+	"sigs.k8s.io/prow/pkg/config/secret"
 	"sigs.k8s.io/prow/pkg/github/ghmetrics"
 )
 
@@ -537,17 +538,25 @@ func NewFromCache(roundTripper http.RoundTripper, cache CachePartitionCreator, m
 // Important note: The redis implementation does not support partitioning the cache
 // which means that requests to the same path from different tokens will invalidate
 // each other.
-func NewRedisCache(roundTripper http.RoundTripper, redisAddress string, redisUsername string, redisPassword string, maxConcurrency int, throttlingTimes RequestThrottlingTimes) http.RoundTripper {
+func NewRedisCache(roundTripper http.RoundTripper, redisAddress string, redisUsername string, redisSecretFile string, maxConcurrency int, throttlingTimes RequestThrottlingTimes) http.RoundTripper {
 
 	var conn redis.Conn
 	var err error
+
+	// Build dial options based on provided credentials
+	dialOpts := []redis.DialOption{}
+
 	if redisUsername != "" {
-		conn, err = redis.Dial("tcp", redisAddress, redis.DialUsername(redisUsername), redis.DialPassword(redisPassword))
-	} else if redisPassword != "" {
-		conn, err = redis.Dial("tcp", redisAddress, redis.DialPassword(redisPassword))
-	} else {
-		conn, err = redis.Dial("tcp", redisAddress)
+		dialOpts = append(dialOpts, redis.DialUsername(redisUsername))
 	}
+
+	if redisSecretFile != "" {
+		redisPassword := secret.GetSecret(redisSecretFile)
+		dialOpts = append(dialOpts, redis.DialPassword(string(redisPassword)))
+	}
+
+	// Connect with whatever options were added (could be none)
+	conn, err = redis.Dial("tcp", redisAddress, dialOpts...)
 
 	if err != nil {
 		logrus.WithError(err).Fatal("Error connecting to Redis")

--- a/pkg/ghcache/ghcache.go
+++ b/pkg/ghcache/ghcache.go
@@ -537,8 +537,18 @@ func NewFromCache(roundTripper http.RoundTripper, cache CachePartitionCreator, m
 // Important note: The redis implementation does not support partitioning the cache
 // which means that requests to the same path from different tokens will invalidate
 // each other.
-func NewRedisCache(roundTripper http.RoundTripper, redisAddress string, maxConcurrency int, throttlingTimes RequestThrottlingTimes) http.RoundTripper {
-	conn, err := redis.Dial("tcp", redisAddress)
+func NewRedisCache(roundTripper http.RoundTripper, redisAddress string, redisUsername string, redisPassword string, maxConcurrency int, throttlingTimes RequestThrottlingTimes) http.RoundTripper {
+
+	var conn redis.Conn
+	var err error
+	if redisUsername != "" {
+		conn, err = redis.Dial("tcp", redisAddress, redis.DialUsername(redisUsername), redis.DialPassword(redisPassword))
+	} else if redisPassword != "" {
+		conn, err = redis.Dial("tcp", redisAddress, redis.DialPassword(redisPassword))
+	} else {
+		conn, err = redis.Dial("tcp", redisAddress)
+	}
+
 	if err != nil {
 		logrus.WithError(err).Fatal("Error connecting to Redis")
 	}


### PR DESCRIPTION
add ghproxy support to valkey/redis using ACL (username and password)

when using `--redis-address` the user can pass the username and password if the redis server has auth

New parameters:
`--redis-username=username`
`--redis-password=password`