### PR TITLE
podutils: ensure minimum secret length is wired through to sidecar

### DIFF
--- a/pkg/pod-utils/decorate/podspec.go
+++ b/pkg/pod-utils/decorate/podspec.go
@@ -917,6 +917,7 @@ func Sidecar(config *prowapi.DecorationConfig, gcsOptions gcsupload.Options, blo
 		censoringOptions.CensoringBufferSize = config.CensoringOptions.CensoringBufferSize
 		censoringOptions.IncludeDirectories = config.CensoringOptions.IncludeDirectories
 		censoringOptions.ExcludeDirectories = config.CensoringOptions.ExcludeDirectories
+		censoringOptions.MinimumSecretLength = config.CensoringOptions.MinimumSecretLength
 	}
 	sidecarConfigEnv, err := sidecar.Encode(sidecar.Options{
 		GcsOptions:       &gcsOptions,


### PR DESCRIPTION
When implementing the minimum secret length, I missed that this needed to be copied over here.