### PR TITLE
Update an example to use a job on the default branch of test-infra

### DIFF
--- a/site/content/en/docs/build-test-update.md
+++ b/site/content/en/docs/build-test-update.md
@@ -2,7 +2,7 @@
 title: "Building, Testing, and Updating Prow"
 weight: 70
 description: >
-  
+
 ---
 
 This guide is directed at Prow developers and maintainers who want to build/test individual components or deploy changes to an existing Prow cluster. ["Deploying Prow"](/docs/getting-started-deploy/) is a better reference for deploying a new Prow cluster.
@@ -118,9 +118,9 @@ for [prow.istio.io](https://prow.istio.io).
 To test ProwJobs for the [prow.k8s.io] instance use [`config/pj-on-kind.sh`](https://github.com/kubernetes/test-infra/blob/master/config/pj-on-kind.sh).
 
 ##### Example
-This command runs the ProwJob [`pull-test-infra-yamllint`](https://github.com/kubernetes/test-infra/blob/170921984a34ca40f2763f9e71d6ce6e033dec03/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml#L94-L107) locally on Kind.
+This command runs the ProwJob [`pull-community-verify`](https://github.com/kubernetes/test-infra/blob/4c7d366981c6cf14a92547240976ed89095bc5e1/config/jobs/kubernetes/community/community-presubmit.yaml#L3-L26) locally on Kind.
 ```sh
-./pj-on-kind.sh pull-test-infra-yamllint
+./pj-on-kind.sh pull-community-verify
 ```
 You may also need to set the `CONFIG_PATH` and `JOB_CONFIG_PATH` environmental variables:
 ```sh


### PR DESCRIPTION
Resolve https://github.com/kubernetes-sigs/prow/issues/479.

Update an example to use a job on the default branch of test-infra.  I confirmed the updated command: `./pj-on-kind.sh pull-community-verify` worked locally. I attached the outputs of the commands below.

<details><summary>./pj-on-kind.sh pull-community-verify</summary>

```
laborant@docker-01:config$ ./pj-on-kind.sh pull-community-verify
job=pull-community-verify
CONFIG_PATH=/home/laborant/test-infra/config/prow/config.yaml
JOB_CONFIG_PATH=/home/laborant/test-infra/config/jobs
OUT_DIR=/mnt/disks/prowjob-out   (Only used when creating a new kind cluster.)
KIND_CONFIG=   (Only used when creating a new kind cluster.)
NODE_DIR=/mnt/disks/kind-node   (Only used when creating a new kind cluster.)
No kind clusters found.
Creating cluster "mkpod" ...
 ✓ Ensuring node image (kindest/node:v1.25.3) 🖼 
 ✓ Preparing nodes 📦  
 ✓ Writing configuration 📜 
 ✓ Starting control-plane 🕹️ 
 ✓ Installing CNI 🔌 
 ✓ Installing StorageClass 💾 
 ✓ Waiting ≤ 5m0s for control-plane = Ready ⏳ 
 • Ready after 19s 💚
Set kubectl context to "kind-mkpod"
You can now use your cluster with:

kubectl cluster-info --context kind-mkpod

Have a nice day! 👋
latest: Pulling from k8s-prow/mkpj
dcccee43ad5d: Pull complete 
9a4040e7f26e: Pull complete 
250c06f7c38e: Pull complete 
44bc7281befa: Pull complete 
Digest: sha256:6e71c2d9f675bce23136443cd8093fad59ed3344325d305963e89eadb7d3b6d5
Status: Downloaded newer image for gcr.io/k8s-prow/mkpj:latest
gcr.io/k8s-prow/mkpj:latest
time="2025-06-20T16:33:18Z" level=warning msg="empty -github-token-path, will use anonymous github client"
time="2025-06-20T16:33:18Z" level=info msg="Throttle(0, 0, [])" client=github
PR Number: 8496
time="2025-06-20T16:37:28Z" level=info msg="GetPullRequest(kubernetes, community, 8496)" client=github
time="2025-06-20T16:37:28Z" level=debug msg="Using GitHub REST API Version: 2022-11-28" client=github
time="2025-06-20T16:37:28Z" level=debug msg="Used token for request" cache-mode= client=github method=GET path=/repos/kubernetes/community/pulls/8496 throttled=true
time="2025-06-20T16:37:28Z" level=debug msg="GetPullRequest(kubernetes, community, 8496) finished" client=github duration=378.004547ms
latest: Pulling from k8s-prow/mkpod
dcccee43ad5d: Already exists 
9a4040e7f26e: Already exists 
250c06f7c38e: Already exists 
e2664d58ffa0: Pull complete 
Digest: sha256:1a95d701f6cafae2c004088e47f15efc0b8e5b8d8fb6a23a2e2ccd94471eda46
Status: Downloaded newer image for gcr.io/k8s-prow/mkpod:latest
gcr.io/k8s-prow/mkpod:latest
time="2025-06-20T16:37:32Z" level=info msg="Generated build-id for job." build-id=1936101121139412992
time="2025-06-20T16:37:32Z" level=info msg="Pod-utils configured for local mode. Instead of uploading to GCS, files will be copied to an output dir on the node." out-dir=/mnt/disks/prowjob-out/pull-community-verify/1936101121139412992
Applying pod to the mkpod cluster. Configure kubectl for the mkpod cluster with:
>  export KUBECONFIG='/home/laborant/.kube/kind-config-mkpod'
NAME                                   READY   STATUS     RESTARTS   AGE
ad84a04b-f536-41c9-9b0a-730ab70eabf8   0/2     Init:0/3   0          0s
ad84a04b-f536-41c9-9b0a-730ab70eabf8   0/2     Init:0/3   0          6s
ad84a04b-f536-41c9-9b0a-730ab70eabf8   0/2     Init:1/3   0          12s
ad84a04b-f536-41c9-9b0a-730ab70eabf8   0/2     Init:2/3   0          19s
ad84a04b-f536-41c9-9b0a-730ab70eabf8   0/2     PodInitializing   0          24s
ad84a04b-f536-41c9-9b0a-730ab70eabf8   2/2     Running           0          52s
ad84a04b-f536-41c9-9b0a-730ab70eabf8   0/2     Completed         0          91s
ad84a04b-f536-41c9-9b0a-730ab70eabf8   0/2     Completed         0          93s
```

</details> 


<details><summary>kubectl logs ad84a04b-f536-41c9-9b0a-730ab70eabf8 -f</summary>

```
laborant@docker-01:~$ kubectl logs ad84a04b-f536-41c9-9b0a-730ab70eabf8 -f
Defaulted container "test" out of: test, sidecar, clonerefs (init), initupload (init), place-entrypoint (init)
Verifying verify-generated-docs.sh
go: downloading github.com/go-git/go-git/v5 v5.2.0
go: downloading github.com/google/go-github/v32 v32.1.0
go: downloading golang.org/x/mod v0.4.0
go: downloading gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c
go: downloading k8s.io/enhancements v0.0.0-20230113204613-7f681415a001
go: downloading github.com/google/go-querystring v1.0.0
go: downloading golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0
go: downloading github.com/go-git/go-billy/v5 v5.0.0
go: downloading github.com/imdario/mergo v0.3.11
go: downloading github.com/sergi/go-diff v1.1.0
go: downloading golang.org/x/sys v0.0.0-20210112080510-489259a85091
go: downloading github.com/mitchellh/go-homedir v1.1.0
go: downloading github.com/emirpasic/gods v1.12.0
go: downloading github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99
go: downloading github.com/go-git/gcfg v1.5.0
go: downloading github.com/kevinburke/ssh_config v0.0.0-20190725054713-01f96b0aa0cd
go: downloading github.com/xanzy/ssh-agent v0.2.1
go: downloading golang.org/x/net v0.0.0-20201224014010-6772e930b67b
go: downloading gopkg.in/warnings.v0 v0.1.2
go: downloading github.com/go-playground/validator/v10 v10.4.1
go: downloading github.com/pkg/errors v0.9.1
go: downloading github.com/go-playground/universal-translator v0.17.0
go: downloading github.com/leodido/go-urn v1.2.1
go: downloading github.com/go-playground/locales v0.13.0
SUCCESS  verify-generated-docs.sh       39s
Verifying verify-spelling.sh
SUCCESS  verify-spelling.sh     3s
Verifying verify-steering-election.sh
SUCCESS  verify-steering-election.sh    0s
```


</details> 