### PR TITLE
Fix `/retitle` race condition

### DIFF
--- a/pkg/plugins/retitle/retitle.go
+++ b/pkg/plugins/retitle/retitle.go
@@ -91,7 +91,7 @@ func handleGenericCommentEvent(pc plugins.Agent, e github.GenericCommentEvent) e
 type githubClient interface {
 	CreateComment(owner, repo string, number int, comment string) error
 	GetPullRequest(org, repo string, number int) (*github.PullRequest, error)
-	EditPullRequest(org, repo string, number int, pr *github.PullRequest) (*github.PullRequest, error)
+	UpdatePullRequest(org, repo string, number int, title, body *string, open *bool, branch *string, canModify *bool) error
 	GetIssue(org, repo string, number int) (*github.Issue, error)
 	EditIssue(org, repo string, number int, issue *github.Issue) (*github.Issue, error)
 }
@@ -144,13 +144,7 @@ func handleGenericComment(gc githubClient, isTrusted func(string) (bool, error),
 	}
 
 	if gce.IsPR {
-		pr, err := gc.GetPullRequest(org, repo, number)
-		if err != nil {
-			return err
-		}
-		pr.Title = newTitle
-		_, err = gc.EditPullRequest(org, repo, number, pr)
-		return err
+		return gc.UpdatePullRequest(org, repo, number, &newTitle, nil, nil, nil, nil)
 	}
 	issue, err := gc.GetIssue(org, repo, number)
 	if err != nil {


### PR DESCRIPTION
Fixes race condition when executing `/retitle` and `/release-note-edit` in the same comment.

**Before:**
Running `/retitle` would retrieve the full PR, modify the title of the local PR object, and then push the PR object up to save it.

This left open a race condition where if `/release-note-edit` executed during the short window where the pull request was retrieved but wasn't saved yet, the release note change would get unintendedly reverted.

**After:**
Update `/retitle` to use `UpdatePullRequest` instead of `EditPullRequest`, `UpdatePullRequest` is a patch operation and we can exclusively update the title, removing the opportunity for the race condition to occur.