### PR TITLE
fix(pkg/github): skip skipped workflow runs when collecting failed runs

### DIFF
--- a/pkg/github/client.go
+++ b/pkg/github/client.go
@@ -29,6 +29,7 @@ import (
 	"net/http"
 	"net/url"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -2078,10 +2079,11 @@ func (c *client) GetFailedActionRunsByHeadBranch(org, repo, branchName, headSHA 
 	// See https://docs.github.com/en/rest/actions/workflow-runs?apiVersion=2022-11-28#list-workflow-runs-for-a-workflow
 	// This makes it hard to use directly. Instead, we loop through the runs and check them individually.
 	// A successful workflow will have status "completed" and conclusion "success".
+	// A skipped workflow will have status "completed" and conclusion "skipped".
 	// A failed workflow also have status "completed", but the conclusion can be either "failure" or "cancelled".
-	// We only want completed jobs that are not successful.
+	// We only want completed jobs that are not skipped and not successful.
 	for _, run := range runs.WorkflowRuns {
-		if run.Status == "completed" && run.Conclusion != "success" {
+		if run.Status == "completed" && !slices.Contains([]string{"success", "skipped"}, run.Conclusion) {
 			prRuns = append(prRuns, run)
 		}
 	}

--- a/pkg/github/client.go
+++ b/pkg/github/client.go
@@ -376,6 +376,8 @@ func (c *client) WithFields(fields logrus.Fields) Client {
 
 var (
 	teamRe = regexp.MustCompile(`^(.*)/(.*)$`)
+
+	passedWorkflowRunConclusions = []string{"success", "skipped"}
 )
 
 const (
@@ -2083,7 +2085,7 @@ func (c *client) GetFailedActionRunsByHeadBranch(org, repo, branchName, headSHA 
 	// A failed workflow also have status "completed", but the conclusion can be either "failure" or "cancelled".
 	// We only want completed jobs that are not skipped and not successful.
 	for _, run := range runs.WorkflowRuns {
-		if run.Status == "completed" && !slices.Contains([]string{"success", "skipped"}, run.Conclusion) {
+		if run.Status == "completed" && !slices.Contains(passedWorkflowRunConclusions, run.Conclusion) {
 			prRuns = append(prRuns, run)
 		}
 	}

--- a/pkg/github/client_test.go
+++ b/pkg/github/client_test.go
@@ -393,6 +393,7 @@ func TestGetFailedActionRunsByHeadBranch(t *testing.T) {
 		successfulRun   = WorkflowRun{HeadSha: headSHA, Status: "completed", Conclusion: "success"}
 		secondFailedRun = WorkflowRun{HeadSha: headSHA, Status: "completed", Conclusion: "failure"}
 		cancelledRun    = WorkflowRun{HeadSha: headSHA, Status: "completed", Conclusion: "cancelled"}
+		skippedRun      = WorkflowRun{HeadSha: headSHA, Status: "completed", Conclusion: "skipped"}
 	)
 	testCases := []struct {
 		name string
@@ -418,7 +419,7 @@ func TestGetFailedActionRunsByHeadBranch(t *testing.T) {
 		{
 			name: "multiple runs, two matching",
 			queryResponse: WorkflowRuns{
-				WorkflowRuns: []WorkflowRun{failedRun, successfulRun, secondFailedRun},
+				WorkflowRuns: []WorkflowRun{failedRun, successfulRun, secondFailedRun, skippedRun},
 			},
 			expectedRuns: []WorkflowRun{failedRun, secondFailedRun},
 		},


### PR DESCRIPTION
This pull request updates the logic for filtering GitHub workflow runs and includes a minor import addition to support the changes. The primary goal is to refine the selection criteria for completed jobs by excluding both "skipped" and "successful" runs.

### Logic updates for filtering workflow runs:
* Updated the filtering condition in `GetFailedActionRunsByHeadBranch` to exclude runs with the conclusion "skipped" in addition to "success". This ensures that skipped workflows are no longer considered as failed runs. (`pkg/github/client.go`, [pkg/github/client.goR2082-R2086](diffhunk://#diff-2bb9ccd2fcbbcfd99cb8e400704ea77cc80dbf62f5982b1f6ed1a0966ac42ae5R2082-R2086))

### Codebase enhancements:
* Added the `slices` package to the import list to leverage its utility functions, specifically `slices.Contains`, for cleaner and more readable filtering logic. (`pkg/github/client.go`, [pkg/github/client.goR32](diffhunk://#diff-2bb9ccd2fcbbcfd99cb8e400704ea77cc80dbf62f5982b1f6ed1a0966ac42ae5R32))