### PR TITLE
Use github DefaultHost Constant Where Possible

### DIFF
--- a/pkg/plugins/assign/assign.go
+++ b/pkg/plugins/assign/assign.go
@@ -190,7 +190,7 @@ type handler struct {
 func newAssignHandler(e github.GenericCommentEvent, gc githubClient, log *logrus.Entry) *handler {
 	org := e.Repo.Owner.Login
 	addFailureResponse := func(mu github.MissingUsers) string {
-		return fmt.Sprintf("GitHub didn't allow me to assign the following users: %s.\n\nNote that only [%s members](https://github.com/orgs/%s/people) with read permissions, repo collaborators and people who have commented on this issue/PR can be assigned. Additionally, issues/PRs can only have 10 assignees at the same time.\nFor more information please see [the contributor guide](https://git.k8s.io/community/contributors/guide/first-contribution.md#issue-assignment-in-github)", strings.Join(mu.Users, ", "), org, org)
+		return fmt.Sprintf("GitHub didn't allow me to assign the following users: %s.\n\nNote that only [%s members](https://%s/orgs/%s/people) with read permissions, repo collaborators and people who have commented on this issue/PR can be assigned. Additionally, issues/PRs can only have 10 assignees at the same time.\nFor more information please see [the contributor guide](https://git.k8s.io/community/contributors/guide/first-contribution.md#issue-assignment-in-github)", strings.Join(mu.Users, ", "), org, github.DefaultHost, org)
 	}
 
 	return &handler{
@@ -208,7 +208,7 @@ func newAssignHandler(e github.GenericCommentEvent, gc githubClient, log *logrus
 func newReviewHandler(e github.GenericCommentEvent, gc githubClient, log *logrus.Entry) *handler {
 	org := e.Repo.Owner.Login
 	addFailureResponse := func(mu github.MissingUsers) string {
-		return fmt.Sprintf("GitHub didn't allow me to request PR reviews from the following users: %s.\n\nNote that only [%s members](https://github.com/orgs/%s/people) and repo collaborators can review this PR, and authors cannot review their own PRs.", strings.Join(mu.Users, ", "), org, org)
+		return fmt.Sprintf("GitHub didn't allow me to request PR reviews from the following users: %s.\n\nNote that only [%s members](https://%s/orgs/%s/people) and repo collaborators can review this PR, and authors cannot review their own PRs.", strings.Join(mu.Users, ", "), org, github.DefaultHost, org)
 	}
 
 	return &handler{

--- a/pkg/plugins/bugzilla/bugzilla.go
+++ b/pkg/plugins/bugzilla/bugzilla.go
@@ -996,7 +996,7 @@ func handleMerge(e event, gc githubClient, bc bugzilla.Client, options plugins.B
 			pr, err := gc.GetPullRequest(item.Org, item.Repo, item.Num)
 			if err != nil {
 				log.WithError(err).Warn("Unexpected error checking merge state of related pull request.")
-				return comment(formatError(fmt.Sprintf("checking the state of a related pull request at https://github.com/%s/%s/pull/%d", item.Org, item.Repo, item.Num), bc.Endpoint(), e.bugId, err))
+				return comment(formatError(fmt.Sprintf("checking the state of a related pull request at https://%s/%s/%s/pull/%d", github.DefaultHost, item.Org, item.Repo, item.Num), bc.Endpoint(), e.bugId, err))
 			}
 			merged = pr.Merged
 			state = pr.State
@@ -1017,7 +1017,7 @@ func handleMerge(e event, gc githubClient, bc bugzilla.Client, options plugins.B
 	}
 
 	link := func(bug bugzilla.ExternalBug) string {
-		return fmt.Sprintf("[%s/%s#%d](https://github.com/%s/%s/pull/%d)", bug.Org, bug.Repo, bug.Num, bug.Org, bug.Repo, bug.Num)
+		return fmt.Sprintf("[%s/%s#%d](https://%s/%s/%s/pull/%d)", bug.Org, bug.Repo, bug.Num, bug.Org, bug.Repo, github.DefaultHost, bug.Num)
 	}
 
 	mergedMessage := func(statement string) string {
@@ -1068,7 +1068,7 @@ func handleCherrypick(e event, gc githubClient, bc bugzilla.Client, options plug
 	pr, err := gc.GetPullRequest(e.org, e.repo, e.cherrypickFromPRNum)
 	if err != nil {
 		log.WithError(err).Warn("Unexpected error getting title of pull request being cherrypicked from.")
-		return comment(fmt.Sprintf("Error creating a cherry-pick bug in Bugzilla: failed to check the state of cherrypicked pull request at https://github.com/%s/%s/pull/%d: %v.\nPlease contact an administrator to resolve this issue, then request a bug refresh with <code>/bugzilla refresh</code>.", e.org, e.repo, e.cherrypickFromPRNum, err))
+		return comment(fmt.Sprintf("Error creating a cherry-pick bug in Bugzilla: failed to check the state of cherrypicked pull request at https://%s/%s/%s/pull/%d: %v.\nPlease contact an administrator to resolve this issue, then request a bug refresh with <code>/bugzilla refresh</code>.", github.DefaultHost, e.org, e.repo, e.cherrypickFromPRNum, err))
 	}
 	// Attempt to identify bug from PR title
 	bugID, bugMissing, err := bugIDFromTitle(pr.Title)
@@ -1239,7 +1239,7 @@ func handleClose(e event, gc githubClient, bc bugzilla.Client, options plugins.B
 						}
 						response += fmt.Sprintf(" All external bug links have been closed. The bug has been moved to the %s state.", options.StateAfterClose)
 					}
-					bzComment := &bugzilla.CommentCreate{ID: bug.ID, Comment: fmt.Sprintf("Bug status changed to %s as previous linked PR https://github.com/%s/%s/pull/%d has been closed", options.StateAfterClose.Status, e.org, e.repo, e.number), IsPrivate: true}
+					bzComment := &bugzilla.CommentCreate{ID: bug.ID, Comment: fmt.Sprintf("Bug status changed to %s as previous linked PR https://%s/%s/%s/pull/%d has been closed", options.StateAfterClose.Status, github.DefaultHost, e.org, e.repo, e.number), IsPrivate: true}
 					if _, err := bc.CreateComment(bzComment); err != nil {
 						response += "\nWarning: Failed to comment on Bugzilla bug with reason for changed state."
 					}

--- a/pkg/plugins/dco/dco.go
+++ b/pkg/plugins/dco/dco.go
@@ -332,7 +332,7 @@ func handle(config plugins.Dco, gc gitHubClient, cp commentPruner, log *logrus.E
 		contributingPath = config.ContributingPath
 	}
 
-	contributingUrl := fmt.Sprintf("https://github.com/%s/blob/%s/%s", contributingRepo, contributingBranch, contributingPath)
+	contributingUrl := fmt.Sprintf("https://%s/%s/blob/%s/%s", github.DefaultHost, contributingRepo, contributingBranch, contributingPath)
 
 	return takeAction(gc, cp, l, org, repo, pr, commitsMissingDCO, existingStatus, contributingUrl, hasYesLabel, hasNoLabel, addComment)
 }
@@ -340,7 +340,7 @@ func handle(config plugins.Dco, gc gitHubClient, cp commentPruner, log *logrus.E
 // MarkdownSHAList prints the list of commits in a markdown-friendly way.
 func MarkdownSHAList(org, repo string, list []github.RepositoryCommit) string {
 	lines := make([]string, len(list))
-	lineFmt := "- [%s](https://github.com/%s/%s/commits/%s) %s"
+	lineFmt := "- [%s](https://%s/%s/%s/commits/%s) %s"
 	for i, commit := range list {
 		if commit.SHA == "" {
 			continue
@@ -355,7 +355,7 @@ func MarkdownSHAList(org, repo string, list []github.RepositoryCommit) string {
 		// get the first line of the commit
 		message := strings.Split(commit.Commit.Message, "\n")[0]
 
-		lines[i] = fmt.Sprintf(lineFmt, shortSHA, org, repo, commit.SHA, message)
+		lines[i] = fmt.Sprintf(lineFmt, shortSHA, github.DefaultHost, org, repo, commit.SHA, message)
 	}
 	return strings.Join(lines, "\n")
 }

--- a/pkg/plugins/milestone/milestone.go
+++ b/pkg/plugins/milestone/milestone.go
@@ -36,7 +36,7 @@ const pluginName = "milestone"
 
 var (
 	milestoneRegex   = regexp.MustCompile(`(?m)^/milestone\s+(.+?)\s*$`)
-	mustBeAuthorized = "You must be a member of the [%s/%s](https://github.com/orgs/%s/teams/%s/members) GitHub team to set the milestone. If you believe you should be able to issue the /milestone command, please contact your %s and have them propose you as an additional delegate for this responsibility."
+	mustBeAuthorized = "You must be a member of the [%s/%s](https://%s/orgs/%s/teams/%s/members) GitHub team to set the milestone. If you believe you should be able to issue the /milestone command, please contact your %s and have them propose you as an additional delegate for this responsibility."
 	invalidMilestone = "The provided milestone is not valid for this repository. Milestones in this repository: [%s]\n\nUse `/milestone %s` to clear the milestone."
 	milestoneTeamMsg = "The milestone maintainers team is the GitHub team %q with ID: %d."
 	clearKeyword     = "clear"
@@ -127,7 +127,7 @@ func handle(gc githubClient, log *logrus.Entry, e *github.GenericCommentEvent, r
 	}
 	if !found {
 		// not in the milestone maintainers team
-		msg := fmt.Sprintf(mustBeAuthorized, org, milestone.MaintainersTeam, org, milestone.MaintainersTeam, milestone.MaintainersFriendlyName)
+		msg := fmt.Sprintf(mustBeAuthorized, org, milestone.MaintainersTeam, github.DefaultHost, org, milestone.MaintainersTeam, milestone.MaintainersFriendlyName)
 		return gc.CreateComment(org, repo, e.Number, plugins.FormatResponseRaw(e.Body, e.HTMLURL, e.User.Login, msg))
 	}
 

--- a/pkg/plugins/milestonestatus/milestonestatus.go
+++ b/pkg/plugins/milestonestatus/milestonestatus.go
@@ -35,7 +35,7 @@ const pluginName = "milestonestatus"
 
 var (
 	statusRegex      = regexp.MustCompile(`(?m)^/status\s+(.+)$`)
-	mustBeAuthorized = "You must be a member of the [%s/%s](https://github.com/orgs/%s/teams/%s/members) GitHub team to add status labels. If you believe you should be able to issue the /status command, please contact your %s and have them propose you as an additional delegate for this responsibility."
+	mustBeAuthorized = "You must be a member of the [%s/%s](https://%s/orgs/%s/teams/%s/members) GitHub team to add status labels. If you believe you should be able to issue the /status command, please contact your %s and have them propose you as an additional delegate for this responsibility."
 	milestoneTeamMsg = "The milestone maintainers team is the GitHub team %q"
 	statusMap        = map[string]string{
 		"approved-for-milestone": "status/approved-for-milestone",
@@ -121,7 +121,7 @@ func handle(gc githubClient, log *logrus.Entry, e *github.GenericCommentEvent, r
 	}
 	if !found {
 		// not in the milestone maintainers team
-		msg := fmt.Sprintf(mustBeAuthorized, org, milestone.MaintainersTeam, org, milestone.MaintainersTeam, milestone.MaintainersFriendlyName)
+		msg := fmt.Sprintf(mustBeAuthorized, org, milestone.MaintainersTeam, github.DefaultHost, org, milestone.MaintainersTeam, milestone.MaintainersFriendlyName)
 		return gc.CreateComment(org, repo, e.Number, msg)
 	}
 

--- a/pkg/plugins/project/project.go
+++ b/pkg/plugins/project/project.go
@@ -39,7 +39,7 @@ const (
 var (
 	projectRegex              = regexp.MustCompile(`(?m)^/project\s(.*?)$`)
 	notTeamConfigMsg          = "There is no maintainer team for this repo or org."
-	notATeamMemberMsg         = "You must be a member of the [%s/%s](https://github.com/orgs/%s/teams/%s/members) github team to set the project and column."
+	notATeamMemberMsg         = "You must be a member of the [%s/%s](https://%s/orgs/%s/teams/%s/members) github team to set the project and column."
 	invalidProject            = "The provided project is not valid for this organization. Projects in Kubernetes orgs and repositories: [%s]."
 	invalidColumn             = "A column is not provided or it's not valid for the project %s. Please provide one of the following columns in the command:\n%v"
 	invalidNumArgs            = "Please provide 1 or more arguments. Example usage: /project 0.5.0, /project 0.5.0 To do, /project clear 0.4.0"
@@ -218,7 +218,7 @@ func handle(gc githubClient, log *logrus.Entry, e *github.GenericCommentEvent, p
 	}
 	if !isAMember {
 		// not in the project maintainers team
-		msg = fmt.Sprintf(notATeamMemberMsg, org, repo, org, repo)
+		msg = fmt.Sprintf(notATeamMemberMsg, org, repo, github.DefaultHost, org, repo)
 		return gc.CreateComment(org, repo, e.Number, plugins.FormatResponseRaw(e.Body, e.HTMLURL, e.User.Login, msg))
 	}
 
@@ -333,7 +333,7 @@ func handle(gc githubClient, log *logrus.Entry, e *github.GenericCommentEvent, p
 	var foundColumnID int
 	for _, colID := range projectColumns {
 		// make issue URL in the form of card content URL
-		issueURL := fmt.Sprintf("https://api.github.com/repos/%s/%s/issues/%v", org, repo, e.Number)
+		issueURL := fmt.Sprintf("%s/repos/%s/%s/issues/%v", github.DefaultAPIEndpoint, org, repo, e.Number)
 		existingProjectCard, err = gc.GetColumnProjectCard(org, colID.ID, issueURL)
 		if err != nil {
 			return err

--- a/pkg/plugins/projectmanager/projectmanager.go
+++ b/pkg/plugins/projectmanager/projectmanager.go
@@ -205,7 +205,7 @@ func getMatchingColumnIDs(gc githubClient, orgRepos map[string]plugins.ManagedOr
 		}
 	}
 
-	issueURL := fmt.Sprintf("https://api.github.com/repos/%s/%s/issues/%v", e.org, e.repo, e.number)
+	issueURL := fmt.Sprintf("%s/repos/%s/%s/issues/%v", github.DefaultAPIEndpoint, e.org, e.repo, e.number)
 	for orgRepoName, managedOrgRepo := range orgRepos {
 		for projectName, managedProject := range managedOrgRepo.Projects {
 			for _, managedColumn := range managedProject.Columns {

--- a/pkg/plugins/transfer-issue/transfer-issue_test.go
+++ b/pkg/plugins/transfer-issue/transfer-issue_test.go
@@ -202,7 +202,7 @@ type testClient struct {
 func (t *testClient) GetRepo(org, name string) (github.FullRepo, error) {
 	r := []rune(name)
 	if lastChar := r[len(r)-1]; unicode.IsSpace(lastChar) {
-		return github.FullRepo{}, fmt.Errorf("failed creating new request: parse \"https://api.github.com/repos/%s/%s\\r\": net/url: invalid control character in URL", org, name)
+		return github.FullRepo{}, fmt.Errorf("failed creating new request: parse \"%s/repos/%s/%s\\r\": net/url: invalid control character in URL", github.DefaultAPIEndpoint, org, name)
 	}
 	repo, err := t.fc.GetRepo(org, name)
 	if len(t.repoNodeID) != 0 {

--- a/pkg/plugins/trigger/pull-request.go
+++ b/pkg/plugins/trigger/pull-request.go
@@ -254,14 +254,14 @@ func welcomeMsg(ghc githubClient, trigger plugins.Trigger, pr github.PullRequest
 	encodedRepoFullName := url.QueryEscape(pr.Base.Repo.FullName)
 	var more string
 	if trigger.TrustedOrg != "" && trigger.TrustedOrg != org {
-		more = fmt.Sprintf("or [%s](https://github.com/orgs/%s/people) ", trigger.TrustedOrg, trigger.TrustedOrg)
+		more = fmt.Sprintf("or [%s](https://%s/orgs/%s/people) ", github.DefaultHost, trigger.TrustedOrg, trigger.TrustedOrg)
 	}
 
 	var joinOrgURL string
 	if trigger.JoinOrgURL != "" {
 		joinOrgURL = trigger.JoinOrgURL
 	} else {
-		joinOrgURL = fmt.Sprintf("https://github.com/orgs/%s/people", org)
+		joinOrgURL = fmt.Sprintf("https://%s/orgs/%s/people", github.DefaultHost, org)
 	}
 
 	var comment string
@@ -280,7 +280,7 @@ I understand the commands that are listed [here](https://go.k8s.io/bot-commands?
 	} else {
 		comment = fmt.Sprintf(`Hi @%s. Thanks for your PR.
 
-I'm waiting for a [%s](https://github.com/orgs/%s/people) %smember to verify that this patch is reasonable to test. If it is, they should reply with `+"`/ok-to-test`"+` on its own line. Until that is done, I will not automatically test new commits in this PR, but the usual testing commands by org members will still work. Regular contributors should [join the org](%s) to skip this step.
+I'm waiting for a [%s](https://%s/orgs/%s/people) %smember to verify that this patch is reasonable to test. If it is, they should reply with `+"`/ok-to-test`"+` on its own line. Until that is done, I will not automatically test new commits in this PR, but the usual testing commands by org members will still work. Regular contributors should [join the org](%s) to skip this step.
 
 Once the patch is verified, the new status will be reflected by the `+"`%s`"+` label.
 
@@ -290,7 +290,7 @@ I understand the commands that are listed [here](https://go.k8s.io/bot-commands?
 
 %s
 </details>
-`, author, org, org, more, joinOrgURL, labels.OkToTest, encodedRepoFullName, plugins.AboutThisBotWithoutCommands)
+`, author, org, github.DefaultHost, org, more, joinOrgURL, labels.OkToTest, encodedRepoFullName, plugins.AboutThisBotWithoutCommands)
 
 		l, err := ghc.GetIssueLabels(org, repo, pr.Number)
 		if err != nil {

--- a/pkg/plugins/verify-owners/verify-owners.go
+++ b/pkg/plugins/verify-owners/verify-owners.go
@@ -364,7 +364,7 @@ func handle(ghc githubClient, gc git.ClientFactory, roc repoownersClient, log *l
 	if triggerConfig.JoinOrgURL != "" {
 		joinOrgURL = triggerConfig.JoinOrgURL
 	} else {
-		joinOrgURL = fmt.Sprintf("https://github.com/orgs/%s/people", org)
+		joinOrgURL = fmt.Sprintf("https://%s/orgs/%s/people", github.DefaultHost, org)
 	}
 
 	if len(nonTrustedUsers) > 0 {

--- a/pkg/pod-utils/clone/clone.go
+++ b/pkg/pod-utils/clone/clone.go
@@ -145,7 +145,7 @@ func PathForRefs(baseDir string, refs prowapi.Refs) string {
 		parts := strings.Split(refs.RepoLink, "://")
 		clonePath = parts[len(parts)-1]
 	} else {
-		clonePath = fmt.Sprintf("github.com/%s/%s", refs.Org, refs.Repo)
+		clonePath = fmt.Sprintf("%s/%s/%s", github.DefaultHost, refs.Org, refs.Repo)
 	}
 	return path.Join(baseDir, "src", clonePath)
 }
@@ -163,7 +163,7 @@ func gitCtxForRefs(refs prowapi.Refs, baseDir string, env []string, user, token 
 	if refs.RepoLink != "" {
 		repoURI = fmt.Sprintf("%s.git", refs.RepoLink)
 	} else {
-		repoURI = fmt.Sprintf("https://github.com/%s/%s.git", refs.Org, refs.Repo)
+		repoURI = fmt.Sprintf("https://%s/%s/%s.git", github.DefaultHost, refs.Org, refs.Repo)
 	}
 
 	g := gitCtx{


### PR DESCRIPTION
Wherever possible, use the github `DefaultHost` constant instead of a static string.