### PR TITLE
docs: Fix hyperlink typos causing bad link

### DIFF
--- a/site/content/en/_index.html
+++ b/site/content/en/_index.html
@@ -18,7 +18,7 @@ title = "Prow"
 
 
 {{% blocks/lead color="white" %}}
-Did you know that <a href="https://github.com/kubernetes/kubernetes>Kubernetes"</a> uses Prow to test PRs? And of course, Prow itself runs on Kubernetes. Inception!
+Did you know that <a href="https://github.com/kubernetes/kubernetes">Kubernetes</a> uses Prow to test PRs? And of course, Prow itself runs on Kubernetes. Inception!
 {{% /blocks/lead %}}
 
 {{< blocks/section color="dark" >}}


### PR DESCRIPTION
Previous fix (#532) for the hyperlink had a typo in it that causes rendering issues and for the link to be invalid. This corrects the typo.