### PR TITLE
Fix Kubernetes link on landing page

### DIFF
--- a/site/content/en/_index.html
+++ b/site/content/en/_index.html
@@ -18,7 +18,7 @@ title = "Prow"
 
 
 {{% blocks/lead color="white" %}}
-Did you know that [Kubernetes](https://github.com/kubernetes/kubernetes) uses Prow to test PRs? And of course, Prow itself runs on Kubernetes. Inception!
+Did you know that <a href="https://github.com/kubernetes/kubernetes>Kubernetes"</a> uses Prow to test PRs? And of course, Prow itself runs on Kubernetes. Inception!
 {{% /blocks/lead %}}
 
 {{< blocks/section color="dark" >}}


### PR DESCRIPTION
There is a link to the main k/k repo on the docs landing page. This index file is html, not markdown, so the existing markdown link formatting does not get rendered into the expected html.

This updates the link to use standard html.

<img width="1642" height="150" alt="image" src="https://github.com/user-attachments/assets/51a35b1d-4dfb-4366-bfd5-043956e78eb3" />
