### PR TITLE
fix(generic comment): avoid ok-to-test message on IgnoreOkToTest

### DIFF
--- a/pkg/plugins/trigger/generic-comment.go
+++ b/pkg/plugins/trigger/generic-comment.go
@@ -92,7 +92,12 @@ func handleGenericComment(c Client, trigger plugins.Trigger, gc github.GenericCo
 			return err
 		}
 		if !trusted {
-			resp := "Cannot trigger testing until a trusted user reviews the PR and leaves an `/ok-to-test` message."
+			var resp string
+			if trigger.IgnoreOkToTest {
+				resp = "PRs from untrusted users cannot be marked as trusted with `/ok-to-test` in this repo meaning untrusted PR authors can never trigger tests themselves. Collaborators can still trigger tests on the PR using `/test`."
+			} else {
+				resp = "Cannot trigger testing until a trusted user reviews the PR and leaves an `/ok-to-test` message."
+			}
 			c.Logger.Infof("Commenting \"%s\".", resp)
 			return c.GitHubClient.CreateComment(org, repo, number, plugins.FormatResponseRaw(gc.Body, gc.HTMLURL, gc.User.Login, resp))
 		}


### PR DESCRIPTION
Emit a message similar to the welcome message in case of untrusted user and trigger.IgnoreOkToTest.

See https://github.com/kubevirt/kubevirt/pull/14110#issuecomment-2781210119