### PR TITLE
Delete old /test help messages after a successful invocation

### DIFF
--- a/pkg/pjutil/help_test.go
+++ b/pkg/pjutil/help_test.go
@@ -1,0 +1,175 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pjutil
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+func TestHelp(t *testing.T) {
+	tests := []struct {
+		name          string
+		userComment   string
+		matchingTests int
+		mayNeedHelp   bool
+		shouldRespond bool
+		note          string
+		shouldPrune   bool
+	}{
+		{
+			name:        "empty comment is neither a failed nor a successful test trigger",
+			userComment: "",
+			mayNeedHelp: false,
+			shouldPrune: false,
+		},
+		{
+			name:        "random comment is neither a failed nor a successful test trigger",
+			userComment: "This is a comment about testing.",
+			mayNeedHelp: false,
+			shouldPrune: false,
+		},
+		{
+			name:          "request for existing test is a successful test trigger",
+			userComment:   "/test e2e",
+			matchingTests: 1,
+			mayNeedHelp:   true,
+			shouldRespond: false,
+			shouldPrune:   true,
+		},
+		{
+			name:          "request for non-existent test is an unsuccessful test trigger",
+			userComment:   "/test f2f",
+			matchingTests: 0,
+			mayNeedHelp:   true,
+			shouldRespond: true,
+			note:          TargetNotFoundNote,
+			shouldPrune:   false,
+		},
+		{
+			name:          "test all when tests exist is a successful test trigger",
+			userComment:   "/test all",
+			matchingTests: 1,
+			mayNeedHelp:   true,
+			shouldRespond: false,
+			shouldPrune:   true,
+		},
+		{
+			name:          "test all when no tests exist is an unsuccessful test trigger",
+			userComment:   "/test all",
+			matchingTests: 0,
+			mayNeedHelp:   true,
+			shouldRespond: true,
+			note:          ThereAreNoTestAllJobsNote,
+			shouldPrune:   false,
+		},
+		{
+			name:          "retest is a successful test trigger",
+			userComment:   "/retest",
+			matchingTests: 1,
+			mayNeedHelp:   false,
+			shouldPrune:   true,
+		},
+		{
+			name:          "retest is a successful test trigger, even when no tests exist",
+			userComment:   "/retest",
+			matchingTests: 0,
+			mayNeedHelp:   false,
+			shouldPrune:   true,
+		},
+		{
+			name:          "empty /test is invalid",
+			userComment:   "/test",
+			mayNeedHelp:   true,
+			shouldRespond: true,
+			note:          TestWithoutTargetNote,
+			shouldPrune:   false,
+		},
+		{
+			name:          "retest with target is invalid",
+			userComment:   "/retest e2e",
+			mayNeedHelp:   true,
+			shouldRespond: true,
+			note:          RetestWithTargetNote,
+			shouldPrune:   false,
+		},
+		{
+			name:          "/test ? is a request for help, not a trigger",
+			userComment:   "/test ?",
+			mayNeedHelp:   true,
+			shouldRespond: true,
+			note:          "",
+			shouldPrune:   false,
+		},
+	}
+
+	required := sets.New("/test e2e", "/test e2e-serial", "/test unit")
+	optional := sets.New("/test lint", "/test e2e-conformance-commodore64")
+	all := required.Union(optional)
+	helpBody := HelpMessage("", "", "", "", all, optional, required)
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// None of the user comments should look like our help comment.
+			if IsHelpComment(tc.userComment) {
+				t.Errorf("Expected IsHelpComment(%q) to return false, got true", tc.userComment)
+			}
+
+			// MayNeedHelpComment is true if the comment uses `/test` or
+			// `/retest` at all (whether valid or invalid).
+			mayNeedHelp := MayNeedHelpComment(tc.userComment)
+			if mayNeedHelp != tc.mayNeedHelp {
+				t.Errorf("Expected MayNeedHelpComment(%q) to return %v, got %v", tc.userComment, tc.mayNeedHelp, mayNeedHelp)
+			}
+
+			// ShouldRespondWithHelp will check if userComment contains a
+			// `/test` or `/retest` invocation that is invalid given the
+			// number of matching tests.
+			shouldRespond, note := ShouldRespondWithHelp(tc.userComment, tc.matchingTests)
+			if shouldRespond != tc.shouldRespond {
+				t.Errorf("Expected ShouldRespondWithHelp(%q, %d) to return %v, got %v", tc.userComment, tc.matchingTests, tc.shouldRespond, shouldRespond)
+			}
+			if note != tc.note {
+				t.Errorf("Expected ShouldRespondWithHelp(%q) to return note %q, got %q", tc.userComment, tc.note, note)
+			}
+
+			// If we should respond with a help comment, then HelpMessage
+			// should return the expected message, and IsHelpComment should
+			// recognize it.
+			if shouldRespond {
+				expectHelpMessage := tc.note + helpBody
+				helpMessage := HelpMessage("", "", "", note, all, optional, required)
+				if helpMessage != expectHelpMessage {
+					t.Errorf("Expected HelpMessage() to return %q, got %q", expectHelpMessage, helpMessage)
+				}
+				if !IsHelpComment(helpMessage) {
+					t.Errorf("Expected IsHelpComment(%q) to return true, got false", helpMessage)
+				}
+			}
+
+			// If we shouldn't respond with a help comment, then we possibly
+			// should respond by deleted old help comments.
+			if !shouldRespond {
+				shouldPrune := ShouldRespondByPruningHelp(tc.userComment)
+				if shouldPrune != tc.shouldPrune {
+					t.Errorf("Expected ShouldRespondByPruningHelp(%q) to return %v, got %v", tc.userComment, tc.shouldPrune, shouldPrune)
+				}
+			}
+		})
+	}
+}

