### PR TITLE
ci: remove legacy gcr.io/k8s-testimages image registry

### DIFF
--- a/cmd/admission/dev.yaml
+++ b/cmd/admission/dev.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: admission
-        image: gcr.io/k8s-testimages/admission:latest  # Note: not gcr.io/k8s-prow for dev
+        image: gcr.io/k8s-staging-test-infra/admission:latest  # Note: not gcr.io/k8s-prow for dev
         imagePullPolicy: Always  # Good practice for dev/debugging, bad for prod
         args:
         - --tls-cert-file=/etc/tls/tls.crt

--- a/cmd/branchprotector/oneshot-job.yaml
+++ b/cmd/branchprotector/oneshot-job.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: branchprotector
-        image: gcr.io/k8s-testimages/branchprotector:latest  # Note: not gcr.io/k8s-prow for dev
+        image: us-docker.pkg.dev/k8s-infra-prow/images/branchprotector:v20250704-ef29ebbe9  # Note: not gcr.io/k8s-prow for dev
         imagePullPolicy: Always  # Good practice for dev/debugging, bad for prod
         args:
         - --config-path=/etc/config/config.yaml

--- a/cmd/generic-autobumper/imagebumper/imagebumper_test.go
+++ b/cmd/generic-autobumper/imagebumper/imagebumper_test.go
@@ -290,43 +290,43 @@ func TestUpdateAllTags(t *testing.T) {
 		},
 		{
 			name:           "file that has only an image replaces the image",
-			content:        "gcr.io/k8s-testimages/some-image:v20190404-12345678",
-			expectedResult: "gcr.io/k8s-testimages/some-image:v20190405-123456789",
+			content:        "gcr.io/k8s-staging-test-infra/some-image:v20190404-12345678",
+			expectedResult: "gcr.io/k8s-staging-test-infra/some-image:v20190405-123456789",
 			newTags: map[string]string{
-				"gcr.io/k8s-testimages/some-image:v20190404-12345678": "v20190405-123456789",
+				"gcr.io/k8s-staging-test-infra/some-image:v20190404-12345678": "v20190405-123456789",
 			},
 		},
 		{
 			name:           "file that has content before and after an image still has it later",
-			content:        `{"image": "gcr.io/k8s-testimages/some-image:v20190404-12345678"}`,
-			expectedResult: `{"image": "gcr.io/k8s-testimages/some-image:v20190405-123456789"}`,
+			content:        `{"image": "gcr.io/k8s-staging-test-infra/some-image:v20190404-12345678"}`,
+			expectedResult: `{"image": "gcr.io/k8s-staging-test-infra/some-image:v20190405-123456789"}`,
 			newTags: map[string]string{
-				"gcr.io/k8s-testimages/some-image:v20190404-12345678": "v20190405-123456789",
+				"gcr.io/k8s-staging-test-infra/some-image:v20190404-12345678": "v20190405-123456789",
 			},
 		},
 		{
 			name:           "file that has multiple different images replaces both of them",
-			content:        `{"images": ["gcr.io/k8s-testimages/some-image:v20190404-12345678-master", "gcr.io/k8s-testimages/some-image:v20190404-12345678-experimental"]}`,
-			expectedResult: `{"images": ["gcr.io/k8s-testimages/some-image:v20190405-123456789-master", "gcr.io/k8s-testimages/some-image:v20190405-123456789-experimental"]}`,
+			content:        `{"images": ["gcr.io/k8s-staging-test-infra/some-image:v20190404-12345678-master", "gcr.io/k8s-staging-test-infra/some-image:v20190404-12345678-experimental"]}`,
+			expectedResult: `{"images": ["gcr.io/k8s-staging-test-infra/some-image:v20190405-123456789-master", "gcr.io/k8s-staging-test-infra/some-image:v20190405-123456789-experimental"]}`,
 			newTags: map[string]string{
-				"gcr.io/k8s-testimages/some-image:v20190404-12345678-master":       "v20190405-123456789-master",
-				"gcr.io/k8s-testimages/some-image:v20190404-12345678-experimental": "v20190405-123456789-experimental",
+				"gcr.io/k8s-staging-test-infra/some-image:v20190404-12345678-master":       "v20190405-123456789-master",
+				"gcr.io/k8s-staging-test-infra/some-image:v20190404-12345678-experimental": "v20190405-123456789-experimental",
 			},
 		},
 		{
 			name:           "file with an error image is still otherwise updated",
-			content:        `{"images": ["gcr.io/k8s-testimages/some-image:0.2", "gcr.io/k8s-testimages/some-image:v20190404-12345678"]}`,
-			expectedResult: `{"images": ["gcr.io/k8s-testimages/some-image:0.2", "gcr.io/k8s-testimages/some-image:v20190405-123456789"]}`,
+			content:        `{"images": ["gcr.io/k8s-staging-test-infra/some-image:0.2", "gcr.io/k8s-staging-test-infra/some-image:v20190404-12345678"]}`,
+			expectedResult: `{"images": ["gcr.io/k8s-staging-test-infra/some-image:0.2", "gcr.io/k8s-staging-test-infra/some-image:v20190405-123456789"]}`,
 			newTags: map[string]string{
-				"gcr.io/k8s-testimages/some-image:v20190404-12345678": "v20190405-123456789",
+				"gcr.io/k8s-staging-test-infra/some-image:v20190404-12345678": "v20190405-123456789",
 			},
 		},
 		{
 			name:           "gcr subdomains are supported",
-			content:        `{"images": ["eu.gcr.io/k8s-testimages/some-image:v20190404-12345678"]}`,
-			expectedResult: `{"images": ["eu.gcr.io/k8s-testimages/some-image:v20190405-123456789"]}`,
+			content:        `{"images": ["eu.gcr.io/k8s-staging-test-infra/some-image:v20190404-12345678"]}`,
+			expectedResult: `{"images": ["eu.gcr.io/k8s-staging-test-infra/some-image:v20190405-123456789"]}`,
 			newTags: map[string]string{
-				"eu.gcr.io/k8s-testimages/some-image:v20190404-12345678": "v20190405-123456789",
+				"eu.gcr.io/k8s-staging-test-infra/some-image:v20190404-12345678": "v20190405-123456789",
 			},
 		},
 		{
@@ -347,13 +347,13 @@ func TestUpdateAllTags(t *testing.T) {
 		},
 		{
 			name:           "images not matching the filter regex are not updated",
-			content:        `{"images": ["gcr.io/k8s-prow/pkg-thing:v20190404-12345678", "gcr.io/k8s-testimages/some-image:v20190404-12345678"]}`,
-			expectedResult: `{"images": ["gcr.io/k8s-prow/pkg-thing:v20190404-12345678", "gcr.io/k8s-testimages/some-image:v20190405-123456789"]}`,
+			content:        `{"images": ["gcr.io/k8s-prow/pkg-thing:v20190404-12345678", "gcr.io/k8s-staging-test-infra/some-image:v20190404-12345678"]}`,
+			expectedResult: `{"images": ["gcr.io/k8s-prow/pkg-thing:v20190404-12345678", "gcr.io/k8s-staging-test-infra/some-image:v20190405-123456789"]}`,
 			newTags: map[string]string{
-				"gcr.io/k8s-prow/pkg-thing:v20190404-12345678":        "v20190405-123456789",
-				"gcr.io/k8s-testimages/some-image:v20190404-12345678": "v20190405-123456789",
+				"gcr.io/k8s-prow/pkg-thing:v20190404-12345678":                "v20190405-123456789",
+				"gcr.io/k8s-staging-test-infra/some-image:v20190404-12345678": "v20190405-123456789",
 			},
-			imageFilter: regexp.MustCompile("gcr.io/k8s-testimages"),
+			imageFilter: regexp.MustCompile("gcr.io/k8s-staging-test-infra"),
 		},
 	}
 

