### PR TITLE
plugin/label: Improve error when adding/removing a restricted label

### DIFF
--- a/pkg/plugins/label/label.go
+++ b/pkg/plugins/label/label.go
@@ -332,7 +332,11 @@ func canUserSetLabel(ghc githubClient, org string, user string, label string, re
 		}
 	}
 
-	return false, fmt.Sprintf("Can not set label %s: Must be member in one of these teams: %v", label, config.AllowedTeams), nil
+	msg := fmt.Sprintf("The label(s) `%s` cannot be applied or removed, because you are not in one of the allowed teams and are not an allowed user.", label)
+	if len(config.AllowedTeams) > 0 {
+		msg += fmt.Sprintf(" Must be a member of one of these teams: %v", strings.Join(config.AllowedTeams, ", "))
+	}
+	return false, msg, nil
 }
 
 func handleLabelAdd(gc githubClient, log *logrus.Entry, config plugins.Label, e *github.PullRequestEvent) error {

--- a/pkg/plugins/label/label.go
+++ b/pkg/plugins/label/label.go
@@ -18,6 +18,7 @@ package label
 
 import (
 	"fmt"
+	"math/rand/v2"
 	"regexp"
 	"strings"
 
@@ -335,6 +336,12 @@ func canUserSetLabel(ghc githubClient, org string, user string, label string, re
 	msg := fmt.Sprintf("The label(s) `%s` cannot be applied or removed, because you are not in one of the allowed teams and are not an allowed user.", label)
 	if len(config.AllowedTeams) > 0 {
 		msg += fmt.Sprintf(" Must be a member of one of these teams: %v", strings.Join(config.AllowedTeams, ", "))
+	} else if len(config.AllowedUsers) > 0 {
+		randomUsers := []string{}
+		for userIdx := range rand.Perm(len(config.AllowedUsers))[:min(len(config.AllowedUsers), 3)] {
+			randomUsers = append(randomUsers, config.AllowedUsers[userIdx])
+		}
+		msg += fmt.Sprintf(" Consider assigning one of the following members: %s", strings.Join(randomUsers, ","))
 	}
 	return false, msg, nil
 }

--- a/pkg/plugins/label/label_test.go
+++ b/pkg/plugins/label/label_test.go
@@ -718,7 +718,7 @@ func TestHandleComment(t *testing.T) {
 			restrictedLabels:    map[string][]plugins.RestrictedLabel{"org": {{Label: "restricted-label", AllowedUsers: []string{orgMemberAlt}}}},
 			action:              github.GenericCommentActionCreated,
 			expectedBotComment:  true,
-			expectedCommentText: "The label(s) `restricted-label` cannot be applied or removed, because you are not in one of the allowed teams and are not an allowed user.",
+			expectedCommentText: "The label(s) `restricted-label` cannot be applied or removed, because you are not in one of the allowed teams and are not an allowed user. Consider assigning one of the following members: Mallory",
 		},
 		{
 			name:              "Restricted label addition, user is in allowed_teams",
@@ -759,7 +759,7 @@ func TestHandleComment(t *testing.T) {
 			restrictedLabels:    map[string][]plugins.RestrictedLabel{"org": {{Label: "restricted-label", AllowedUsers: []string{orgMemberAlt}}}},
 			action:              github.GenericCommentActionCreated,
 			expectedBotComment:  true,
-			expectedCommentText: "The label(s) `restricted-label` cannot be applied or removed, because you are not in one of the allowed teams and are not an allowed user.",
+			expectedCommentText: "The label(s) `restricted-label` cannot be applied or removed, because you are not in one of the allowed teams and are not an allowed user. Consider assigning one of the following members: Mallory",
 		},
 		{
 			name:                  "Restricted label removal, user is in allowed_teams",

--- a/pkg/plugins/label/label_test.go
+++ b/pkg/plugins/label/label_test.go
@@ -35,6 +35,7 @@ import (
 
 const (
 	orgMember    = "Alice"
+	orgMemberAlt = "Mallory"
 	nonOrgMember = "Bob"
 )
 
@@ -700,16 +701,27 @@ func TestHandleComment(t *testing.T) {
 			action:                github.GenericCommentActionCreated,
 		},
 		{
-			name:               "Restricted label addition, user is not in group",
+			name:               "Restricted label addition, user is not in allowed_teams",
 			body:               `/label restricted-label`,
 			repoLabels:         []string{"restricted-label"},
 			commenter:          orgMember,
 			restrictedLabels:   map[string][]plugins.RestrictedLabel{"org": {{Label: "restricted-label", AllowedTeams: []string{"privileged-group"}}}},
 			action:             github.GenericCommentActionCreated,
 			expectedBotComment: true,
+			expectedCommentText: "The label(s) `restricted-label` cannot be applied or removed, because you are not in one of the allowed teams and are not an allowed user. Must be a member of one of these teams: privileged-group",
 		},
 		{
-			name:              "Restricted label addition, user is in group",
+			name:                "Restricted label addition, user is not in allowed_users and allowed_teams is empty",
+			body:                `/label restricted-label`,
+			repoLabels:          []string{"restricted-label"},
+			commenter:           orgMember,
+			restrictedLabels:    map[string][]plugins.RestrictedLabel{"org": {{Label: "restricted-label", AllowedUsers: []string{orgMemberAlt}}}},
+			action:              github.GenericCommentActionCreated,
+			expectedBotComment:  true,
+			expectedCommentText: "The label(s) `restricted-label` cannot be applied or removed, because you are not in one of the allowed teams and are not an allowed user.",
+		},
+		{
+			name:              "Restricted label addition, user is in allowed_teams",
 			body:              `/label restricted-label`,
 			repoLabels:        []string{"restricted-label"},
 			commenter:         orgMember,
@@ -728,17 +740,29 @@ func TestHandleComment(t *testing.T) {
 			expectedNewLabels: formatWithPRInfo("restricted-label"),
 		},
 		{
-			name:               "Restricted label removal, user is not in group",
-			body:               `/remove-label restricted-label`,
-			repoLabels:         []string{"restricted-label"},
-			issueLabels:        []string{"restricted-label"},
-			commenter:          orgMember,
-			restrictedLabels:   map[string][]plugins.RestrictedLabel{"org": {{Label: "restricted-label", AllowedTeams: []string{"privileged-group"}}}},
-			action:             github.GenericCommentActionCreated,
-			expectedBotComment: true,
+			name:                "Restricted label removal, user is not in allowed_teams",
+			body:                `/remove-label restricted-label`,
+			repoLabels:          []string{"restricted-label"},
+			issueLabels:         []string{"restricted-label"},
+			commenter:           orgMember,
+			restrictedLabels:    map[string][]plugins.RestrictedLabel{"org": {{Label: "restricted-label", AllowedTeams: []string{"privileged-group"}}}},
+			action:              github.GenericCommentActionCreated,
+			expectedBotComment:  true,
+			expectedCommentText: "The label(s) `restricted-label` cannot be applied or removed, because you are not in one of the allowed teams and are not an allowed user. Must be a member of one of these teams: privileged-group",
 		},
 		{
-			name:                  "Restricted label removal, user is in group",
+			name:                "Restricted label removal, user is not in allowed_users and allowed_teams is empty",
+			body:                `/remove-label restricted-label`,
+			repoLabels:          []string{"restricted-label"},
+			issueLabels:         []string{"restricted-label"},
+			commenter:           orgMember,
+			restrictedLabels:    map[string][]plugins.RestrictedLabel{"org": {{Label: "restricted-label", AllowedUsers: []string{orgMemberAlt}}}},
+			action:              github.GenericCommentActionCreated,
+			expectedBotComment:  true,
+			expectedCommentText: "The label(s) `restricted-label` cannot be applied or removed, because you are not in one of the allowed teams and are not an allowed user.",
+		},
+		{
+			name:                  "Restricted label removal, user is in allowed_teams",
 			body:                  `/remove-label restricted-label`,
 			repoLabels:            []string{"restricted-label"},
 			issueLabels:           []string{"restricted-label"},

--- a/pkg/plugins/label/label_test.go
+++ b/pkg/plugins/label/label_test.go
@@ -715,7 +715,7 @@ func TestHandleComment(t *testing.T) {
 			commenter:         orgMember,
 			restrictedLabels:  map[string][]plugins.RestrictedLabel{"org": {{Label: "restricted-label", AllowedTeams: []string{"privileged-group"}}}},
 			action:            github.GenericCommentActionCreated,
-			teams:             map[string]map[string]fakegithub.TeamWithMembers{"org": {"privileged-group": {Members: sets.New[string](orgMember)}}},
+			teams:             map[string]map[string]fakegithub.TeamWithMembers{"org": {"privileged-group": {Members: sets.New(orgMember)}}},
 			expectedNewLabels: formatWithPRInfo("restricted-label"),
 		},
 		{
@@ -745,7 +745,7 @@ func TestHandleComment(t *testing.T) {
 			commenter:             orgMember,
 			restrictedLabels:      map[string][]plugins.RestrictedLabel{"org": {{Label: "restricted-label", AllowedTeams: []string{"privileged-group"}}}},
 			action:                github.GenericCommentActionCreated,
-			teams:                 map[string]map[string]fakegithub.TeamWithMembers{"org": {"privileged-group": {Members: sets.New[string](orgMember)}}},
+			teams:                 map[string]map[string]fakegithub.TeamWithMembers{"org": {"privileged-group": {Members: sets.New(orgMember)}}},
 			expectedRemovedLabels: formatWithPRInfo("restricted-label"),
 		},
 		{


### PR DESCRIPTION
Currently, if you attempt to add a restricted label and `allowed_teams` is unset/empty, you get the following unhelpful message.

```
@username: Can not set label cherry-pick-approved: Must be member in one of these teams: []
```

Improve this so that we no longer suggest being a member of no team and instead suggest reaching out to one of the users in `allowed_users` instead:

```
@username: The label(s) `restricted-label` cannot be applied or removed, because you are not in one of the allowed teams and are not an allowed user. Consider assigning one of the following members: Mallory
```

We also improve the common path where `allowed_teams` is populated, aligning the error message with those of other errors paths:

```
@username: The label(s) `restricted-label` cannot be applied or removed, because you are not in one of the allowed teams and are not an allowed user. Must be a member of one of these teams: privileged-group
```

> [!NOTE]
> I suspect dumping a list of users could get "chatty", so I've intentionally
> avoided formatting these as links (i.e. we emit `user`, not `@user`) and only
> print up to 3 users. In most cases, this code should not be triggered since
> projects will usually make use of `allowed_teams`.
