### PR TITLE
tide: remove PR from batch when batch fails

### DIFF
--- a/pkg/tide/tide.go
+++ b/pkg/tide/tide.go
@@ -934,6 +934,33 @@ func pickHighestPriorityPR(log *logrus.Entry, prs []CodeReviewCommon, cc map[int
 	return false, smallestPR
 }
 
+// pickLowestPriorityPR returns the PR with the highest number (newest, lowest
+// priority in Tide's ordering) from the list. Used to select which PR to
+// exclude when bisecting a failed batch.
+func pickLowestPriorityPR(prs []CodeReviewCommon) (bool, CodeReviewCommon) {
+	if len(prs) == 0 {
+		return false, CodeReviewCommon{}
+	}
+	result := prs[0]
+	for _, pr := range prs[1:] {
+		if pr.Number > result.Number {
+			result = pr
+		}
+	}
+	return true, result
+}
+
+// withoutPR returns a copy of prs excluding the PR with the given number.
+func withoutPR(prs []CodeReviewCommon, excludeNumber int) []CodeReviewCommon {
+	result := make([]CodeReviewCommon, 0, len(prs))
+	for _, pr := range prs {
+		if pr.Number != excludeNumber {
+			result = append(result, pr)
+		}
+	}
+	return result
+}
+
 // accumulateBatch looks at existing batch ProwJobs and, if applicable, returns:
 // * A list of PRs that are part of a batch test that finished successfully
 // * A list of PRs that are part of a batch test that hasn't finished yet but
@@ -943,7 +970,7 @@ func pickHighestPriorityPR(log *logrus.Entry, prs []CodeReviewCommon, cc map[int
 // successBatch, it's possible that these jobs haven't run yet, and in the case
 // we should consider this batch as failed so that takeAction can trigger a new
 // batch.
-func (c *syncController) accumulateBatch(sp subpool) (successBatch []CodeReviewCommon, pendingBatch []CodeReviewCommon) {
+func (c *syncController) accumulateBatch(sp subpool) (successBatch, pendingBatch, failedBatch []CodeReviewCommon) {
 	sp.log.Debug("accumulating PRs for batch testing")
 	prNums := make(map[int]CodeReviewCommon)
 	for _, pr := range sp.prs {
@@ -1032,9 +1059,11 @@ func (c *syncController) accumulateBatch(sp subpool) (successBatch []CodeReviewC
 			pendingBatch = state.prs
 		case successState:
 			successBatch = state.prs
+		case failureState:
+			failedBatch = state.prs
 		}
 	}
-	return successBatch, pendingBatch
+	return successBatch, pendingBatch, failedBatch
 }
 
 // prowJobsFromContexts constructs ProwJob objects from all successful presubmit contexts that include a baseSHA.
@@ -1539,7 +1568,7 @@ func (c *syncController) nonFailedBatchForJobAndRefsExists(jobName string, refs 
 	return len(pjs.Items) > 0
 }
 
-func (c *syncController) takeAction(sp subpool, batchPending, successes, pendings, missings, batchMerges []CodeReviewCommon, missingSerialTests map[int][]config.Presubmit) (Action, []CodeReviewCommon, error) {
+func (c *syncController) takeAction(sp subpool, batchPending, batchFailed, successes, pendings, missings, batchMerges []CodeReviewCommon, missingSerialTests map[int][]config.Presubmit) (Action, []CodeReviewCommon, error) {
 	var merged []CodeReviewCommon
 	var err error
 	defer func() {
@@ -1565,9 +1594,19 @@ func (c *syncController) takeAction(sp subpool, batchPending, successes, pending
 	if len(sp.presubmits) == 0 {
 		return Wait, nil, nil
 	}
-	// If we have no batch, trigger one.
+	// If we have no batch, trigger one. If a batch just failed CI, bisect by
+	// excluding the lowest-priority PR from the failed set and testing a
+	// smaller batch, rather than re-triggering the same failing combination.
 	if len(sp.prs) > 1 && len(batchPending) == 0 {
-		batch, presubmits, err := c.pickBatch(sp, sp.cc, c.pickNewBatch)
+		batchSP := sp
+		if len(batchFailed) > 0 {
+			if ok, pr := pickLowestPriorityPR(batchFailed); ok {
+				sp.log.WithField("excluded_pr", pr.Number).Info(
+					"Bisecting failed batch by excluding lowest-priority PR")
+				batchSP.prs = withoutPR(sp.prs, pr.Number)
+			}
+		}
+		batch, presubmits, err := c.pickBatch(batchSP, sp.cc, c.pickNewBatch)
 		if err != nil {
 			return Wait, nil, err
 		}
@@ -1778,13 +1817,14 @@ func (c *syncController) presubmitsForBatch(prs []CodeReviewCommon, org, repo, b
 func (c *syncController) syncSubpool(sp subpool, blocks []blockers.Blocker) (Pool, error) {
 	sp.log.WithField("num_prs", len(sp.prs)).WithField("num_prowjobs", len(sp.pjs)).Info("Syncing subpool")
 	successes, pendings, missings, missingSerialTests := c.accumulate(sp.presubmits, sp.prs, sp.pjs, sp.sha)
-	batchMerge, batchPending := c.accumulateBatch(sp)
+	batchMerge, batchPending, batchFailed := c.accumulateBatch(sp)
 	sp.log.WithFields(logrus.Fields{
 		"prs-passing":   prNumbers(successes),
 		"prs-pending":   prNumbers(pendings),
 		"prs-missing":   prNumbers(missings),
 		"batch-passing": prNumbers(batchMerge),
 		"batch-pending": prNumbers(batchPending),
+		"batch-failed":  prNumbers(batchFailed),
 	}).Info("Subpool accumulated.")
 
 	tenantIDs := sp.TenantIDs()
@@ -1795,7 +1835,7 @@ func (c *syncController) syncSubpool(sp subpool, blocks []blockers.Blocker) (Poo
 	if len(blocks) > 0 {
 		act = PoolBlocked
 	} else {
-		act, targets, err = c.takeAction(sp, batchPending, successes, pendings, missings, batchMerge, missingSerialTests)
+		act, targets, err = c.takeAction(sp, batchPending, batchFailed, successes, pendings, missings, batchMerge, missingSerialTests)
 		if err != nil {
 			if mf, ok := err.(*mergeFailure); ok {
 				errorString = mf.historyMessage()

--- a/pkg/tide/tide_test.go
+++ b/pkg/tide/tide_test.go
@@ -298,7 +298,7 @@ func TestAccumulateBatch(t *testing.T) {
 				changedFiles: &changedFilesAgent{},
 				logger:       logrus.WithField("test", test.name),
 			}
-			merges, pending := c.accumulateBatch(subpool{org: "org", repo: "repo", prs: pulls, pjs: pjs, log: logrus.WithField("test", test.name)})
+			merges, pending, _ := c.accumulateBatch(subpool{org: "org", repo: "repo", prs: pulls, pjs: pjs, log: logrus.WithField("test", test.name)})
 			if (len(pending) > 0) != test.pending {
 				t.Errorf("For case \"%s\", got wrong pending.", test.name)
 			}
@@ -1536,6 +1536,7 @@ func testTakeAction(clients localgit.Clients, t *testing.T) {
 		name string
 
 		batchPending     bool
+		batchFailed      []int
 		successes        []int
 		pendings         []int
 		nones            []int
@@ -1965,6 +1966,41 @@ func testTakeAction(clients localgit.Clients, t *testing.T) {
 			action:           Trigger,
 			enableScheduling: true,
 		},
+		{
+			name:        "batch merge fails, returns MergeBatch with error (issue #474)",
+			batchMerges: []int{0, 1},
+			mergeErrs: map[int]error{
+				0: github.UnmergablePRError("merge conflict"),
+				1: github.UnmergablePRError("merge conflict"),
+			},
+			merged:    0,
+			triggered: 0,
+			action:    MergeBatch,
+			expectErr: true,
+		},
+		{
+			// When a batch CI test fails, Tide bisects by excluding the
+			// lowest-priority PR (highest number) from the failed batch and
+			// triggers a smaller batch from the remaining pool PRs.
+			// Pool has PRs {0,1,2}, failed batch was {0,1,2}, so PR 2 is
+			// excluded. The new batch is picked from {0,1}.
+			name:        "batch CI fails, bisects by excluding lowest-priority PR (issue #474)",
+			batchFailed: []int{0, 1, 2},
+			successes:   []int{},
+			pendings:    []int{},
+			nones:       []int{0, 1, 2},
+			batchMerges: []int{},
+			presubmits: map[int][]config.Presubmit{
+				100: {
+					{Reporter: config.Reporter{Context: "foo"}},
+					{Reporter: config.Reporter{Context: "if-changed"}},
+				},
+			},
+			merged:           0,
+			triggered:        2,
+			triggeredBatches: 2,
+			action:           TriggerBatch,
+		},
 	}
 
 	for _, tc := range testcases {
@@ -2109,7 +2145,11 @@ func testTakeAction(clients localgit.Clients, t *testing.T) {
 			if tc.batchPending {
 				batchPending = []CodeReviewCommon{{}}
 			}
-			act, _, err := c.takeAction(sp, batchPending, genPulls(tc.successes), genPulls(tc.pendings), genPulls(tc.nones), genPulls(tc.batchMerges), sp.presubmits)
+			var batchFailed []CodeReviewCommon
+			for _, n := range tc.batchFailed {
+				batchFailed = append(batchFailed, CodeReviewCommon{Number: n})
+			}
+			act, _, err := c.takeAction(sp, batchPending, batchFailed, genPulls(tc.successes), genPulls(tc.pendings), genPulls(tc.nones), genPulls(tc.batchMerges), sp.presubmits)
 			if act != tc.action {
 				t.Errorf("Wrong action. Got %v, wanted %v.", act, tc.action)
 			}


### PR DESCRIPTION
Fixes: https://github.com/kubernetes-sigs/prow/issues/474

This PR adds the exclusion of the lowest-priority PR when a batch fails.
Previously, when a Batch failed to merge, it didn't account for the possibility of failure; the action in `takeAction` was always `MergeBatch`, regardless of the error. This sometimes led to /hold-ing one of the PRs from the batch, and then it would merge. 
Now, Tide excludes the lowest-priority PR from the failed batch and triggers a smaller batch, breaking the cycle.

🤖 Assisted by Claude.