### PR TITLE
Fix Tide automatic retrigger to use configured GitHub host

### DIFF
--- a/pkg/tide/github.go
+++ b/pkg/tide/github.go
@@ -408,21 +408,32 @@ func (gi *GitHubProvider) GetChangedFiles(org, repo string, number int) ([]strin
 }
 
 func (gi *GitHubProvider) refsForJob(sp subpool, prs []CodeReviewCommon) (prowapi.Refs, error) {
+	// Get the configured GitHub host URL (defaults to https://github.com if not set)
+	githubHost := "https://" + github.DefaultHost
+	if gi.cfg().GitHubOptions.LinkURL != nil {
+		githubHost = gi.cfg().GitHubOptions.LinkURL.String()
+	}
+
 	refs := prowapi.Refs{
-		Org:     sp.org,
-		Repo:    sp.repo,
-		BaseRef: sp.branch,
-		BaseSHA: sp.sha,
+		Org:      sp.org,
+		Repo:     sp.repo,
+		BaseRef:  sp.branch,
+		BaseSHA:  sp.sha,
+		RepoLink: fmt.Sprintf("%s/%s/%s", githubHost, sp.org, sp.repo),
+		BaseLink: fmt.Sprintf("%s/%s/%s/tree/%s", githubHost, sp.org, sp.repo, sp.sha),
 	}
 	for _, pr := range prs {
 		refs.Pulls = append(
 			refs.Pulls,
 			prowapi.Pull{
-				Number:  pr.Number,
-				Title:   pr.Title,
-				Author:  string(pr.AuthorLogin),
-				SHA:     pr.HeadRefOID,
-				HeadRef: pr.HeadRefName,
+				Number:     pr.Number,
+				Title:      pr.Title,
+				Author:     string(pr.AuthorLogin),
+				SHA:        pr.HeadRefOID,
+				HeadRef:    pr.HeadRefName,
+				Link:       fmt.Sprintf("%s/%s/%s/pull/%d", githubHost, sp.org, sp.repo, pr.Number),
+				CommitLink: fmt.Sprintf("%s/%s/%s/commit/%s", githubHost, sp.org, sp.repo, pr.HeadRefOID),
+				AuthorLink: fmt.Sprintf("%s/%s", githubHost, pr.AuthorLogin),
 			},
 		)
 	}


### PR DESCRIPTION
Previously, when Tide automatically retriggered jobs before merge, the `refsForJob()` function was not populating the RepoLink, BaseLink, and PR-level link fields (Link, CommitLink, AuthorLink) in the prowapi.Refs and prowapi.Pull structures.

These link fields are used by ProwJob pods to construct URLs for Git operations and to reference the correct GitHub instance. When these fields are left empty, the git cloning operations in ProwJob pods fall back to constructing URLs using the default "github.com" host, rather than using the configured GitHub Enterprise host (e.g., "github.example.com") from the GitHubOptions.LinkURL configuration.

Specifically, in pkg/pod-utils/clone/clone.go:163-167, the `gitCtxForRefs` function checks if refs.RepoLink is set:

```go
  if refs.RepoLink != "" {
      repoURI = fmt.Sprintf("%s.git", refs.RepoLink)
  } else {
      repoURI = fmt.Sprintf("https://%s/%s/%s.git", github.DefaultHost, refs.Org, refs.Repo)
  }
```

When RepoLink is empty, it defaults to github.DefaultHost ("github.com").

The fix populates these fields using the configured GitHub host from gi.cfg().GitHubOptions.LinkURL (defaulting to github.DefaultHost if not configured), ensuring ProwJob specs contain the correct URLs for the configured GitHub instance.

This matches the behavior of the Gerrit provider's CreateRefs function and the trigger plugin's createRefs function, which both properly populate these link fields.

Fixes #410

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>