--- a/pkg/plugins/trigger/generic-comment_test.go
+++ b/pkg/plugins/trigger/generic-comment_test.go
@@ -47,6 +47,14 @@ func issueLabels(labels ...string) []string {
 
 const shouldNotAddComment = "<none>"
 
+type fakeCommentPruner struct {
+	called bool
+}
+
+func (cp *fakeCommentPruner) PruneComments(shouldPrune func(github.IssueComment) bool) {
+	cp.called = true
+}
+
 type testcase struct {
 	name string
 
@@ -64,6 +72,7 @@ type testcase struct {
 	IssueLabels    []string
 	IgnoreOkToTest bool
 	AddedComment   string
+	PruneHelp      bool
 }
 
 func TestHandleGenericComment(t *testing.T) {
@@ -123,6 +132,7 @@ func TestHandleGenericComment(t *testing.T) {
 			State:       "open",
 			IsPR:        true,
 			ShouldBuild: true,
+			PruneHelp:   true,
 		},
 		{
 			name:        "reject /test from non-trusted member when PR author is untrusted",
@@ -141,6 +151,7 @@ func TestHandleGenericComment(t *testing.T) {
 			State:       "open",
 			IsPR:        true,
 			ShouldBuild: true,
+			PruneHelp:   true,
 			IssueLabels: issueLabels(labels.OkToTest),
 		},
 		{
@@ -151,6 +162,7 @@ func TestHandleGenericComment(t *testing.T) {
 			State:         "open",
 			IsPR:          true,
 			ShouldBuild:   true,
+			PruneHelp:     true,
 			IssueLabels:   issueLabels(labels.NeedsOkToTest, labels.OkToTest),
 			RemovedLabels: issueLabels(labels.NeedsOkToTest),
 		},
@@ -201,6 +213,7 @@ func TestHandleGenericComment(t *testing.T) {
 			State:       "open",
 			IsPR:        true,
 			ShouldBuild: true,
+			PruneHelp:   true,
 		},
 		{
 			name: "Wrong branch",
@@ -221,6 +234,7 @@ func TestHandleGenericComment(t *testing.T) {
 			IsPR:          true,
 			ShouldBuild:   true,
 			StartsExactly: "pull-jib",
+			PruneHelp:     true,
 		},
 		{
 			name: "Retest with one running and one failed, trailing space.",
@@ -231,6 +245,7 @@ func TestHandleGenericComment(t *testing.T) {
 			IsPR:          true,
 			ShouldBuild:   true,
 			StartsExactly: "pull-jib",
+			PruneHelp:     true,
 		},
 		{
 			name:   "test of silly regex job",
@@ -255,6 +270,10 @@ func TestHandleGenericComment(t *testing.T) {
 			},
 			ShouldBuild:   true,
 			StartsExactly: "pull-jab",
+
+			// We only add/remove help comments for things that look like the
+			// normal triggers.
+			PruneHelp: false,
 		},
 		{
 			name: "needs-ok-to-test label is removed when no presubmit runs by default",
@@ -345,6 +364,7 @@ func TestHandleGenericComment(t *testing.T) {
 			},
 			ShouldBuild:   true,
 			StartsExactly: "pull-jab",
+			PruneHelp:     true,
 		},
 		{
 			name:   "Retest of skip_if_only_changed job that hasn't run. Changes require job",
@@ -372,6 +392,7 @@ func TestHandleGenericComment(t *testing.T) {
 			},
 			ShouldBuild:   true,
 			StartsExactly: "pull-jab",
+			PruneHelp:     true,
 		},
 		{
 			name:   "Retest of run_if_changed job that failed. Changes require job",
@@ -398,6 +419,7 @@ func TestHandleGenericComment(t *testing.T) {
 			},
 			ShouldBuild:   true,
 			StartsExactly: "pull-jib",
+			PruneHelp:     true,
 		},
 		{
 			name:   "Retest of skip_if_only_changed job that failed. Changes require job",
@@ -424,6 +446,7 @@ func TestHandleGenericComment(t *testing.T) {
 			},
 			ShouldBuild:   true,
 			StartsExactly: "pull-jib",
+			PruneHelp:     true,
 		},
 		{
 			name:   "/test of run_if_changed job that has passed",
@@ -450,6 +473,7 @@ func TestHandleGenericComment(t *testing.T) {
 			},
 			ShouldBuild:   true,
 			StartsExactly: "pull-jub",
+			PruneHelp:     true,
 		},
 		{
 			name:   "/test of skip_if_only_changed job that has passed",
@@ -476,6 +500,7 @@ func TestHandleGenericComment(t *testing.T) {
 			},
 			ShouldBuild:   true,
 			StartsExactly: "pull-jub",
+			PruneHelp:     true,
 		},
 		{
 			name:   "Retest triggers failed job",
@@ -498,6 +523,7 @@ func TestHandleGenericComment(t *testing.T) {
 				},
 			},
 			ShouldBuild: true,
+			PruneHelp:   true,
 		},
 		{
 			name:   "Retest triggers failed job that is optional",
@@ -521,6 +547,7 @@ func TestHandleGenericComment(t *testing.T) {
 				},
 			},
 			ShouldBuild: true,
+			PruneHelp:   true,
 		},
 		{
 			name:   "Retest-Required doesn't triggers failed job",
@@ -543,6 +570,7 @@ func TestHandleGenericComment(t *testing.T) {
 				},
 			},
 			ShouldBuild: true,
+			PruneHelp:   true,
 		},
 		{
 			name:   "Retest-Required doesn't trigger failed job that is optional",
@@ -565,6 +593,7 @@ func TestHandleGenericComment(t *testing.T) {
 					},
 				},
 			},
+			PruneHelp: true,
 		},
 		{
 			name:   "Retest of run_if_changed job that failed. Changes do not require the job",
@@ -590,6 +619,7 @@ func TestHandleGenericComment(t *testing.T) {
 				},
 			},
 			ShouldBuild: true,
+			PruneHelp:   true,
 		},
 		{
 			name:   "Retest of skip_if_only_changed job that failed. Changes do not require the job",
@@ -615,6 +645,7 @@ func TestHandleGenericComment(t *testing.T) {
 				},
 			},
 			ShouldBuild: true,
+			PruneHelp:   true,
 		},
 		{
 			name:   "Run if changed job triggered by /ok-to-test",
@@ -708,6 +739,7 @@ func TestHandleGenericComment(t *testing.T) {
 			},
 			ShouldBuild:   true,
 			StartsExactly: "pull-jab",
+			PruneHelp:     true,
 		},
 		{
 			name:   "branch-sharded job. no shard matches base branch",
@@ -767,6 +799,7 @@ func TestHandleGenericComment(t *testing.T) {
 					},
 				},
 			},
