### PR TITLE
Properly set defaults for jira rate limiting

### DIFF
--- a/pkg/flagutil/jira.go
+++ b/pkg/flagutil/jira.go
@@ -168,13 +168,19 @@ func (o *JiraOptions) Client() (jira.Client, error) {
 	if o.backoff != nil {
 		opts = append(opts, jira.WithBackOff(o.backoff))
 	}
-	if o.retryWaitMin != 1*time.Second {
+	if o.retryWaitMin == 0 {
+		opts = append(opts, jira.WithRetryWaitMin(1*time.Second))
+	} else {
 		opts = append(opts, jira.WithRetryWaitMin(o.retryWaitMin))
 	}
-	if o.retryWaitMax != 30*time.Second {
+	if o.retryWaitMax == 0 {
+		opts = append(opts, jira.WithRetryWaitMax(30*time.Second))
+	} else {
 		opts = append(opts, jira.WithRetryWaitMax(o.retryWaitMax))
 	}
-	if o.retryMax != 4 {
+	if o.retryMax == 0 {
+		opts = append(opts, jira.WithRetryMax(4))
+	} else {
 		opts = append(opts, jira.WithRetryMax(o.retryMax))
 	}
 


### PR DESCRIPTION
The original change incorrectly tested against default values instead of actually setting default values, properly, if the values all contained numeric nil (i.e. 0) values.  This PR will set reasonable default values always and users can override them as needed.