### PR TITLE
Allow filtering jobs by owner, repo and org

### DIFF
--- a/cmd/deck/main.go
+++ b/cmd/deck/main.go
@@ -786,40 +786,66 @@ func handleProwJobs(ja *jobs.JobAgent, log *logrus.Entry) http.HandlerFunc {
 		setHeadersNoCaching(w)
 		jobs := ja.ProwJobs()
 		omit := r.URL.Query().Get("omit")
+		omitSet := sets.New(strings.Split(omit, ",")...)
 
-		if set := sets.New[string](strings.Split(omit, ",")...); set.Len() > 0 {
-			for i := range jobs {
-				jobs[i].ManagedFields = nil
-				if set.Has(Annotations) {
-					jobs[i].Annotations = nil
+		org := r.URL.Query().Get("org")
+		repo := r.URL.Query().Get("repo")
+		owner := r.URL.Query().Get("owner")
+
+		ownerMatch := func(job prowapi.ProwJob, owner string) bool {
+			if job.Spec.Refs == nil {
+				return false
+			}
+			for _, pull := range job.Spec.Refs.Pulls {
+				if pull.Author == owner {
+					return true
 				}
-				if set.Has(Labels) {
-					jobs[i].Labels = nil
-				}
-				if set.Has(DecorationConfig) {
-					jobs[i].Spec.DecorationConfig = nil
-				}
-				if set.Has(PodSpec) {
-					// when we omit the podspec, we don't set it completely to nil
-					// instead, we set it to a new podspec that just has an empty container for each container that exists in the actual podspec
-					// this is so we can determine how many containers there are for a given prowjob without fetching all of the podspec details
-					// this is necessary for prow/cmd/deck/static/prow/pkg.ts to determine whether the logIcon should link to a log endpoint or to spyglass
-					if jobs[i].Spec.PodSpec != nil {
-						emptyContainers := []coreapi.Container{}
-						for range jobs[i].Spec.PodSpec.Containers {
-							emptyContainers = append(emptyContainers, coreapi.Container{})
-						}
-						jobs[i].Spec.PodSpec = &coreapi.PodSpec{
-							Containers: emptyContainers,
-						}
+			}
+			return false
+		}
+
+		finalJobs := make([]prowapi.ProwJob, 0)
+		for i := range jobs {
+			if org != "" && (jobs[i].Spec.Refs == nil || jobs[i].Spec.Refs.Org != org) {
+				continue
+			}
+			if repo != "" && (jobs[i].Spec.Refs == nil || jobs[i].Spec.Refs.Repo != repo) {
+				continue
+			}
+			if owner != "" && !ownerMatch(jobs[i], owner) {
+				continue
+			}
+			jobs[i].ManagedFields = nil
+			if omitSet.Has(Annotations) {
+				jobs[i].Annotations = nil
+			}
+			if omitSet.Has(Labels) {
+				jobs[i].Labels = nil
+			}
+			if omitSet.Has(DecorationConfig) {
+				jobs[i].Spec.DecorationConfig = nil
+			}
+			if omitSet.Has(PodSpec) {
+				// when we omit the podspec, we don't set it completely to nil
+				// instead, we set it to a new podspec that just has an empty container for each container that exists in the actual podspec
+				// this is so we can determine how many containers there are for a given prowjob without fetching all of the podspec details
+				// this is necessary for prow/cmd/deck/static/prow/pkg.ts to determine whether the logIcon should link to a log endpoint or to spyglass
+				if jobs[i].Spec.PodSpec != nil {
+					emptyContainers := []coreapi.Container{}
+					for range jobs[i].Spec.PodSpec.Containers {
+						emptyContainers = append(emptyContainers, coreapi.Container{})
+					}
+					jobs[i].Spec.PodSpec = &coreapi.PodSpec{
+						Containers: emptyContainers,
 					}
 				}
 			}
+			finalJobs = append(finalJobs, jobs[i])
 		}
 
 		jd, err := json.Marshal(struct {
 			Items []prowapi.ProwJob `json:"items"`
-		}{jobs})
+		}{finalJobs})
 		if err != nil {
 			log.WithError(err).Error("Error marshaling jobs.")
 			jd = []byte("{}")

--- a/cmd/deck/main.go
+++ b/cmd/deck/main.go
@@ -32,6 +32,7 @@ import (
 	"net/url"
 	"os"
 	"path"
+	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -781,35 +782,49 @@ func handleNotCached(next http.Handler) http.HandlerFunc {
 	}
 }
 
+// handleProwJobs returns an http.HandlerFunc that serves the /prowjobs.js endpoint.
+// It accepts the following optional query parameters:
+//
+// - omit: comma-separated list of fields to strip from each job in the response.
+// - org: filter jobs to those whose Spec.Refs.Org matches exactly (case-sensitive).
+// - repo: filter jobs to those whose Spec.Refs.Repo matches exactly (case-sensitive).
+// - owner: filter jobs to those with a pull in Spec.Refs.Pulls whose Author matches exactly (case-sensitive)
 func handleProwJobs(ja *jobs.JobAgent, log *logrus.Entry) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		setHeadersNoCaching(w)
 		jobs := ja.ProwJobs()
 		omit := r.URL.Query().Get("omit")
-		omitSet := sets.New(strings.Split(omit, ",")...)
+		omitSet := sets.New[string](strings.Split(omit, ",")...)
 
 		org := r.URL.Query().Get("org")
 		repo := r.URL.Query().Get("repo")
 		owner := r.URL.Query().Get("owner")
 
 		ownerMatch := func(job prowapi.ProwJob, owner string) bool {
+			// Periodic jobs do not have a Pull request owner
 			if job.Spec.Refs == nil {
 				return false
 			}
-			for _, pull := range job.Spec.Refs.Pulls {
-				if pull.Author == owner {
-					return true
-				}
+			return slices.ContainsFunc(job.Spec.Refs.Pulls, func(pull prowapi.Pull) bool {
+				return pull.Author == owner
+			})
+		}
+
+		refsMatch := func(job prowapi.ProwJob, value string, field func(prowapi.Refs) string) bool {
+			if job.Spec.Refs == nil {
+				return slices.ContainsFunc(job.Spec.ExtraRefs, func(ref prowapi.Refs) bool {
+					return field(ref) == value
+				})
 			}
-			return false
+			return field(*job.Spec.Refs) == value
 		}
 
 		finalJobs := make([]prowapi.ProwJob, 0)
 		for i := range jobs {
-			if org != "" && (jobs[i].Spec.Refs == nil || jobs[i].Spec.Refs.Org != org) {
+			if org != "" && !refsMatch(jobs[i], org, func(r prowapi.Refs) string { return r.Org }) {
 				continue
 			}
-			if repo != "" && (jobs[i].Spec.Refs == nil || jobs[i].Spec.Refs.Repo != repo) {
+			if repo != "" && !refsMatch(jobs[i], repo, func(r prowapi.Refs) string { return r.Repo }) {
 				continue
 			}
 			if owner != "" && !ownerMatch(jobs[i], owner) {

--- a/cmd/deck/main_test.go
+++ b/cmd/deck/main_test.go
@@ -31,6 +31,7 @@ import (
 	"net/url"
 	"os"
 	"reflect"
+	"slices"
 	"strconv"
 	"testing"
 	"time"
@@ -425,6 +426,185 @@ func TestProwJob(t *testing.T) {
 	if res.Status.State != prowapi.PendingState {
 		t.Errorf("Wrong state, expected \"%v\", got \"%v\"", prowapi.PendingState, res.Status.State)
 	}
+}
+
+// TestHandleProwJobsWithFilter checks if, given a list of prowjobs, the filters
+// are respected and just a subset of jobs are returned.
+func TestHandleProwJobsWithFilter(t *testing.T) {
+	kc := fkc{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "fullref",
+				Labels: map[string]string{
+					"goodbye": "world",
+				},
+			},
+			Spec: prowapi.ProwJobSpec{
+				Agent: prowapi.KubernetesAgent,
+				Job:   "job",
+				Refs: &prowapi.Refs{
+					Org:  "amazingk8s",
+					Repo: "pizzacontroller",
+					Pulls: []prowapi.Pull{
+						{
+							Author: "someone",
+						},
+					},
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "differentorg",
+				Labels: map[string]string{
+					"goodbye": "world",
+				},
+			},
+			Spec: prowapi.ProwJobSpec{
+				Agent: prowapi.KubernetesAgent,
+				Job:   "job",
+				Refs: &prowapi.Refs{
+					Org:  "otherk8s",
+					Repo: "pizzacontroller",
+					Pulls: []prowapi.Pull{
+						{
+							Author: "someone",
+						},
+					},
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "nullref",
+			},
+			Spec: prowapi.ProwJobSpec{
+				Agent: prowapi.KubernetesAgent,
+				Job:   "job",
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "noowner",
+			},
+			Spec: prowapi.ProwJobSpec{
+				Agent: prowapi.KubernetesAgent,
+				Job:   "job",
+				Refs: &prowapi.Refs{
+					Org:  "amazingk8s",
+					Repo: "pizzacontroller",
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "multiowner",
+			},
+			Spec: prowapi.ProwJobSpec{
+				Agent: prowapi.KubernetesAgent,
+				Job:   "job",
+				Refs: &prowapi.Refs{
+					Org:  "amazingk8s",
+					Repo: "pizzacontroller",
+					Pulls: []prowapi.Pull{
+						{
+							Author: "someone",
+						},
+						{
+							Author: "anotherone",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	type testCase struct {
+		Name         string
+		Owner        string
+		Org          string
+		Repo         string
+		ExpectedJobs []string
+	}
+
+	testCases := []testCase{
+		{
+			Name:         "no filter should return all the tests",
+			ExpectedJobs: []string{"fullref", "nullref", "noowner", "multiowner", "differentorg"},
+		},
+		{
+			Name:         "owner filter should return just jobs with the right owner",
+			Owner:        "anotherone",
+			ExpectedJobs: []string{"multiowner"},
+		},
+		{
+			Name:         "owner and org filter should return just jobs with the right owner and org",
+			Owner:        "someone",
+			Org:          "amazingk8s",
+			ExpectedJobs: []string{"fullref", "multiowner"},
+		},
+		{
+			Name:         "owner, org and repo filter should return just jobs the right job",
+			Owner:        "someone",
+			Org:          "otherk8s",
+			Repo:         "pizzacontroller",
+			ExpectedJobs: []string{"differentorg"},
+		},
+	}
+
+	fakeJa := jobs.NewJobAgent(context.Background(), kc, false, true, []string{}, map[string]jobs.PodLogClient{}, fca{}.Config)
+	fakeJa.Start()
+
+	handler := handleProwJobs(fakeJa, logrus.WithField("handler", "/prowjobs.js"))
+
+	for _, tc := range testCases {
+
+		queryS := make(url.Values)
+		if tc.Org != "" {
+			queryS.Add("org", tc.Org)
+		}
+		if tc.Repo != "" {
+			queryS.Add("repo", tc.Repo)
+		}
+		if tc.Owner != "" {
+			queryS.Add("owner", tc.Owner)
+		}
+
+		req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("/prowjobs.js?%s", queryS.Encode()), nil)
+		if err != nil {
+			t.Errorf("Error making request: %v", err)
+		}
+
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+		if rr.Code != http.StatusOK {
+			t.Errorf("Bad error code: %d", rr.Code)
+		}
+		resp := rr.Result()
+		defer resp.Body.Close()
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			t.Errorf("Error reading response body: %v", err)
+		}
+		type prowjobItems struct {
+			Items []prowapi.ProwJob `json:"items"`
+		}
+		var res prowjobItems
+		if err := json.Unmarshal(body, &res); err != nil {
+			t.Errorf("Error unmarshalling: %v", err)
+		}
+		slices.Sort(tc.ExpectedJobs)
+		returnedJobs := make([]string, len(res.Items))
+		for i := range res.Items {
+			returnedJobs[i] = res.Items[i].Name
+		}
+		slices.Sort(returnedJobs)
+		if !slices.Equal(tc.ExpectedJobs, returnedJobs) {
+			t.Errorf("TEST %s: returned invalid jobs, expecting %+v returned %+v", tc.Name, tc.ExpectedJobs, returnedJobs)
+		}
+
+	}
+
 }
 
 type fakeAuthenticatedUserIdentifier struct {

--- a/cmd/deck/main_test.go
+++ b/cmd/deck/main_test.go
@@ -485,6 +485,36 @@ func TestHandleProwJobsWithFilter(t *testing.T) {
 		},
 		{
 			ObjectMeta: metav1.ObjectMeta{
+				Name: "extrarefs-org-match",
+			},
+			Spec: prowapi.ProwJobSpec{
+				Agent: prowapi.KubernetesAgent,
+				Job:   "periodic-job",
+				ExtraRefs: []prowapi.Refs{
+					{
+						Org:  "amazingk8s",
+						Repo: "testinfra",
+					},
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "extrarefs-different-org",
+			},
+			Spec: prowapi.ProwJobSpec{
+				Agent: prowapi.KubernetesAgent,
+				Job:   "periodic-job",
+				ExtraRefs: []prowapi.Refs{
+					{
+						Org:  "otherk8s",
+						Repo: "testinfra",
+					},
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
 				Name: "noowner",
 			},
 			Spec: prowapi.ProwJobSpec{
@@ -530,7 +560,7 @@ func TestHandleProwJobsWithFilter(t *testing.T) {
 	testCases := []testCase{
 		{
 			Name:         "no filter should return all the tests",
-			ExpectedJobs: []string{"fullref", "nullref", "noowner", "multiowner", "differentorg"},
+			ExpectedJobs: []string{"fullref", "nullref", "noowner", "multiowner", "differentorg", "extrarefs-org-match", "extrarefs-different-org"},
 		},
 		{
 			Name:         "owner filter should return just jobs with the right owner",
@@ -549,6 +579,22 @@ func TestHandleProwJobsWithFilter(t *testing.T) {
 			Org:          "otherk8s",
 			Repo:         "pizzacontroller",
 			ExpectedJobs: []string{"differentorg"},
+		},
+		{
+			Name:         "org filter should match jobs with ExtraRefs",
+			Org:          "amazingk8s",
+			ExpectedJobs: []string{"fullref", "noowner", "multiowner", "extrarefs-org-match"},
+		},
+		{
+			Name:         "repo filter should match jobs with ExtraRefs",
+			Repo:         "testinfra",
+			ExpectedJobs: []string{"extrarefs-org-match", "extrarefs-different-org"},
+		},
+		{
+			Name:         "org and repo filter should match jobs with ExtraRefs",
+			Org:          "otherk8s",
+			Repo:         "testinfra",
+			ExpectedJobs: []string{"extrarefs-different-org"},
 		},
 	}
 
@@ -581,7 +627,9 @@ func TestHandleProwJobsWithFilter(t *testing.T) {
 			t.Errorf("Bad error code: %d", rr.Code)
 		}
 		resp := rr.Result()
-		defer resp.Body.Close()
+		if err := resp.Body.Close(); err != nil {
+			t.Errorf("Error closing the body stream: %v", err)
+		}
 		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			t.Errorf("Error reading response body: %v", err)


### PR DESCRIPTION
This PR changes Prow handler prowjob.js, allowing new query parameters that can be used to filter the returned jobs by org, repo and owner.

The idea is that instead of returning the full array of jobs running on this Prow instance, just the expected jobs are returned reducing a lot the json size when dealing just with a specific org, or with a big prow instance.