+			PruneHelp: true,
 		},
 		{
 			name: "/retest of SkipIfOnlyChanged job that doesn't need to run and hasn't run",
@@ -792,6 +825,7 @@ func TestHandleGenericComment(t *testing.T) {
 					},
 				},
 			},
+			PruneHelp: true,
 		},
 		{
 			name: "explicit /test for RunIfChanged job that doesn't need to run",
@@ -870,6 +904,7 @@ func TestHandleGenericComment(t *testing.T) {
 			},
 			ShouldBuild:   true,
 			StartsExactly: "pull-jub",
+			PruneHelp:     true,
 		},
 		{
 			name:   "/test all of skip_if_only_changed job that has passed and needs to run",
@@ -896,6 +931,7 @@ func TestHandleGenericComment(t *testing.T) {
 			},
 			ShouldBuild:   true,
 			StartsExactly: "pull-jub",
+			PruneHelp:     true,
 		},
 		{
 			name:   "/test all of run_if_changed job that has passed and doesn't need to run",
@@ -953,6 +989,7 @@ func TestHandleGenericComment(t *testing.T) {
 			State:       "open",
 			IsPR:        true,
 			ShouldBuild: true,
+			PruneHelp:   true,
 		},
 		{
 			name:        `Non-trusted member after "/lgtm" and "/approve"`,
@@ -1134,6 +1171,7 @@ func TestHandleGenericComment(t *testing.T) {
 			IsPR:          true,
 			ShouldBuild:   true,
 			StartsExactly: "pull-jib",
+			PruneHelp:     true,
 		},
 		{
 			name:         "/test with unknown target results in a help message",
@@ -1485,23 +1523,25 @@ func TestHandleGenericComment(t *testing.T) {
 			}
 			trigger.SetDefaults()
 
+			cp := &fakeCommentPruner{}
+
 			log.Printf("running case %s", tc.name)
 			// In some cases handleGenericComment can be called twice for the same event.
 			// For instance on Issue/PR creation and modification.
 			// Let's call it twice to ensure idempotency.
-			if err := handleGenericComment(c, trigger, event); err != nil {
+			if err := handleGenericComment(c, cp, trigger, event); err != nil {
 				t.Fatalf("%s: didn't expect error: %s", tc.name, err)
 			}
-			validate(t, fakeProwJobClient.Fake.Actions(), g, tc)
-			if err := handleGenericComment(c, trigger, event); err != nil {
+			validate(t, fakeProwJobClient.Fake.Actions(), g, cp, tc)
+			if err := handleGenericComment(c, cp, trigger, event); err != nil {
 				t.Fatalf("%s: didn't expect error: %s", tc.name, err)
 			}
-			validate(t, fakeProwJobClient.Fake.Actions(), g, tc)
+			validate(t, fakeProwJobClient.Fake.Actions(), g, cp, tc)
 		})
 	}
 }
 
-func validate(t *testing.T, actions []clienttesting.Action, g *fakegithub.FakeClient, tc testcase) {
+func validate(t *testing.T, actions []clienttesting.Action, g *fakegithub.FakeClient, cp *fakeCommentPruner, tc testcase) {
 	startedContexts := sets.New[string]()
 	for _, action := range actions {
 		switch action := action.(type) {
@@ -1540,6 +1580,11 @@ func validate(t *testing.T, actions []clienttesting.Action, g *fakegithub.FakeCl
 				}
 			}
 		}
+	}
+	if tc.PruneHelp && !cp.called {
+		t.Errorf("expected to prune old help comment on successful trigger, but did not")
+	} else if !tc.PruneHelp && cp.called {
+		t.Errorf("expected to not prune old help comment, but did")
 	}
 }
 

--- a/pkg/plugins/trigger/trigger.go
+++ b/pkg/plugins/trigger/trigger.go
@@ -210,7 +210,11 @@ func handlePullRequest(pc plugins.Agent, pr github.PullRequestEvent) error {
 }
 
 func handleGenericCommentEvent(pc plugins.Agent, gc github.GenericCommentEvent) error {
-	return handleGenericComment(getClient(pc), pc.PluginConfig.TriggerFor(gc.Repo.Owner.Login, gc.Repo.Name), gc)
+	cp, err := pc.CommentPruner()
+	if err != nil {
+		return err
+	}
+	return handleGenericComment(getClient(pc), cp, pc.PluginConfig.TriggerFor(gc.Repo.Owner.Login, gc.Repo.Name), gc)
 }
 
 func handlePush(pc plugins.Agent, pe github.PushEvent) error {


### PR DESCRIPTION
If a user misuses `/test` or `/retest` and gets a 50-page-long help message from prow, and then triggers a test correctly afterward, delete the help message so as to de-spam the PR.

Fixes #374 

I don't know this codebase at all and probably did stuff wrong. Also, I'm not sure how to actually test it. ~~(I assume I need to add a unit test to `pkg/plugins/trigger/` too, but I was having a hard time figuring out if I could actually figure out which test cases should result in comment deletion correctly just from the info already in the testcase struct, so I gave up on it for now since you might request large rewrites anyway...)~~

/assign @petr-muller 
since you :+1: 'd the idea on #374...