### PR TITLE
branchprotector: remove protection from excluded branches

### DIFF
--- a/cmd/branchprotector/protect_test.go
+++ b/cmd/branchprotector/protect_test.go
@@ -1112,6 +1112,12 @@ branch-protection:
 				{
 					Org:     "kubernetes",
 					Repo:    "test-infra",
+					Branch:  "skip",
+					Request: nil, // nil Request triggers RemoveBranchProtection
+				},
+				{
+					Org:     "kubernetes",
+					Repo:    "test-infra",
 					Branch:  "master",
 					Request: &github.BranchProtectionRequest{EnforceAdmins: &no},
 				},
@@ -1133,6 +1139,18 @@ branch-protection:
           - sk.*
 `,
 			expected: []requirements{
+				{
+					Org:     "kubernetes",
+					Repo:    "test-infra",
+					Branch:  "skip",
+					Request: nil, // nil Request triggers RemoveBranchProtection
+				},
+				{
+					Org:     "kubernetes",
+					Repo:    "test-infra",
+					Branch:  "foobar1",
+					Request: nil, // nil Request triggers RemoveBranchProtection
+				},
 				{
 					Org:     "kubernetes",
 					Repo:    "test-infra",


### PR DESCRIPTION
Fix issue where excluded branches retain existing protection instead of being removed.

When a branch is added to the exclude list in branchprotector configuration, the tool
correctly stops applying new protection rules but does not remove existing protection
from branches that were previously protected.

This change adds logic to detect excluded branches that are currently protected and
queue them for removal by sending requirements with Request: nil, which triggers
RemoveBranchProtection() in the configureBranches() function.

The fix prevents push failures like:
  remote: error: GH006: Protected branch update failed for refs/heads/konflux-branch
  remote: - Changes must be made through a pull request.

Changes:
- Add detection logic for excluded protected branches in UpdateRepo()
- Send removal requests (Request: nil) for such branches
- Update tests to expect removal requests for excluded protected branches
- Add code comment explaining the call flow to RemoveBranchProtection

Fixes kubernetes-sigs/prow#477
