### PR TITLE
Allow reason with /unhold too

### DIFF
--- a/pkg/plugins/hold/hold.go
+++ b/pkg/plugins/hold/hold.go
@@ -40,7 +40,7 @@ const (
 
 var (
 	labelRe       = regexp.MustCompile(`(?mi)^/hold(\s.*)?$`)
-	labelCancelRe = regexp.MustCompile(`(?mi)^/(remove-hold|hold\s+cancel|unhold)\s*$`)
+	labelCancelRe = regexp.MustCompile(`(?mi)^/(remove-hold|hold\s+cancel|unhold)(\s.*)?$`)
 )
 
 type hasLabelFunc func(label string, issueLabels []github.Label) bool

--- a/pkg/plugins/hold/hold_test.go
+++ b/pkg/plugins/hold/hold_test.go
@@ -93,8 +93,8 @@ func TestHandle(t *testing.T) {
 			isPR:          true,
 		},
 		{
-			name:          "requested hold cancel with whitespace",
-			body:          "/hold   cancel  ",
+			name:          "requested hold cancel with a reason",
+			body:          "/hold   cancel  further review has happened and I have whitespace",
 			hasLabel:      true,
 			shouldLabel:   false,
 			shouldUnlabel: true,
@@ -117,8 +117,8 @@ func TestHandle(t *testing.T) {
 			isPR:          true,
 		},
 		{
-			name:          "requested unhold with whitespace",
-			body:          "/unhold    ",
+			name:          "requested unhold with a reason",
+			body:          "/unhold   further review has happened and I have whitespace",
 			hasLabel:      true,
 			shouldLabel:   false,
 			shouldUnlabel: true,


### PR DESCRIPTION
Since commit 69ffdfc, the `/hold` command allows a reason. For example:

```
/hold while we wait for foo to merge
```

However, you can't do the equivalent for `/unhold` and its variants. This is confusing. Correct it. This opens up the chance that someone could do e.g.

```
/hold cancel everything while I review this epic code
```

And get an unhold rather than a hold, but that seems an acceptable risk.