--- a/cmd/peribolos/dev.yaml
+++ b/cmd/peribolos/dev.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: peribolos
-        image: gcr.io/k8s-testimages/peribolos:latest  # Note: not gcr.io/k8s-prow for dev
+        image: gcr.io/k8s-staging-test-infra/peribolos:latest  # Note: not gcr.io/k8s-prow for dev
         imagePullPolicy: Always  # Good practice for dev/debugging, bad for prod
         args:
         - --config-path=/etc/config/config.yaml

--- a/cmd/pipeline/dev.yaml
+++ b/cmd/pipeline/dev.yaml
@@ -15,7 +15,7 @@ spec:
       serviceAccount: prow-pipeline
       containers:
       - name: pipeline
-        image: gcr.io/k8s-testimages/pipeline:latest  # Note: not gcr.io/k8s-prow for dev
+        image: gcr.io/k8s-staging-test-infra/pipeline:latest  # Note: not gcr.io/k8s-prow for dev
         imagePullPolicy: Always  # Good practice for dev/debugging, bad for prod
         args:
         - --config=/etc/config/config.yaml

--- a/site/content/en/docs/components/cli-tools/generic-autobumper.md
+++ b/site/content/en/docs/components/cli-tools/generic-autobumper.md
@@ -84,7 +84,7 @@ prefixes:
     summarise: false
     consistentImages: true
   - name: "Prow-Test-Images"
-    prefix: "gcr.io/k8s-testimages/"
+    prefix: "gcr.io/k8s-staging-test-infra/"
     repo: "https://github.com/kubernetes/test-infra"
     summarise: false
     consistentImages: false


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/sig testing

#### What this PR does / why we need it:

Legacy image registry removal purpose

#### Which issue(s) this PR is related to:

[Migrate away from gcr.io/k8s-testimages repo #470](https://github.com/kubernetes-sigs/prow/issues/470)

#### Special notes for your reviewer:

NONE

#### Does this PR introduce a user-facing change?

NONE

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

NONE
