### PR TITLE
fix(verify-owners): handle invalid OWNERS_ALIASES file case

### DIFF
--- a/pkg/plugins/verify-owners/verify-owners_test.go
+++ b/pkg/plugins/verify-owners/verify-owners_test.go
@@ -146,6 +146,12 @@ var ownerAliasesFiles = map[string][]byte{
   not-yet-existing-alias:
   - bob
 `),
+	"invalidOwnersAliases": []byte(`aliases:
+  approvers:
+  - alice
+  - bob
+  -
+`),
 }
 
 func IssueLabelsContain(arr []string, str string) bool {
@@ -450,6 +456,12 @@ func testHandle(clients localgit.Clients, t *testing.T) {
 			filesChangedAfterPR: []string{"OWNERS_ALIASES"},
 			addedContent:        "toBeAddedAlias",
 			shouldLabel:         false,
+		},
+		{
+			name:         "invalid OWNERS_ALIASES",
+			filesChanged: []string{"OWNERS_ALIASES"},
+			ownersFile:   "invalidOwnersAliases",
+			shouldLabel:  true,
 		},
 	}
 	lg, c, err := clients()


### PR DESCRIPTION
As seen in https://github.com/kubernetes-sigs/prow/issues/514 the case of a corrupt OWNERS_ALIASES file is unhandled, leaving the peril of merging an invalid file.

This change adds the label and attaches a comment to the pull request that notifies the user of the case.

Fixes #514 