### PR TITLE
Only set Authorization header if not already set

### DIFF
--- a/pkg/jira/jira.go
+++ b/pkg/jira/jira.go
@@ -21,16 +21,15 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/andygrunwald/go-jira"
+	"github.com/hashicorp/go-retryablehttp"
+	"github.com/sirupsen/logrus"
 	stdio "io"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"net/http"
 	"net/url"
 	"strings"
 	"sync"
-
-	"github.com/andygrunwald/go-jira"
-	"github.com/hashicorp/go-retryablehttp"
-	"github.com/sirupsen/logrus"
-	"k8s.io/apimachinery/pkg/util/sets"
 
 	"sigs.k8s.io/prow/pkg/version"
 )
@@ -623,7 +622,7 @@ func (bart *bearerAuthRoundtripper) RoundTrip(req *http.Request) (*http.Response
 	req2.URL = new(url.URL)
 	*req2.URL = *req.URL
 	token := bart.generator()
-	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", token))
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
 	logrus.WithField("curl", toCurl(req2)).Trace("Executing http request")
 	return bart.upstream.RoundTrip(req2)
 }


### PR DESCRIPTION
I was researching some issues with jira rate limits and observed a behavior that I don't think was intended.  Basically, the  `bearerAuthRoundtripper`'s `RoundTrip()` method appends the `Authentication` header for every retry that it performs.  By default, there can be upto 4 retries performed for every failed call into Jira.  Assuming that every attempt fails, the last command that runs will have 5 `Authorization` headers attached to it...

```
curl -k -v -XGET -H 'Authorization: Bearer <TOKEN>' -H 'Authorization: Bearer <TOKEN>' -H 'Authorization: Bearer <TOKEN>' -H 'Authorization: Bearer <TOKEN>' -H 'Authorization: Bearer <TOKEN>' '<JIRA ENDPOINT>/rest/api/2/issue/<ISSUE>'
```
This PR updates the logic to `Set` the `Authorization` header, which will replace any pre-existing header.