### PR TITLE
secretutil: implement configurable minimum secret length

### DIFF
--- a/config/prow/cluster/prowjob-crd/prowjob_customresourcedefinition.yaml
+++ b/config/prow/cluster/prowjob-crd/prowjob_customresourcedefinition.yaml
@@ -149,6 +149,12 @@ spec:
                         items:
                           type: string
                         type: array
+                      minimum_secret_length:
+                        description: |-
+                          MinimumSecretLength is the minimum length a secret must have to be censored.
+                          Secrets shorter than this length will not be censored. If unset, defaults to 0
+                          (all secrets are censored regardless of length).
+                        type: integer
                     type: object
                   cookiefile_secret:
                     description: |-

--- a/pkg/apis/prowjobs/v1/types.go
+++ b/pkg/apis/prowjobs/v1/types.go
@@ -594,6 +594,11 @@ type CensoringOptions struct {
 	// matches a glob in IncludeDirectories. Entries in this list are relative to $ARTIFACTS,
 	// and are parsed with the go-zglob library, allowing for globbed matches.
 	ExcludeDirectories []string `json:"exclude_directories,omitempty"`
+
+	// MinimumSecretLength is the minimum length a secret must have to be censored.
+	// Secrets shorter than this length will not be censored. If unset, defaults to 0
+	// (all secrets are censored regardless of length).
+	MinimumSecretLength *int `json:"minimum_secret_length,omitempty"`
 }
 
 type SchedulingOptions struct {
@@ -635,6 +640,10 @@ func (g *CensoringOptions) ApplyDefault(def *CensoringOptions) *CensoringOptions
 
 	if merged.ExcludeDirectories == nil {
 		merged.ExcludeDirectories = def.ExcludeDirectories
+	}
+
+	if merged.MinimumSecretLength == nil {
+		merged.MinimumSecretLength = def.MinimumSecretLength
 	}
 	return &merged
 }

--- a/pkg/apis/prowjobs/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/prowjobs/v1/zz_generated.deepcopy.go
@@ -53,6 +53,11 @@ func (in *CensoringOptions) DeepCopyInto(out *CensoringOptions) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.MinimumSecretLength != nil {
+		in, out := &in.MinimumSecretLength, &out.MinimumSecretLength
+		*out = new(int)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/config/prow-config-documented.yaml
+++ b/pkg/config/prow-config-documented.yaml
@@ -622,6 +622,10 @@ plank:
                 # globbed matches.
                 include_directories:
                     - ""
+                # MinimumSecretLength is the minimum length a secret must have to be censored.
+                # Secrets shorter than this length will not be censored. If unset, defaults to 0
+                # (all secrets are censored regardless of length).
+                minimum_secret_length: 0
             # CookieFileSecret is the name of a kubernetes secret that contains
             # a git http.cookiefile, which should be used during the cloning process.
             cookiefile_secret: ""
@@ -975,6 +979,10 @@ plank:
                 # globbed matches.
                 include_directories:
                     - ""
+                # MinimumSecretLength is the minimum length a secret must have to be censored.
+                # Secrets shorter than this length will not be censored. If unset, defaults to 0
+                # (all secrets are censored regardless of length).
+                minimum_secret_length: 0
             # CookieFileSecret is the name of a kubernetes secret that contains
             # a git http.cookiefile, which should be used during the cloning process.
             cookiefile_secret: ""

--- a/pkg/sidecar/censor.go
+++ b/pkg/sidecar/censor.go
@@ -77,7 +77,14 @@ func (o Options) censor() error {
 		return fmt.Errorf("could not load secrets: %w", err)
 	}
 	logrus.WithField("secrets", len(secrets)).Debug("Loaded secrets to censor.")
-	censorer := secretutil.NewCensorer()
+
+	minLength := 0
+	if o.CensoringOptions.MinimumSecretLength != nil {
+		minLength = *o.CensoringOptions.MinimumSecretLength
+	}
+	logrus.WithField("minimum_secret_length", minLength).Debug("Using minimum secret length for censoring.")
+
+	censorer := secretutil.NewCensorerWithMinLength(minLength)
 	censorer.RefreshBytes(secrets...)
 
 	bufferSize := defaultBufferSize

--- a/pkg/sidecar/options.go
+++ b/pkg/sidecar/options.go
@@ -125,6 +125,11 @@ type CensoringOptions struct {
 	// IniFilenames are secret filenames that should be parsed as INI files in order to
 	// censor the values in the key-value mapping as well as the full content of the file.
 	IniFilenames []string `json:"ini_filenames,omitempty"`
+
+	// MinimumSecretLength is the minimum length a secret must have to be censored.
+	// Secrets shorter than this length will not be censored. If unset, defaults to 0
+	// (all secrets are censored regardless of length).
+	MinimumSecretLength *int `json:"minimum_secret_length,omitempty"`
 }
 
 func (o Options) entries() []wrapper.Options {

--- a/pkg/spyglass/lenses/common/bindata.go
+++ b/pkg/spyglass/lenses/common/bindata.go
@@ -93,7 +93,7 @@ func staticSpyglassLensHtml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "static/spyglass-lens.html", size: 616, mode: os.FileMode(420), modTime: time.Unix(1744640848, 0)}
+	info := bindataFileInfo{name: "static/spyglass-lens.html", size: 616, mode: os.FileMode(420), modTime: time.Unix(1749061292, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }


### PR DESCRIPTION
Short "secrets" tend not to be so, and cause issues when it gets censored in test names or serializable fields like test duration.

An example, putting 443 in a secret would cause that to be censored from junit durations, rendering the XML unmarshallable.

Or, using "mon", for montreal - a location of a data center - will cause test names that mention `monitoring` to become `XXXitoring`.

These are real-world examples in OpenShift.  It's unlikely any truly secret data is less than 6 characters, but to be safe the behavior is unchanged upstream -- the default minimum length is 0.

fixes [#26453](https://github.com/kubernetes/test-infra/issues/26453)