### PR TITLE
`peribolos`: add org roles feature

### DIFF
--- a/cmd/peribolos/main.go
+++ b/cmd/peribolos/main.go
@@ -409,9 +409,6 @@ func dumpOrgConfig(client dumpClient, orgName string, ignoreSecretTeams bool, ig
 		return nil, fmt.Errorf("failed to list organization roles: %w", err)
 	}
 	logrus.Debugf("Found %d organization roles", len(roles))
-	if len(roles) > 0 {
-		out.Roles = make(map[string]org.Role, len(roles))
-	}
 	for _, role := range roles {
 		logrus.WithField("role", role.Name).Debug("Recording organization role.")
 
@@ -447,9 +444,14 @@ func dumpOrgConfig(client dumpClient, orgName string, ignoreSecretTeams bool, ig
 			userLogins = append(userLogins, user.Login)
 		}
 
-		out.Roles[role.Name] = org.Role{
-			Teams: teamNames,
-			Users: userLogins,
+		if len(teamNames) > 0 || len(userLogins) > 0 {
+			if out.Roles == nil {
+				out.Roles = make(map[string]org.Role)
+			}
+			out.Roles[role.Name] = org.Role{
+				Teams: teamNames,
+				Users: userLogins,
+			}
 		}
 	}
 

--- a/cmd/peribolos/main.go
+++ b/cmd/peribolos/main.go
@@ -59,6 +59,7 @@ type options struct {
 	fixTeamRepos          bool
 	fixRepos              bool
 	fixCollaborators      bool
+	fixOrgRoles           bool
 	ignoreInvitees        bool
 	ignoreSecretTeams     bool
 	ignoreEnterpriseTeams bool
@@ -97,6 +98,7 @@ func (o *options) parseArgs(flags *flag.FlagSet, args []string) error {
 	flags.BoolVar(&o.fixTeamRepos, "fix-team-repos", false, "Add/remove team permissions on repos if set")
 	flags.BoolVar(&o.fixRepos, "fix-repos", false, "Create/update repositories if set")
 	flags.BoolVar(&o.fixCollaborators, "fix-collaborators", false, "Add/remove/update repository collaborators if set")
+	flags.BoolVar(&o.fixOrgRoles, "fix-org-roles", false, "Assign/remove organization roles to teams and users if set")
 	flags.BoolVar(&o.allowRepoArchival, "allow-repo-archival", false, "If set, archiving repos is allowed while updating repos")
 	flags.BoolVar(&o.allowRepoPublish, "allow-repo-publish", false, "If set, making private repos public is allowed while updating repos")
 	flags.StringVar(&o.logLevel, "log-level", logrus.InfoLevel.String(), fmt.Sprintf("Logging level, one of %v", logrus.AllLevels))
@@ -148,6 +150,10 @@ func (o *options) parseArgs(flags *flag.FlagSet, args []string) error {
 
 	if o.fixTeamRepos && !o.fixTeams {
 		return fmt.Errorf("--fix-team-repos requires --fix-teams")
+	}
+
+	if o.fixOrgRoles && !o.fixTeams {
+		return fmt.Errorf("--fix-org-roles requires --fix-teams")
 	}
 
 	return nil
@@ -212,6 +218,9 @@ type dumpClient interface {
 	GetRepo(owner, name string) (github.FullRepo, error)
 	GetRepos(org string, isUser bool) ([]github.Repo, error)
 	ListDirectCollaboratorsWithPermissions(org, repo string) (map[string]github.RepoPermissionLevel, error)
+	ListOrganizationRoles(org string) ([]github.OrganizationRole, error)
+	ListTeamsWithRole(org string, roleID int) ([]github.OrganizationRoleAssignment, error)
+	ListUsersWithRole(org string, roleID int) ([]github.OrganizationRoleAssignment, error)
 	BotUser() (*github.UserData, error)
 }
 
@@ -275,6 +284,7 @@ func dumpOrgConfig(client dumpClient, orgName string, ignoreSecretTeams bool, ig
 	idMap := map[int]org.Team{} // metadata for a team
 	children := map[int][]int{} // what children does it have
 	var tops []int              // what are the top-level teams
+	slugToName := map[string]string{}
 
 	for _, t := range teams {
 		logger := logrus.WithFields(logrus.Fields{"id": t.ID, "name": t.Name})
@@ -287,6 +297,7 @@ func dumpOrgConfig(client dumpClient, orgName string, ignoreSecretTeams bool, ig
 			logger.Debug("Ignoring secret team.")
 			continue
 		}
+		slugToName[t.Slug] = t.Name
 		d := t.Description
 		nt := org.Team{
 			TeamMetadata: org.TeamMetadata{
@@ -390,6 +401,53 @@ func dumpOrgConfig(client dumpClient, orgName string, ignoreSecretTeams bool, ig
 			repoConfig.Collaborators = directCollabs
 		}
 		out.Repos[full.Name] = repoConfig
+	}
+
+	// Dump organization roles
+	roles, err := client.ListOrganizationRoles(orgName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list organization roles: %w", err)
+	}
+	logrus.Debugf("Found %d organization roles", len(roles))
+	if len(roles) > 0 {
+		out.Roles = make(map[string]org.Role, len(roles))
+	}
+	for _, role := range roles {
+		logrus.WithField("role", role.Name).Debug("Recording organization role.")
+
+		// Get teams with this role
+		teamsWithRole, err := client.ListTeamsWithRole(orgName, role.ID)
+		if err != nil {
+			logrus.WithError(err).Warnf("Failed to list teams with role %s", role.Name)
+			continue
+		}
+
+		// Get users with this role
+		usersWithRole, err := client.ListUsersWithRole(orgName, role.ID)
+		if err != nil {
+			logrus.WithError(err).Warnf("Failed to list users with role %s", role.Name)
+			continue
+		}
+
+		// Build team and user lists
+		var teamSlugs []string
+		for _, team := range teamsWithRole {
+			if name, ok := slugToName[team.Slug]; ok {
+				teamSlugs = append(teamSlugs, name)
+			} else {
+				teamSlugs = append(teamSlugs, team.Slug)
+			}
+		}
+
+		var userLogins []string
+		for _, user := range usersWithRole {
+			userLogins = append(userLogins, user.Login)
+		}
+
+		out.Roles[role.Name] = org.Role{
+			Teams: teamSlugs,
+			Users: userLogins,
+		}
 	}
 
 	return &out, nil
@@ -541,6 +599,8 @@ func configureOrgMembers(opt options, client orgClient, orgName string, orgConfi
 			}
 		} else if om.State == github.StatePending {
 			logrus.Infof("Invited %s to %s as a %s", user, orgName, role)
+			// Track the new invitation so role assignment can skip this user
+			invitees.Insert(github.NormLogin(user))
 		} else {
 			logrus.Infof("Set %s as a %s of %s", user, role, orgName)
 		}
@@ -945,6 +1005,13 @@ func orgFailedInvitations(opt options, client failedInviteClient, orgName string
 }
 
 func configureOrg(opt options, client github.Client, orgName string, orgConfig org.Config) error {
+	// Validate role configuration early (before any API calls) if we're going to configure roles
+	if opt.fixOrgRoles {
+		if err := orgConfig.ValidateRoles(); err != nil {
+			return fmt.Errorf("invalid role configuration: %w", err)
+		}
+	}
+
 	// Ensure that metadata is configured correctly.
 	if !opt.fixOrg {
 		logrus.Infof("Skipping org metadata configuration")
@@ -968,6 +1035,9 @@ func configureOrg(opt options, client github.Client, orgName string, orgConfig o
 	} else if err := configureOrgMembers(opt, client, orgName, orgConfig, invitees, failedInvites); err != nil {
 		return fmt.Errorf("failed to configure %s members: %w", orgName, err)
 	}
+
+	// Note: New invitations sent by configureOrgMembers are tracked in the invitees set,
+	// so role assignment can skip users with pending invitations without an extra API call.
 
 	// Create repositories in the org
 	if !opt.fixRepos {
@@ -1012,6 +1082,14 @@ func configureOrg(opt options, client github.Client, orgName string, orgConfig o
 			return fmt.Errorf("failed to configure %s team %s repos: %w", orgName, name, err)
 		}
 	}
+
+	// Configure organization roles
+	if !opt.fixOrgRoles {
+		logrus.Infof("Skipping organization roles configuration")
+	} else if err := configureOrgRoles(client, orgName, orgConfig, githubTeams, invitees); err != nil {
+		return fmt.Errorf("failed to configure %s organization roles: %w", orgName, err)
+	}
+
 	return nil
 }
 
@@ -1529,6 +1607,220 @@ func configureTeamRepos(client teamRepoClient, githubTeams map[string]github.Tea
 	}
 
 	return utilerrors.NewAggregate(updateErrors)
+}
+
+type orgRolesClient interface {
+	ListOrganizationRoles(org string) ([]github.OrganizationRole, error)
+	AssignOrganizationRoleToTeam(org, teamSlug string, roleID int) error
+	RemoveOrganizationRoleFromTeam(org, teamSlug string, roleID int) error
+	AssignOrganizationRoleToUser(org, user string, roleID int) error
+	RemoveOrganizationRoleFromUser(org, user string, roleID int) error
+	ListTeamsWithRole(org string, roleID int) ([]github.OrganizationRoleAssignment, error)
+	ListUsersWithRole(org string, roleID int) ([]github.OrganizationRoleAssignment, error)
+}
+
+// configureOrgRoles configures organization roles for teams and users
+func configureOrgRoles(client orgRolesClient, orgName string, orgConfig org.Config, githubTeams map[string]github.Team, invitees sets.Set[string]) error {
+	// Note: Role configuration is validated at the start of configureOrg() before any API calls
+
+	// Get current organization roles from GitHub
+	roles, err := client.ListOrganizationRoles(orgName)
+	if err != nil {
+		return fmt.Errorf("failed to list organization roles: %w", err)
+	}
+
+	if len(roles) == 0 {
+		logrus.Debugf("No organization roles exist in %s", orgName)
+		return nil
+	}
+
+	// Create a map of configured role names (lowercase) for quick lookup
+	configuredRoles := make(map[string]org.Role)
+	for roleName, roleConfig := range orgConfig.Roles {
+		configuredRoles[strings.ToLower(roleName)] = roleConfig
+	}
+
+	unconfiguredCount := len(roles) - len(configuredRoles)
+	logrus.Debugf("Processing %d organization roles (%d configured, %d unconfigured to check for cleanup)",
+		len(roles), len(configuredRoles), unconfiguredCount)
+
+	var allErrors []error
+
+	// Iterate over ALL GitHub roles to handle both configured and unconfigured roles
+	for _, role := range roles {
+		roleNameLower := strings.ToLower(role.Name)
+
+		if roleConfig, isConfigured := configuredRoles[roleNameLower]; isConfigured {
+			// Role is in config - sync to match desired state
+			if err := configureRoleTeamAssignments(client, orgName, role.Name, role.ID, roleConfig.Teams, githubTeams); err != nil {
+				allErrors = append(allErrors, fmt.Errorf("failed to configure team assignments for role %s: %w", role.Name, err))
+			}
+			if err := configureRoleUserAssignments(client, orgName, role.Name, role.ID, roleConfig.Users, invitees); err != nil {
+				allErrors = append(allErrors, fmt.Errorf("failed to configure user assignments for role %s: %w", role.Name, err))
+			}
+		} else {
+			// Role is NOT in config - remove all assignments (clean up orphaned assignments)
+			logrus.Debugf("Role %q not in config, checking for assignments to clean up", role.Name)
+			if err := configureRoleTeamAssignments(client, orgName, role.Name, role.ID, []string{}, githubTeams); err != nil {
+				allErrors = append(allErrors, fmt.Errorf("failed to remove team assignments for unconfigured role %s: %w", role.Name, err))
+			}
+			if err := configureRoleUserAssignments(client, orgName, role.Name, role.ID, []string{}, invitees); err != nil {
+				allErrors = append(allErrors, fmt.Errorf("failed to remove user assignments for unconfigured role %s: %w", role.Name, err))
+			}
+		}
+	}
+
+	// Check if any configured roles don't exist in GitHub
+	for roleName := range orgConfig.Roles {
+		found := false
+		for _, role := range roles {
+			if strings.EqualFold(role.Name, roleName) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("role %q does not exist in organization %s - create the role in GitHub before assigning it", roleName, orgName)
+		}
+	}
+
+	return utilerrors.NewAggregate(allErrors)
+}
+
+// configureRoleTeamAssignments configures team assignments for a specific role
+func configureRoleTeamAssignments(client orgRolesClient, orgName, roleName string, roleID int, wantTeams []string, githubTeams map[string]github.Team) error {
+	// Get current team assignments for this role
+	currentTeams, err := client.ListTeamsWithRole(orgName, roleID)
+	if err != nil {
+		return fmt.Errorf("failed to list teams with role %s: %w", roleName, err)
+	}
+
+	// If we want no teams and have no teams, we're done
+	if len(wantTeams) == 0 && len(currentTeams) == 0 {
+		return nil
+	}
+
+	// Build a map of normalized team name to team slug for the teams we have in config
+	// This allows resolving "MyTeam" (config name) to "my-team" (GitHub slug)
+	normalizedTeams := make(map[string]string)
+	for name, team := range githubTeams {
+		normalizedTeams[strings.ToLower(name)] = team.Slug
+	}
+
+	// Create sets for comparison using slugs
+	wantSet := sets.New[string]()
+	for _, teamName := range wantTeams {
+		// Resolve config team name to slug
+		if slug, ok := normalizedTeams[strings.ToLower(teamName)]; ok {
+			wantSet.Insert(slug)
+		} else {
+			return fmt.Errorf("team %q referenced in role %q could not be resolved to a GitHub team slug - ensure the team exists in your teams configuration and was successfully created", teamName, roleName)
+		}
+	}
+
+	haveSet := sets.New[string]()
+	for _, team := range currentTeams {
+		haveSet.Insert(team.Slug)
+	}
+
+	// Teams to add
+	var errors []error
+	toAdd := wantSet.Difference(haveSet)
+	for teamSlug := range toAdd {
+		if err := client.AssignOrganizationRoleToTeam(orgName, teamSlug, roleID); err != nil {
+			errors = append(errors, fmt.Errorf("failed to assign role %s to team %s: %w", roleName, teamSlug, err))
+			logrus.WithError(err).Warnf("Failed to assign role %s to team %s", roleName, teamSlug)
+		} else {
+			logrus.Infof("Assigned role %s to team %s", roleName, teamSlug)
+		}
+	}
+
+	// Teams to remove
+	toRemove := haveSet.Difference(wantSet)
+	for teamSlug := range toRemove {
+		if err := client.RemoveOrganizationRoleFromTeam(orgName, teamSlug, roleID); err != nil {
+			errors = append(errors, fmt.Errorf("failed to remove role %s from team %s: %w", roleName, teamSlug, err))
+			logrus.WithError(err).Warnf("Failed to remove role %s from team %s", roleName, teamSlug)
+		} else {
+			logrus.Infof("Removed role %s from team %s", roleName, teamSlug)
+		}
+	}
+
+	return utilerrors.NewAggregate(errors)
+}
+
+// configureRoleUserAssignments configures user assignments for a specific role
+func configureRoleUserAssignments(client orgRolesClient, orgName, roleName string, roleID int, wantUsers []string, invitees sets.Set[string]) error {
+	// Get current user assignments for this role
+	currentUsers, err := client.ListUsersWithRole(orgName, roleID)
+	if err != nil {
+		return fmt.Errorf("failed to list users with role %s: %w", roleName, err)
+	}
+
+	// Create maps to preserve original casing while comparing normalized usernames
+	wantMap := make(map[string]string) // normalized -> original
+	for _, user := range wantUsers {
+		wantMap[github.NormLogin(user)] = user
+	}
+
+	// Only consider DIRECT assignments when building haveMap.
+	// Users with "indirect" assignment have the role via team membership and should not be
+	// removed just because they're not in the users list - they keep the role through their team.
+	haveMap := make(map[string]string) // normalized -> original
+	for _, user := range currentUsers {
+		if user.Assignment == "indirect" {
+			logrus.Debugf("Skipping indirect role assignment for user %s (has role via team membership)", user.Login)
+			continue
+		}
+		haveMap[github.NormLogin(user.Login)] = user.Login
+	}
+
+	// If we want no direct users and have no direct users, we're done
+	if len(wantUsers) == 0 && len(haveMap) == 0 {
+		return nil
+	}
+
+	// Create sets for comparison with normalized usernames
+	wantSet := sets.New[string]()
+	for normalized := range wantMap {
+		wantSet.Insert(normalized)
+	}
+	haveSet := sets.New[string]()
+	for normalized := range haveMap {
+		haveSet.Insert(normalized)
+	}
+
+	// Users to add
+	var errors []error
+	toAdd := wantSet.Difference(haveSet)
+	for normalizedUser := range toAdd {
+		originalUser := wantMap[normalizedUser]
+		// Skip users who have pending org invitations - they must accept before we can assign roles
+		if invitees.Has(normalizedUser) {
+			logrus.Infof("Waiting for %s to accept org invitation before assigning role %s", originalUser, roleName)
+			continue
+		}
+		if err := client.AssignOrganizationRoleToUser(orgName, originalUser, roleID); err != nil {
+			errors = append(errors, fmt.Errorf("failed to assign role %s to user %s: %w", roleName, originalUser, err))
+			logrus.WithError(err).Warnf("Failed to assign role %s to user %s", roleName, originalUser)
+		} else {
+			logrus.Infof("Assigned role %s to user %s", roleName, originalUser)
+		}
+	}
+
+	// Users to remove
+	toRemove := haveSet.Difference(wantSet)
+	for normalizedUser := range toRemove {
+		originalUser := haveMap[normalizedUser]
+		if err := client.RemoveOrganizationRoleFromUser(orgName, originalUser, roleID); err != nil {
+			errors = append(errors, fmt.Errorf("failed to remove role %s from user %s: %w", roleName, originalUser, err))
+			logrus.WithError(err).Warnf("Failed to remove role %s from user %s", roleName, originalUser)
+		} else {
+			logrus.Infof("Removed role %s from user %s", roleName, originalUser)
+		}
+	}
+
+	return utilerrors.NewAggregate(errors)
 }
 
 // teamMembersClient can list/remove/update people to a team.

--- a/cmd/peribolos/main.go
+++ b/cmd/peribolos/main.go
@@ -418,34 +418,37 @@ func dumpOrgConfig(client dumpClient, orgName string, ignoreSecretTeams bool, ig
 		// Get teams with this role
 		teamsWithRole, err := client.ListTeamsWithRole(orgName, role.ID)
 		if err != nil {
-			logrus.WithError(err).Warnf("Failed to list teams with role %s", role.Name)
-			continue
+			return nil, fmt.Errorf("failed to list teams with role %s: %w", role.Name, err)
 		}
 
 		// Get users with this role
 		usersWithRole, err := client.ListUsersWithRole(orgName, role.ID)
 		if err != nil {
-			logrus.WithError(err).Warnf("Failed to list users with role %s", role.Name)
-			continue
+			return nil, fmt.Errorf("failed to list users with role %s: %w", role.Name, err)
 		}
 
-		// Build team and user lists
-		var teamSlugs []string
+		// Build team list, filtering out secret teams when --ignore-secret-teams is set
+		var teamNames []string
 		for _, team := range teamsWithRole {
+			// Only include teams that are in slugToName (secret teams are excluded from this map)
 			if name, ok := slugToName[team.Slug]; ok {
-				teamSlugs = append(teamSlugs, name)
-			} else {
-				teamSlugs = append(teamSlugs, team.Slug)
+				teamNames = append(teamNames, name)
+			} else if !ignoreSecretTeams {
+				teamNames = append(teamNames, team.Slug)
 			}
 		}
 
+		// Build user list, filtering out indirect assignments (users who have the role via team membership)
 		var userLogins []string
 		for _, user := range usersWithRole {
+			if user.Assignment == "indirect" {
+				continue
+			}
 			userLogins = append(userLogins, user.Login)
 		}
 
 		out.Roles[role.Name] = org.Role{
-			Teams: teamSlugs,
+			Teams: teamNames,
 			Users: userLogins,
 		}
 	}
@@ -962,7 +965,7 @@ type inviteClient interface {
 
 func orgInvitations(opt options, client inviteClient, orgName string) (sets.Set[string], error) {
 	invitees := sets.Set[string]{}
-	if (!opt.fixOrgMembers && !opt.fixTeamMembers) || opt.ignoreInvitees {
+	if (!opt.fixOrgMembers && !opt.fixTeamMembers && !opt.fixOrgRoles) || opt.ignoreInvitees {
 		return invitees, nil
 	}
 	is, err := client.ListOrgInvitations(orgName)
@@ -1621,28 +1624,45 @@ type orgRolesClient interface {
 
 // configureOrgRoles configures organization roles for teams and users
 func configureOrgRoles(client orgRolesClient, orgName string, orgConfig org.Config, githubTeams map[string]github.Team, invitees sets.Set[string]) error {
-	// Note: Role configuration is validated at the start of configureOrg() before any API calls
-
 	// Get current organization roles from GitHub
 	roles, err := client.ListOrganizationRoles(orgName)
 	if err != nil {
 		return fmt.Errorf("failed to list organization roles: %w", err)
 	}
 
-	if len(roles) == 0 {
-		logrus.Debugf("No organization roles exist in %s", orgName)
+	if len(roles) == 0 && len(orgConfig.Roles) == 0 {
 		return nil
 	}
 
-	// Create a map of configured role names (lowercase) for quick lookup
-	configuredRoles := make(map[string]org.Role)
-	for roleName, roleConfig := range orgConfig.Roles {
-		configuredRoles[strings.ToLower(roleName)] = roleConfig
+	// Build a lookup of GitHub roles by lowercase name
+	githubRolesByName := make(map[string]github.OrganizationRole, len(roles))
+	for _, role := range roles {
+		githubRolesByName[strings.ToLower(role.Name)] = role
 	}
 
-	unconfiguredCount := len(roles) - len(configuredRoles)
+	// Validate all configured roles exist in GitHub BEFORE any mutations
+	for roleName := range orgConfig.Roles {
+		if _, ok := githubRolesByName[strings.ToLower(roleName)]; !ok {
+			return fmt.Errorf("role %q does not exist in organization %s - create the role in GitHub before assigning it", roleName, orgName)
+		}
+	}
+
+	// Create a set of configured role names (lowercase) for quick lookup
+	configuredRoleNames := make(map[string]bool, len(orgConfig.Roles))
+	for roleName := range orgConfig.Roles {
+		configuredRoleNames[strings.ToLower(roleName)] = true
+	}
+
+	var configuredCount, unconfiguredCount int
+	for _, role := range roles {
+		if configuredRoleNames[strings.ToLower(role.Name)] {
+			configuredCount++
+		} else {
+			unconfiguredCount++
+		}
+	}
 	logrus.Debugf("Processing %d organization roles (%d configured, %d unconfigured to check for cleanup)",
-		len(roles), len(configuredRoles), unconfiguredCount)
+		len(roles), configuredCount, unconfiguredCount)
 
 	var allErrors []error
 
@@ -1650,8 +1670,9 @@ func configureOrgRoles(client orgRolesClient, orgName string, orgConfig org.Conf
 	for _, role := range roles {
 		roleNameLower := strings.ToLower(role.Name)
 
-		if roleConfig, isConfigured := configuredRoles[roleNameLower]; isConfigured {
+		if configuredRoleNames[roleNameLower] {
 			// Role is in config - sync to match desired state
+			roleConfig := orgConfig.Roles[findOriginalRoleName(orgConfig.Roles, roleNameLower)]
 			if err := configureRoleTeamAssignments(client, orgName, role.Name, role.ID, roleConfig.Teams, githubTeams); err != nil {
 				allErrors = append(allErrors, fmt.Errorf("failed to configure team assignments for role %s: %w", role.Name, err))
 			}
@@ -1670,21 +1691,17 @@ func configureOrgRoles(client orgRolesClient, orgName string, orgConfig org.Conf
 		}
 	}
 
-	// Check if any configured roles don't exist in GitHub
-	for roleName := range orgConfig.Roles {
-		found := false
-		for _, role := range roles {
-			if strings.EqualFold(role.Name, roleName) {
-				found = true
-				break
-			}
-		}
-		if !found {
-			return fmt.Errorf("role %q does not exist in organization %s - create the role in GitHub before assigning it", roleName, orgName)
+	return utilerrors.NewAggregate(allErrors)
+}
+
+// findOriginalRoleName returns the original-cased key from the roles map that matches the lowercase name.
+func findOriginalRoleName(roles map[string]org.Role, lowerName string) string {
+	for name := range roles {
+		if strings.ToLower(name) == lowerName {
+			return name
 		}
 	}
-
-	return utilerrors.NewAggregate(allErrors)
+	return lowerName
 }
 
 // configureRoleTeamAssignments configures team assignments for a specific role
@@ -1708,14 +1725,18 @@ func configureRoleTeamAssignments(client orgRolesClient, orgName, roleName strin
 	}
 
 	// Create sets for comparison using slugs
+	var resolveErrors []error
 	wantSet := sets.New[string]()
 	for _, teamName := range wantTeams {
 		// Resolve config team name to slug
 		if slug, ok := normalizedTeams[strings.ToLower(teamName)]; ok {
 			wantSet.Insert(slug)
 		} else {
-			return fmt.Errorf("team %q referenced in role %q could not be resolved to a GitHub team slug - ensure the team exists in your teams configuration and was successfully created", teamName, roleName)
+			resolveErrors = append(resolveErrors, fmt.Errorf("team %q referenced in role %q could not be resolved to a GitHub team slug", teamName, roleName))
 		}
+	}
+	if len(resolveErrors) > 0 {
+		return utilerrors.NewAggregate(resolveErrors)
 	}
 
 	haveSet := sets.New[string]()

--- a/cmd/peribolos/main.go
+++ b/cmd/peribolos/main.go
@@ -422,34 +422,37 @@ func dumpOrgConfig(client dumpClient, orgName string, ignoreSecretTeams bool, ig
 		// Get teams with this role
 		teamsWithRole, err := client.ListTeamsWithRole(orgName, role.ID)
 		if err != nil {
-			logrus.WithError(err).Warnf("Failed to list teams with role %s", role.Name)
-			continue
+			return nil, fmt.Errorf("failed to list teams with role %s: %w", role.Name, err)
 		}
 
 		// Get users with this role
 		usersWithRole, err := client.ListUsersWithRole(orgName, role.ID)
 		if err != nil {
-			logrus.WithError(err).Warnf("Failed to list users with role %s", role.Name)
-			continue
+			return nil, fmt.Errorf("failed to list users with role %s: %w", role.Name, err)
 		}
 
-		// Build team and user lists
-		var teamSlugs []string
+		// Build team list, filtering out secret teams when --ignore-secret-teams is set
+		var teamNames []string
 		for _, team := range teamsWithRole {
+			// Only include teams that are in slugToName (secret teams are excluded from this map)
 			if name, ok := slugToName[team.Slug]; ok {
-				teamSlugs = append(teamSlugs, name)
-			} else {
-				teamSlugs = append(teamSlugs, team.Slug)
+				teamNames = append(teamNames, name)
+			} else if !ignoreSecretTeams {
+				teamNames = append(teamNames, team.Slug)
 			}
 		}
 
+		// Build user list, filtering out indirect assignments (users who have the role via team membership)
 		var userLogins []string
 		for _, user := range usersWithRole {
+			if user.Assignment == "indirect" {
+				continue
+			}
 			userLogins = append(userLogins, user.Login)
 		}
 
 		out.Roles[role.Name] = org.Role{
-			Teams: teamSlugs,
+			Teams: teamNames,
 			Users: userLogins,
 		}
 	}
@@ -966,7 +969,7 @@ type inviteClient interface {
 
 func orgInvitations(opt options, client inviteClient, orgName string) (sets.Set[string], error) {
 	invitees := sets.Set[string]{}
-	if (!opt.fixOrgMembers && !opt.fixTeamMembers) || opt.ignoreInvitees {
+	if (!opt.fixOrgMembers && !opt.fixTeamMembers && !opt.fixOrgRoles) || opt.ignoreInvitees {
 		return invitees, nil
 	}
 	is, err := client.ListOrgInvitations(orgName)
@@ -1621,28 +1624,45 @@ type orgRolesClient interface {
 
 // configureOrgRoles configures organization roles for teams and users
 func configureOrgRoles(client orgRolesClient, orgName string, orgConfig org.Config, githubTeams map[string]github.Team, invitees sets.Set[string]) error {
-	// Note: Role configuration is validated at the start of configureOrg() before any API calls
-
 	// Get current organization roles from GitHub
 	roles, err := client.ListOrganizationRoles(orgName)
 	if err != nil {
 		return fmt.Errorf("failed to list organization roles: %w", err)
 	}
 
-	if len(roles) == 0 {
-		logrus.Debugf("No organization roles exist in %s", orgName)
+	if len(roles) == 0 && len(orgConfig.Roles) == 0 {
 		return nil
 	}
 
-	// Create a map of configured role names (lowercase) for quick lookup
-	configuredRoles := make(map[string]org.Role)
-	for roleName, roleConfig := range orgConfig.Roles {
-		configuredRoles[strings.ToLower(roleName)] = roleConfig
+	// Build a lookup of GitHub roles by lowercase name
+	githubRolesByName := make(map[string]github.OrganizationRole, len(roles))
+	for _, role := range roles {
+		githubRolesByName[strings.ToLower(role.Name)] = role
 	}
 
-	unconfiguredCount := len(roles) - len(configuredRoles)
+	// Validate all configured roles exist in GitHub BEFORE any mutations
+	for roleName := range orgConfig.Roles {
+		if _, ok := githubRolesByName[strings.ToLower(roleName)]; !ok {
+			return fmt.Errorf("role %q does not exist in organization %s - create the role in GitHub before assigning it", roleName, orgName)
+		}
+	}
+
+	// Create a set of configured role names (lowercase) for quick lookup
+	configuredRoleNames := make(map[string]bool, len(orgConfig.Roles))
+	for roleName := range orgConfig.Roles {
+		configuredRoleNames[strings.ToLower(roleName)] = true
+	}
+
+	var configuredCount, unconfiguredCount int
+	for _, role := range roles {
+		if configuredRoleNames[strings.ToLower(role.Name)] {
+			configuredCount++
+		} else {
+			unconfiguredCount++
+		}
+	}
 	logrus.Debugf("Processing %d organization roles (%d configured, %d unconfigured to check for cleanup)",
-		len(roles), len(configuredRoles), unconfiguredCount)
+		len(roles), configuredCount, unconfiguredCount)
 
 	var allErrors []error
 
@@ -1650,8 +1670,9 @@ func configureOrgRoles(client orgRolesClient, orgName string, orgConfig org.Conf
 	for _, role := range roles {
 		roleNameLower := strings.ToLower(role.Name)
 
-		if roleConfig, isConfigured := configuredRoles[roleNameLower]; isConfigured {
+		if configuredRoleNames[roleNameLower] {
 			// Role is in config - sync to match desired state
+			roleConfig := orgConfig.Roles[findOriginalRoleName(orgConfig.Roles, roleNameLower)]
 			if err := configureRoleTeamAssignments(client, orgName, role.Name, role.ID, roleConfig.Teams, githubTeams); err != nil {
 				allErrors = append(allErrors, fmt.Errorf("failed to configure team assignments for role %s: %w", role.Name, err))
 			}
@@ -1670,21 +1691,17 @@ func configureOrgRoles(client orgRolesClient, orgName string, orgConfig org.Conf
 		}
 	}
 
-	// Check if any configured roles don't exist in GitHub
-	for roleName := range orgConfig.Roles {
-		found := false
-		for _, role := range roles {
-			if strings.EqualFold(role.Name, roleName) {
-				found = true
-				break
-			}
-		}
-		if !found {
-			return fmt.Errorf("role %q does not exist in organization %s - create the role in GitHub before assigning it", roleName, orgName)
+	return utilerrors.NewAggregate(allErrors)
+}
+
+// findOriginalRoleName returns the original-cased key from the roles map that matches the lowercase name.
+func findOriginalRoleName(roles map[string]org.Role, lowerName string) string {
+	for name := range roles {
+		if strings.ToLower(name) == lowerName {
+			return name
 		}
 	}
-
-	return utilerrors.NewAggregate(allErrors)
+	return lowerName
 }
 
 // configureRoleTeamAssignments configures team assignments for a specific role
@@ -1708,14 +1725,18 @@ func configureRoleTeamAssignments(client orgRolesClient, orgName, roleName strin
 	}
 
 	// Create sets for comparison using slugs
+	var resolveErrors []error
 	wantSet := sets.New[string]()
 	for _, teamName := range wantTeams {
 		// Resolve config team name to slug
 		if slug, ok := normalizedTeams[strings.ToLower(teamName)]; ok {
 			wantSet.Insert(slug)
 		} else {
-			return fmt.Errorf("team %q referenced in role %q could not be resolved to a GitHub team slug - ensure the team exists in your teams configuration and was successfully created", teamName, roleName)
+			resolveErrors = append(resolveErrors, fmt.Errorf("team %q referenced in role %q could not be resolved to a GitHub team slug", teamName, roleName))
 		}
+	}
+	if len(resolveErrors) > 0 {
+		return utilerrors.NewAggregate(resolveErrors)
 	}
 
 	haveSet := sets.New[string]()

--- a/cmd/peribolos/main.go
+++ b/cmd/peribolos/main.go
@@ -413,9 +413,6 @@ func dumpOrgConfig(client dumpClient, orgName string, ignoreSecretTeams bool, ig
 		return nil, fmt.Errorf("failed to list organization roles: %w", err)
 	}
 	logrus.Debugf("Found %d organization roles", len(roles))
-	if len(roles) > 0 {
-		out.Roles = make(map[string]org.Role, len(roles))
-	}
 	for _, role := range roles {
 		logrus.WithField("role", role.Name).Debug("Recording organization role.")
 
@@ -451,9 +448,14 @@ func dumpOrgConfig(client dumpClient, orgName string, ignoreSecretTeams bool, ig
 			userLogins = append(userLogins, user.Login)
 		}
 
-		out.Roles[role.Name] = org.Role{
-			Teams: teamNames,
-			Users: userLogins,
+		if len(teamNames) > 0 || len(userLogins) > 0 {
+			if out.Roles == nil {
+				out.Roles = make(map[string]org.Role)
+			}
+			out.Roles[role.Name] = org.Role{
+				Teams: teamNames,
+				Users: userLogins,
+			}
 		}
 	}
 

--- a/cmd/peribolos/main.go
+++ b/cmd/peribolos/main.go
@@ -285,16 +285,22 @@ func dumpOrgConfig(client dumpClient, orgName string, ignoreSecretTeams bool, ig
 	children := map[int][]int{} // what children does it have
 	var tops []int              // what are the top-level teams
 	slugToName := map[string]string{}
+	// Slugs of teams intentionally excluded from the dump (secret/enterprise per
+	// ignore flags). Used to keep such teams out of dumped role assignments so we
+	// do not leak ignored teams as raw slugs.
+	ignoredTeamSlugs := sets.New[string]()
 
 	for _, t := range teams {
 		logger := logrus.WithFields(logrus.Fields{"id": t.ID, "name": t.Name})
 		if ignoreEnterpriseTeams && t.Type == github.TeamTypeEnterprise {
 			logger.Debug("Skipping enterprise team.")
+			ignoredTeamSlugs.Insert(t.Slug)
 			continue
 		}
 		p := org.Privacy(t.Privacy)
 		if ignoreSecretTeams && p == org.Secret {
 			logger.Debug("Ignoring secret team.")
+			ignoredTeamSlugs.Insert(t.Slug)
 			continue
 		}
 		slugToName[t.Slug] = t.Name
@@ -407,10 +413,14 @@ func dumpOrgConfig(client dumpClient, orgName string, ignoreSecretTeams bool, ig
 		out.Repos[full.Name] = repoConfig
 	}
 
-	// Dump organization roles
+	// Dump organization roles. Listing roles requires org-roles read scope;
+	// tokens without it (or orgs where the API is unavailable) should still be
+	// able to dump everything else, so failures here are logged and skipped
+	// rather than aborting the whole dump.
 	roles, err := client.ListOrganizationRoles(orgName)
 	if err != nil {
-		return nil, fmt.Errorf("failed to list organization roles: %w", err)
+		logrus.WithError(err).Warn("Failed to list organization roles; omitting roles from dump")
+		roles = nil
 	}
 	logrus.Debugf("Found %d organization roles", len(roles))
 	for _, role := range roles {
@@ -419,22 +429,27 @@ func dumpOrgConfig(client dumpClient, orgName string, ignoreSecretTeams bool, ig
 		// Get teams with this role
 		teamsWithRole, err := client.ListTeamsWithRole(orgName, role.ID)
 		if err != nil {
-			return nil, fmt.Errorf("failed to list teams with role %s: %w", role.Name, err)
+			logrus.WithError(err).Warnf("Failed to list teams with role %s; skipping role in dump", role.Name)
+			continue
 		}
 
 		// Get users with this role
 		usersWithRole, err := client.ListUsersWithRole(orgName, role.ID)
 		if err != nil {
-			return nil, fmt.Errorf("failed to list users with role %s: %w", role.Name, err)
+			logrus.WithError(err).Warnf("Failed to list users with role %s; skipping role in dump", role.Name)
+			continue
 		}
 
-		// Build team list, filtering out secret teams when --ignore-secret-teams is set
+		// Build team list. Teams that were intentionally excluded from the dump
+		// (secret/enterprise per ignore flags) are skipped so we do not leak them
+		// as raw slugs and produce a config that fails ValidateRoles on re-apply.
 		var teamNames []string
 		for _, team := range teamsWithRole {
-			// Only include teams that are in slugToName (secret teams are excluded from this map)
 			if name, ok := slugToName[team.Slug]; ok {
 				teamNames = append(teamNames, name)
-			} else if !ignoreSecretTeams {
+			} else if ignoredTeamSlugs.Has(team.Slug) {
+				logrus.WithField("team", team.Slug).Debug("Skipping role team assignment for intentionally ignored team.")
+			} else {
 				teamNames = append(teamNames, team.Slug)
 			}
 		}
@@ -1649,61 +1664,26 @@ func configureOrgRoles(client orgRolesClient, orgName string, orgConfig org.Conf
 		}
 	}
 
-	// Create a set of configured role names (lowercase) for quick lookup
-	configuredRoleNames := make(map[string]bool, len(orgConfig.Roles))
-	for roleName := range orgConfig.Roles {
-		configuredRoleNames[strings.ToLower(roleName)] = true
-	}
-
-	var configuredCount, unconfiguredCount int
-	for _, role := range roles {
-		if configuredRoleNames[strings.ToLower(role.Name)] {
-			configuredCount++
-		} else {
-			unconfiguredCount++
-		}
-	}
-	logrus.Debugf("Processing %d organization roles (%d configured, %d unconfigured to check for cleanup)",
-		len(roles), configuredCount, unconfiguredCount)
+	logrus.Debugf("Processing %d configured organization roles (of %d total in org)", len(orgConfig.Roles), len(roles))
 
 	var allErrors []error
 
-	// Iterate over ALL GitHub roles to handle both configured and unconfigured roles
-	for _, role := range roles {
-		roleNameLower := strings.ToLower(role.Name)
-
-		if configuredRoleNames[roleNameLower] {
-			// Role is in config - sync to match desired state
-			roleConfig := orgConfig.Roles[findOriginalRoleName(orgConfig.Roles, roleNameLower)]
-			if err := configureRoleTeamAssignments(client, orgName, role.Name, role.ID, roleConfig.Teams, githubTeams); err != nil {
-				allErrors = append(allErrors, fmt.Errorf("failed to configure team assignments for role %s: %w", role.Name, err))
-			}
-			if err := configureRoleUserAssignments(client, orgName, role.Name, role.ID, roleConfig.Users, invitees); err != nil {
-				allErrors = append(allErrors, fmt.Errorf("failed to configure user assignments for role %s: %w", role.Name, err))
-			}
-		} else {
-			// Role is NOT in config - remove all assignments (clean up orphaned assignments)
-			logrus.Debugf("Role %q not in config, checking for assignments to clean up", role.Name)
-			if err := configureRoleTeamAssignments(client, orgName, role.Name, role.ID, []string{}, githubTeams); err != nil {
-				allErrors = append(allErrors, fmt.Errorf("failed to remove team assignments for unconfigured role %s: %w", role.Name, err))
-			}
-			if err := configureRoleUserAssignments(client, orgName, role.Name, role.ID, []string{}, invitees); err != nil {
-				allErrors = append(allErrors, fmt.Errorf("failed to remove user assignments for unconfigured role %s: %w", role.Name, err))
-			}
+	// Only manage roles that are explicitly declared in config. Roles absent
+	// from config - including GitHub's built-in predefined roles and any roles
+	// managed out-of-band - are left untouched. To empty a role, declare it in
+	// config with no teams/users. (This mirrors how peribolos avoids mutating
+	// resources it was not asked to manage.)
+	for roleName, roleConfig := range orgConfig.Roles {
+		role := githubRolesByName[strings.ToLower(roleName)]
+		if err := configureRoleTeamAssignments(client, orgName, role.Name, role.ID, roleConfig.Teams, githubTeams); err != nil {
+			allErrors = append(allErrors, fmt.Errorf("failed to configure team assignments for role %s: %w", role.Name, err))
+		}
+		if err := configureRoleUserAssignments(client, orgName, role.Name, role.ID, roleConfig.Users, invitees); err != nil {
+			allErrors = append(allErrors, fmt.Errorf("failed to configure user assignments for role %s: %w", role.Name, err))
 		}
 	}
 
 	return utilerrors.NewAggregate(allErrors)
-}
-
-// findOriginalRoleName returns the original-cased key from the roles map that matches the lowercase name.
-func findOriginalRoleName(roles map[string]org.Role, lowerName string) string {
-	for name := range roles {
-		if strings.ToLower(name) == lowerName {
-			return name
-		}
-	}
-	return lowerName
 }
 
 // configureRoleTeamAssignments configures team assignments for a specific role

--- a/cmd/peribolos/main.go
+++ b/cmd/peribolos/main.go
@@ -59,6 +59,7 @@ type options struct {
 	fixTeamRepos          bool
 	fixRepos              bool
 	fixCollaborators      bool
+	fixOrgRoles           bool
 	ignoreInvitees        bool
 	ignoreSecretTeams     bool
 	ignoreEnterpriseTeams bool
@@ -97,6 +98,7 @@ func (o *options) parseArgs(flags *flag.FlagSet, args []string) error {
 	flags.BoolVar(&o.fixTeamRepos, "fix-team-repos", false, "Add/remove team permissions on repos if set")
 	flags.BoolVar(&o.fixRepos, "fix-repos", false, "Create/update repositories if set")
 	flags.BoolVar(&o.fixCollaborators, "fix-collaborators", false, "Add/remove/update repository collaborators if set")
+	flags.BoolVar(&o.fixOrgRoles, "fix-org-roles", false, "Assign/remove organization roles to teams and users if set")
 	flags.BoolVar(&o.allowRepoArchival, "allow-repo-archival", false, "If set, archiving repos is allowed while updating repos")
 	flags.BoolVar(&o.allowRepoPublish, "allow-repo-publish", false, "If set, changing repository visibility to public is allowed while updating repos")
 	flags.StringVar(&o.logLevel, "log-level", logrus.InfoLevel.String(), fmt.Sprintf("Logging level, one of %v", logrus.AllLevels))
@@ -148,6 +150,10 @@ func (o *options) parseArgs(flags *flag.FlagSet, args []string) error {
 
 	if o.fixTeamRepos && !o.fixTeams {
 		return fmt.Errorf("--fix-team-repos requires --fix-teams")
+	}
+
+	if o.fixOrgRoles && !o.fixTeams {
+		return fmt.Errorf("--fix-org-roles requires --fix-teams")
 	}
 
 	return nil
@@ -212,6 +218,9 @@ type dumpClient interface {
 	GetRepo(owner, name string) (github.FullRepo, error)
 	GetRepos(org string, isUser bool) ([]github.Repo, error)
 	ListDirectCollaboratorsWithPermissions(org, repo string) (map[string]github.RepoPermissionLevel, error)
+	ListOrganizationRoles(org string) ([]github.OrganizationRole, error)
+	ListTeamsWithRole(org string, roleID int) ([]github.OrganizationRoleAssignment, error)
+	ListUsersWithRole(org string, roleID int) ([]github.OrganizationRoleAssignment, error)
 	BotUser() (*github.UserData, error)
 }
 
@@ -275,6 +284,7 @@ func dumpOrgConfig(client dumpClient, orgName string, ignoreSecretTeams bool, ig
 	idMap := map[int]org.Team{} // metadata for a team
 	children := map[int][]int{} // what children does it have
 	var tops []int              // what are the top-level teams
+	slugToName := map[string]string{}
 
 	for _, t := range teams {
 		logger := logrus.WithFields(logrus.Fields{"id": t.ID, "name": t.Name})
@@ -287,6 +297,7 @@ func dumpOrgConfig(client dumpClient, orgName string, ignoreSecretTeams bool, ig
 			logger.Debug("Ignoring secret team.")
 			continue
 		}
+		slugToName[t.Slug] = t.Name
 		d := t.Description
 		nt := org.Team{
 			TeamMetadata: org.TeamMetadata{
@@ -394,6 +405,53 @@ func dumpOrgConfig(client dumpClient, orgName string, ignoreSecretTeams bool, ig
 			repoConfig.Collaborators = directCollabs
 		}
 		out.Repos[full.Name] = repoConfig
+	}
+
+	// Dump organization roles
+	roles, err := client.ListOrganizationRoles(orgName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list organization roles: %w", err)
+	}
+	logrus.Debugf("Found %d organization roles", len(roles))
+	if len(roles) > 0 {
+		out.Roles = make(map[string]org.Role, len(roles))
+	}
+	for _, role := range roles {
+		logrus.WithField("role", role.Name).Debug("Recording organization role.")
+
+		// Get teams with this role
+		teamsWithRole, err := client.ListTeamsWithRole(orgName, role.ID)
+		if err != nil {
+			logrus.WithError(err).Warnf("Failed to list teams with role %s", role.Name)
+			continue
+		}
+
+		// Get users with this role
+		usersWithRole, err := client.ListUsersWithRole(orgName, role.ID)
+		if err != nil {
+			logrus.WithError(err).Warnf("Failed to list users with role %s", role.Name)
+			continue
+		}
+
+		// Build team and user lists
+		var teamSlugs []string
+		for _, team := range teamsWithRole {
+			if name, ok := slugToName[team.Slug]; ok {
+				teamSlugs = append(teamSlugs, name)
+			} else {
+				teamSlugs = append(teamSlugs, team.Slug)
+			}
+		}
+
+		var userLogins []string
+		for _, user := range usersWithRole {
+			userLogins = append(userLogins, user.Login)
+		}
+
+		out.Roles[role.Name] = org.Role{
+			Teams: teamSlugs,
+			Users: userLogins,
+		}
 	}
 
 	return &out, nil
@@ -545,6 +603,8 @@ func configureOrgMembers(opt options, client orgClient, orgName string, orgConfi
 			}
 		} else if om.State == github.StatePending {
 			logrus.Infof("Invited %s to %s as a %s", user, orgName, role)
+			// Track the new invitation so role assignment can skip this user
+			invitees.Insert(github.NormLogin(user))
 		} else {
 			logrus.Infof("Set %s as a %s of %s", user, role, orgName)
 		}
@@ -949,6 +1009,13 @@ func orgFailedInvitations(opt options, client failedInviteClient, orgName string
 }
 
 func configureOrg(opt options, client github.Client, orgName string, orgConfig org.Config) error {
+	// Validate role configuration early (before any API calls) if we're going to configure roles
+	if opt.fixOrgRoles {
+		if err := orgConfig.ValidateRoles(); err != nil {
+			return fmt.Errorf("invalid role configuration: %w", err)
+		}
+	}
+
 	// Ensure that metadata is configured correctly.
 	if !opt.fixOrg {
 		logrus.Infof("Skipping org metadata configuration")
@@ -972,6 +1039,9 @@ func configureOrg(opt options, client github.Client, orgName string, orgConfig o
 	} else if err := configureOrgMembers(opt, client, orgName, orgConfig, invitees, failedInvites); err != nil {
 		return fmt.Errorf("failed to configure %s members: %w", orgName, err)
 	}
+
+	// Note: New invitations sent by configureOrgMembers are tracked in the invitees set,
+	// so role assignment can skip users with pending invitations without an extra API call.
 
 	// Create repositories in the org
 	if !opt.fixRepos {
@@ -1016,6 +1086,14 @@ func configureOrg(opt options, client github.Client, orgName string, orgConfig o
 			return fmt.Errorf("failed to configure %s team %s repos: %w", orgName, name, err)
 		}
 	}
+
+	// Configure organization roles
+	if !opt.fixOrgRoles {
+		logrus.Infof("Skipping organization roles configuration")
+	} else if err := configureOrgRoles(client, orgName, orgConfig, githubTeams, invitees); err != nil {
+		return fmt.Errorf("failed to configure %s organization roles: %w", orgName, err)
+	}
+
 	return nil
 }
 
@@ -1529,6 +1607,220 @@ func configureTeamRepos(client teamRepoClient, githubTeams map[string]github.Tea
 	}
 
 	return utilerrors.NewAggregate(updateErrors)
+}
+
+type orgRolesClient interface {
+	ListOrganizationRoles(org string) ([]github.OrganizationRole, error)
+	AssignOrganizationRoleToTeam(org, teamSlug string, roleID int) error
+	RemoveOrganizationRoleFromTeam(org, teamSlug string, roleID int) error
+	AssignOrganizationRoleToUser(org, user string, roleID int) error
+	RemoveOrganizationRoleFromUser(org, user string, roleID int) error
+	ListTeamsWithRole(org string, roleID int) ([]github.OrganizationRoleAssignment, error)
+	ListUsersWithRole(org string, roleID int) ([]github.OrganizationRoleAssignment, error)
+}
+
+// configureOrgRoles configures organization roles for teams and users
+func configureOrgRoles(client orgRolesClient, orgName string, orgConfig org.Config, githubTeams map[string]github.Team, invitees sets.Set[string]) error {
+	// Note: Role configuration is validated at the start of configureOrg() before any API calls
+
+	// Get current organization roles from GitHub
+	roles, err := client.ListOrganizationRoles(orgName)
+	if err != nil {
+		return fmt.Errorf("failed to list organization roles: %w", err)
+	}
+
+	if len(roles) == 0 {
+		logrus.Debugf("No organization roles exist in %s", orgName)
+		return nil
+	}
+
+	// Create a map of configured role names (lowercase) for quick lookup
+	configuredRoles := make(map[string]org.Role)
+	for roleName, roleConfig := range orgConfig.Roles {
+		configuredRoles[strings.ToLower(roleName)] = roleConfig
+	}
+
+	unconfiguredCount := len(roles) - len(configuredRoles)
+	logrus.Debugf("Processing %d organization roles (%d configured, %d unconfigured to check for cleanup)",
+		len(roles), len(configuredRoles), unconfiguredCount)
+
+	var allErrors []error
+
+	// Iterate over ALL GitHub roles to handle both configured and unconfigured roles
+	for _, role := range roles {
+		roleNameLower := strings.ToLower(role.Name)
+
+		if roleConfig, isConfigured := configuredRoles[roleNameLower]; isConfigured {
+			// Role is in config - sync to match desired state
+			if err := configureRoleTeamAssignments(client, orgName, role.Name, role.ID, roleConfig.Teams, githubTeams); err != nil {
+				allErrors = append(allErrors, fmt.Errorf("failed to configure team assignments for role %s: %w", role.Name, err))
+			}
+			if err := configureRoleUserAssignments(client, orgName, role.Name, role.ID, roleConfig.Users, invitees); err != nil {
+				allErrors = append(allErrors, fmt.Errorf("failed to configure user assignments for role %s: %w", role.Name, err))
+			}
+		} else {
+			// Role is NOT in config - remove all assignments (clean up orphaned assignments)
+			logrus.Debugf("Role %q not in config, checking for assignments to clean up", role.Name)
+			if err := configureRoleTeamAssignments(client, orgName, role.Name, role.ID, []string{}, githubTeams); err != nil {
+				allErrors = append(allErrors, fmt.Errorf("failed to remove team assignments for unconfigured role %s: %w", role.Name, err))
+			}
+			if err := configureRoleUserAssignments(client, orgName, role.Name, role.ID, []string{}, invitees); err != nil {
+				allErrors = append(allErrors, fmt.Errorf("failed to remove user assignments for unconfigured role %s: %w", role.Name, err))
+			}
+		}
+	}
+
+	// Check if any configured roles don't exist in GitHub
+	for roleName := range orgConfig.Roles {
+		found := false
+		for _, role := range roles {
+			if strings.EqualFold(role.Name, roleName) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("role %q does not exist in organization %s - create the role in GitHub before assigning it", roleName, orgName)
+		}
+	}
+
+	return utilerrors.NewAggregate(allErrors)
+}
+
+// configureRoleTeamAssignments configures team assignments for a specific role
+func configureRoleTeamAssignments(client orgRolesClient, orgName, roleName string, roleID int, wantTeams []string, githubTeams map[string]github.Team) error {
+	// Get current team assignments for this role
+	currentTeams, err := client.ListTeamsWithRole(orgName, roleID)
+	if err != nil {
+		return fmt.Errorf("failed to list teams with role %s: %w", roleName, err)
+	}
+
+	// If we want no teams and have no teams, we're done
+	if len(wantTeams) == 0 && len(currentTeams) == 0 {
+		return nil
+	}
+
+	// Build a map of normalized team name to team slug for the teams we have in config
+	// This allows resolving "MyTeam" (config name) to "my-team" (GitHub slug)
+	normalizedTeams := make(map[string]string)
+	for name, team := range githubTeams {
+		normalizedTeams[strings.ToLower(name)] = team.Slug
+	}
+
+	// Create sets for comparison using slugs
+	wantSet := sets.New[string]()
+	for _, teamName := range wantTeams {
+		// Resolve config team name to slug
+		if slug, ok := normalizedTeams[strings.ToLower(teamName)]; ok {
+			wantSet.Insert(slug)
+		} else {
+			return fmt.Errorf("team %q referenced in role %q could not be resolved to a GitHub team slug - ensure the team exists in your teams configuration and was successfully created", teamName, roleName)
+		}
+	}
+
+	haveSet := sets.New[string]()
+	for _, team := range currentTeams {
+		haveSet.Insert(team.Slug)
+	}
+
+	// Teams to add
+	var errors []error
+	toAdd := wantSet.Difference(haveSet)
+	for teamSlug := range toAdd {
+		if err := client.AssignOrganizationRoleToTeam(orgName, teamSlug, roleID); err != nil {
+			errors = append(errors, fmt.Errorf("failed to assign role %s to team %s: %w", roleName, teamSlug, err))
+			logrus.WithError(err).Warnf("Failed to assign role %s to team %s", roleName, teamSlug)
+		} else {
+			logrus.Infof("Assigned role %s to team %s", roleName, teamSlug)
+		}
+	}
+
+	// Teams to remove
+	toRemove := haveSet.Difference(wantSet)
+	for teamSlug := range toRemove {
+		if err := client.RemoveOrganizationRoleFromTeam(orgName, teamSlug, roleID); err != nil {
+			errors = append(errors, fmt.Errorf("failed to remove role %s from team %s: %w", roleName, teamSlug, err))
+			logrus.WithError(err).Warnf("Failed to remove role %s from team %s", roleName, teamSlug)
+		} else {
+			logrus.Infof("Removed role %s from team %s", roleName, teamSlug)
+		}
+	}
+
+	return utilerrors.NewAggregate(errors)
+}
+
+// configureRoleUserAssignments configures user assignments for a specific role
+func configureRoleUserAssignments(client orgRolesClient, orgName, roleName string, roleID int, wantUsers []string, invitees sets.Set[string]) error {
+	// Get current user assignments for this role
+	currentUsers, err := client.ListUsersWithRole(orgName, roleID)
+	if err != nil {
+		return fmt.Errorf("failed to list users with role %s: %w", roleName, err)
+	}
+
+	// Create maps to preserve original casing while comparing normalized usernames
+	wantMap := make(map[string]string) // normalized -> original
+	for _, user := range wantUsers {
+		wantMap[github.NormLogin(user)] = user
+	}
+
+	// Only consider DIRECT assignments when building haveMap.
+	// Users with "indirect" assignment have the role via team membership and should not be
+	// removed just because they're not in the users list - they keep the role through their team.
+	haveMap := make(map[string]string) // normalized -> original
+	for _, user := range currentUsers {
+		if user.Assignment == "indirect" {
+			logrus.Debugf("Skipping indirect role assignment for user %s (has role via team membership)", user.Login)
+			continue
+		}
+		haveMap[github.NormLogin(user.Login)] = user.Login
+	}
+
+	// If we want no direct users and have no direct users, we're done
+	if len(wantUsers) == 0 && len(haveMap) == 0 {
+		return nil
+	}
+
+	// Create sets for comparison with normalized usernames
+	wantSet := sets.New[string]()
+	for normalized := range wantMap {
+		wantSet.Insert(normalized)
+	}
+	haveSet := sets.New[string]()
+	for normalized := range haveMap {
+		haveSet.Insert(normalized)
+	}
+
+	// Users to add
+	var errors []error
+	toAdd := wantSet.Difference(haveSet)
+	for normalizedUser := range toAdd {
+		originalUser := wantMap[normalizedUser]
+		// Skip users who have pending org invitations - they must accept before we can assign roles
+		if invitees.Has(normalizedUser) {
+			logrus.Infof("Waiting for %s to accept org invitation before assigning role %s", originalUser, roleName)
+			continue
+		}
+		if err := client.AssignOrganizationRoleToUser(orgName, originalUser, roleID); err != nil {
+			errors = append(errors, fmt.Errorf("failed to assign role %s to user %s: %w", roleName, originalUser, err))
+			logrus.WithError(err).Warnf("Failed to assign role %s to user %s", roleName, originalUser)
+		} else {
+			logrus.Infof("Assigned role %s to user %s", roleName, originalUser)
+		}
+	}
+
+	// Users to remove
+	toRemove := haveSet.Difference(wantSet)
+	for normalizedUser := range toRemove {
+		originalUser := haveMap[normalizedUser]
+		if err := client.RemoveOrganizationRoleFromUser(orgName, originalUser, roleID); err != nil {
+			errors = append(errors, fmt.Errorf("failed to remove role %s from user %s: %w", roleName, originalUser, err))
+			logrus.WithError(err).Warnf("Failed to remove role %s from user %s", roleName, originalUser)
+		} else {
+			logrus.Infof("Removed role %s from user %s", roleName, originalUser)
+		}
+	}
+
+	return utilerrors.NewAggregate(errors)
 }
 
 // teamMembersClient can list/remove/update people to a team.

--- a/cmd/peribolos/main_test.go
+++ b/cmd/peribolos/main_test.go
@@ -2320,12 +2320,12 @@ func TestDumpOrgConfig(t *testing.T) {
 				{ID: 2, Name: "billing-manager"},
 			},
 			teamsWithRole: map[int][]github.OrganizationRoleAssignment{
-				1: {{ID: 1, Slug: "security-team", Type: "Team"}},
-				2: {{ID: 2, Slug: "finance-team", Type: "Team"}},
+				1: {{ID: 1, Slug: "security-team"}},
+				2: {{ID: 2, Slug: "finance-team"}},
 			},
 			usersWithRole: map[int][]github.OrganizationRoleAssignment{
-				1: {{ID: 3, Login: "security-admin", Type: "User"}},
-				2: {{ID: 4, Login: "finance-admin", Type: "User"}},
+				1: {{ID: 3, Login: "security-admin"}},
+				2: {{ID: 4, Login: "finance-admin"}},
 			},
 			expected: org.Config{
 				Metadata: org.Metadata{
@@ -4403,120 +4403,8 @@ func TestConfigureCollaborators_PermissionMatrix_PendingInvitationUpdates(t *tes
 	}
 }
 
-// Test organization roles functionality - comprehensive tests
-func TestOrganizationRoles(t *testing.T) {
-	// Test that the functions exist and can be called
-	// This ensures the functions compile and have correct signatures
-	t.Log("Organization roles functions exist and compile correctly")
-
-	// Test basic config structures
-	t.Run("role config structure", func(t *testing.T) {
-		// Test org.Role structure
-		role := org.Role{
-			Teams: []string{"team1", "team2"},
-			Users: []string{"user1", "user2"},
-		}
-
-		if len(role.Teams) != 2 {
-			t.Errorf("Expected 2 teams, got %d", len(role.Teams))
-		}
-		if len(role.Users) != 2 {
-			t.Errorf("Expected 2 users, got %d", len(role.Users))
-		}
-
-		// Test org.Config with roles
-		config := org.Config{
-			Roles: map[string]org.Role{
-				"security-manager": role,
-			},
-		}
-
-		if len(config.Roles) != 1 {
-			t.Errorf("Expected 1 role, got %d", len(config.Roles))
-		}
-
-		secRole, exists := config.Roles["security-manager"]
-		if !exists {
-			t.Error("security-manager role should exist")
-		}
-		if len(secRole.Teams) != 2 {
-			t.Errorf("Expected 2 teams in security-manager role, got %d", len(secRole.Teams))
-		}
-	})
-}
-
-// Test organization roles fail-fast scenarios
-func TestOrganizationRolesFailFast(t *testing.T) {
-	t.Run("validate role assignments correctly handle missing entities", func(t *testing.T) {
-		// Test role mapping logic
-		roleMap := map[string]int{
-			"existing-role": 1,
-		}
-
-		// This would fail - role doesn't exist
-		if roleID, exists := roleMap["non-existent-role"]; exists {
-			t.Errorf("Expected role 'non-existent-role' to not exist, but got ID %d", roleID)
-		}
-
-		// This would succeed - role exists
-		if _, exists := roleMap["existing-role"]; !exists {
-			t.Error("Expected role 'existing-role' to exist")
-		}
-
-		// Test team validation logic
-		githubTeams := map[string]github.Team{
-			"existing-team": {ID: 1, Slug: "existing-team", Name: "Existing Team"},
-		}
-
-		// This would fail - team doesn't exist
-		if _, exists := githubTeams["non-existent-team"]; exists {
-			t.Error("Expected team 'non-existent-team' to not exist")
-		}
-
-		// This would succeed - team exists
-		if _, exists := githubTeams["existing-team"]; !exists {
-			t.Error("Expected team 'existing-team' to exist")
-		}
-	})
-
-	t.Run("error messages contain expected information", func(t *testing.T) {
-		// Test that our error messages contain the expected information
-		testCases := []struct {
-			name             string
-			errorMsg         string
-			expectedContains []string
-		}{
-			{
-				name:             "role not found error",
-				errorMsg:         "role non-existent-role does not exist in organization test-org - check your configuration",
-				expectedContains: []string{"role", "non-existent-role", "does not exist", "organization", "test-org"},
-			},
-			{
-				name:             "team not found error",
-				errorMsg:         "team non-existent-team not found in organization test-org, cannot assign role security-manager - check your team configuration",
-				expectedContains: []string{"team", "non-existent-team", "not found", "organization", "test-org", "security-manager"},
-			},
-			{
-				name:             "user not org member error",
-				errorMsg:         "all users with role assignments must be org members: alice, bob",
-				expectedContains: []string{"users with role assignments", "must be org members", "alice", "bob"},
-			},
-		}
-
-		for _, tc := range testCases {
-			t.Run(tc.name, func(t *testing.T) {
-				for _, expected := range tc.expectedContains {
-					if !strings.Contains(tc.errorMsg, expected) {
-						t.Errorf("Expected error message to contain '%s', but message was: %s", expected, tc.errorMsg)
-					}
-				}
-			})
-		}
-	})
-
-	// Note: User/team reference validation is tested in pkg/config/org/org_test.go (TestValidateRoles)
-	// The validation happens at the start of configureOrg(), before any API calls are made
-
+// Test configureOrgRoles scenarios
+func TestConfigureOrgRoles(t *testing.T) {
 	t.Run("fails when configured role does not exist in GitHub", func(t *testing.T) {
 		orgConfig := org.Config{
 			Admins: []string{"admin-user"},
@@ -4593,10 +4481,10 @@ func TestOrganizationRolesFailFast(t *testing.T) {
 				{ID: 1, Name: "security-manager"},
 			},
 			teamsWithRole: map[int][]github.OrganizationRoleAssignment{
-				1: {{ID: 10, Slug: "old-team", Type: "Team"}}, // Existing team assignment
+				1: {{ID: 10, Slug: "old-team"}}, // Existing team assignment
 			},
 			usersWithRole: map[int][]github.OrganizationRoleAssignment{
-				1: {{ID: 5, Login: "old-user", Type: "User"}}, // Existing user assignment
+				1: {{ID: 5, Login: "old-user"}}, // Existing user assignment
 			},
 		}
 
@@ -4642,11 +4530,11 @@ func TestOrganizationRolesFailFast(t *testing.T) {
 				{ID: 2, Name: "billing-manager"},  // In config - should be synced
 			},
 			teamsWithRole: map[int][]github.OrganizationRoleAssignment{
-				1: {{ID: 10, Slug: "security-team", Type: "Team"}}, // Should be removed
+				1: {{ID: 10, Slug: "security-team"}}, // Should be removed
 				2: {},                                              // No teams
 			},
 			usersWithRole: map[int][]github.OrganizationRoleAssignment{
-				1: {{ID: 5, Login: "security-admin", Type: "User"}}, // Should be removed
+				1: {{ID: 5, Login: "security-admin"}}, // Should be removed
 				2: {},                                               // No users yet
 			},
 		}
@@ -4807,7 +4695,7 @@ func TestConfigureRoleTeamAssignments(t *testing.T) {
 			roleID:    1,
 			wantTeams: []string{},
 			currentTeams: []github.OrganizationRoleAssignment{
-				{ID: 10, Slug: "old-team", Type: "Team"},
+				{ID: 10, Slug: "old-team"},
 			},
 			githubTeams:    map[string]github.Team{},
 			expectAssigned: []string{},
@@ -4819,7 +4707,7 @@ func TestConfigureRoleTeamAssignments(t *testing.T) {
 			roleID:    1,
 			wantTeams: []string{"new-team"},
 			currentTeams: []github.OrganizationRoleAssignment{
-				{ID: 10, Slug: "old-team", Type: "Team"},
+				{ID: 10, Slug: "old-team"},
 			},
 			githubTeams: map[string]github.Team{
 				"new-team": {ID: 20, Slug: "new-team", Name: "New Team"},
@@ -4846,7 +4734,7 @@ func TestConfigureRoleTeamAssignments(t *testing.T) {
 			roleID:    1,
 			wantTeams: []string{"existing-team"},
 			currentTeams: []github.OrganizationRoleAssignment{
-				{ID: 10, Slug: "existing-team", Type: "Team"},
+				{ID: 10, Slug: "existing-team"},
 			},
 			githubTeams: map[string]github.Team{
 				"existing-team": {ID: 10, Slug: "existing-team", Name: "Existing Team"},
@@ -4877,11 +4765,11 @@ func TestConfigureRoleTeamAssignments(t *testing.T) {
 			}
 
 			// Compare slices with nil-safe comparison
-			if !slicesEqual(client.assignedTeamRoles, tc.expectAssigned) {
+			if !slicesEqualUnordered(client.assignedTeamRoles, tc.expectAssigned) {
 				t.Errorf("Assigned teams mismatch:\nExpected: %v\nGot: %v", tc.expectAssigned, client.assignedTeamRoles)
 			}
 
-			if !slicesEqual(client.removedTeamRoles, tc.expectRemoved) {
+			if !slicesEqualUnordered(client.removedTeamRoles, tc.expectRemoved) {
 				t.Errorf("Removed teams mismatch:\nExpected: %v\nGot: %v", tc.expectRemoved, client.removedTeamRoles)
 			}
 		})
@@ -4927,7 +4815,7 @@ func TestConfigureRoleUserAssignments(t *testing.T) {
 			roleID:    1,
 			wantUsers: []string{},
 			currentUsers: []github.OrganizationRoleAssignment{
-				{ID: 5, Login: "old-user", Type: "User"},
+				{ID: 5, Login: "old-user"},
 			},
 			expectAssigned: []string{},
 			expectRemoved:  []string{"test-org/old-user/1"},
@@ -4938,7 +4826,7 @@ func TestConfigureRoleUserAssignments(t *testing.T) {
 			roleID:    1,
 			wantUsers: []string{"new-user"},
 			currentUsers: []github.OrganizationRoleAssignment{
-				{ID: 5, Login: "old-user", Type: "User"},
+				{ID: 5, Login: "old-user"},
 			},
 			expectAssigned: []string{"test-org/new-user/1"},
 			expectRemoved:  []string{"test-org/old-user/1"},
@@ -4949,7 +4837,7 @@ func TestConfigureRoleUserAssignments(t *testing.T) {
 			roleID:    1,
 			wantUsers: []string{"NewUser"},
 			currentUsers: []github.OrganizationRoleAssignment{
-				{ID: 5, Login: "newuser", Type: "User"},
+				{ID: 5, Login: "newuser"},
 			},
 			expectAssigned: []string{},
 			expectRemoved:  []string{},
@@ -4969,8 +4857,8 @@ func TestConfigureRoleUserAssignments(t *testing.T) {
 			roleID:    1,
 			wantUsers: []string{},
 			currentUsers: []github.OrganizationRoleAssignment{
-				{ID: 5, Login: "OldUser", Type: "User"},
-				{ID: 6, Login: "AnotherOldUser", Type: "User"},
+				{ID: 5, Login: "OldUser"},
+				{ID: 6, Login: "AnotherOldUser"},
 			},
 			expectAssigned: []string{},
 			expectRemoved:  []string{"test-org/OldUser/1", "test-org/AnotherOldUser/1"},
@@ -4981,7 +4869,7 @@ func TestConfigureRoleUserAssignments(t *testing.T) {
 			roleID:    1,
 			wantUsers: []string{"existing-user"},
 			currentUsers: []github.OrganizationRoleAssignment{
-				{ID: 5, Login: "existing-user", Type: "User"},
+				{ID: 5, Login: "existing-user"},
 			},
 			expectAssigned: []string{},
 			expectRemoved:  []string{},
@@ -5009,19 +4897,12 @@ func TestConfigureRoleUserAssignments(t *testing.T) {
 				t.Errorf("Unexpected error: %v", err)
 			}
 
-			// Compare slices with nil-safe comparison (sort first since order is non-deterministic)
-			sort.Strings(client.assignedUserRoles)
-			expectedAssigned := append([]string{}, tc.expectAssigned...)
-			sort.Strings(expectedAssigned)
-			if !slicesEqual(client.assignedUserRoles, expectedAssigned) {
-				t.Errorf("Assigned users mismatch:\nExpected: %v\nGot: %v", expectedAssigned, client.assignedUserRoles)
+			if !slicesEqualUnordered(client.assignedUserRoles, tc.expectAssigned) {
+				t.Errorf("Assigned users mismatch:\nExpected: %v\nGot: %v", tc.expectAssigned, client.assignedUserRoles)
 			}
 
-			sort.Strings(client.removedUserRoles)
-			expectedRemoved := append([]string{}, tc.expectRemoved...)
-			sort.Strings(expectedRemoved)
-			if !slicesEqual(client.removedUserRoles, expectedRemoved) {
-				t.Errorf("Removed users mismatch:\nExpected: %v\nGot: %v", expectedRemoved, client.removedUserRoles)
+			if !slicesEqualUnordered(client.removedUserRoles, tc.expectRemoved) {
+				t.Errorf("Removed users mismatch:\nExpected: %v\nGot: %v", tc.expectRemoved, client.removedUserRoles)
 			}
 		})
 	}
@@ -5067,18 +4948,152 @@ func TestConfigureRoleUserAssignmentsSkipsPendingInvitees(t *testing.T) {
 	}
 }
 
-// slicesEqual compares two string slices treating nil and empty slices as equal
-func slicesEqual(a, b []string) bool {
+// Test that indirect user assignments are skipped
+func TestConfigureRoleUserAssignmentsSkipsIndirect(t *testing.T) {
+	client := &fakeOrgRolesClient{
+		usersWithRole: map[int][]github.OrganizationRoleAssignment{
+			1: {
+				{ID: 1, Login: "direct-user", Assignment: "direct"},
+				{ID: 2, Login: "indirect-user", Assignment: "indirect"},
+				{ID: 3, Login: "mixed-user", Assignment: "mixed"},
+			},
+		},
+	}
+
+	// Config wants no users — only direct and mixed assignments should be removed
+	err := configureRoleUserAssignments(client, "test-org", "test-role", 1, []string{}, sets.Set[string]{})
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	if !slicesEqualUnordered(client.removedUserRoles, []string{"test-org/direct-user/1", "test-org/mixed-user/1"}) {
+		t.Errorf("Expected direct-user and mixed-user removed, got: %v", client.removedUserRoles)
+	}
+}
+
+// Test error propagation in team assignments
+func TestConfigureRoleTeamAssignmentsErrors(t *testing.T) {
+	t.Run("list teams error", func(t *testing.T) {
+		client := &fakeOrgRolesClient{
+			listTeamsWithRoleErr: fmt.Errorf("api error"),
+		}
+		err := configureRoleTeamAssignments(client, "test-org", "test-role", 1, []string{"team"}, map[string]github.Team{})
+		if err == nil {
+			t.Error("Expected error but got none")
+		}
+	})
+
+	t.Run("assign error", func(t *testing.T) {
+		client := &fakeOrgRolesClient{
+			teamsWithRole:     map[int][]github.OrganizationRoleAssignment{1: {}},
+			assignTeamRoleErr: fmt.Errorf("assign failed"),
+		}
+		githubTeams := map[string]github.Team{
+			"my-team": {ID: 1, Slug: "my-team"},
+		}
+		err := configureRoleTeamAssignments(client, "test-org", "test-role", 1, []string{"my-team"}, githubTeams)
+		if err == nil {
+			t.Error("Expected error but got none")
+		}
+	})
+
+	t.Run("remove error", func(t *testing.T) {
+		client := &fakeOrgRolesClient{
+			teamsWithRole: map[int][]github.OrganizationRoleAssignment{
+				1: {{ID: 1, Slug: "old-team"}},
+			},
+			removeTeamRoleErr: fmt.Errorf("remove failed"),
+		}
+		err := configureRoleTeamAssignments(client, "test-org", "test-role", 1, []string{}, map[string]github.Team{})
+		if err == nil {
+			t.Error("Expected error but got none")
+		}
+	})
+}
+
+// Test error propagation in user assignments
+func TestConfigureRoleUserAssignmentsErrors(t *testing.T) {
+	t.Run("list users error", func(t *testing.T) {
+		client := &fakeOrgRolesClient{
+			listUsersWithRoleErr: fmt.Errorf("api error"),
+		}
+		err := configureRoleUserAssignments(client, "test-org", "test-role", 1, []string{"user"}, sets.Set[string]{})
+		if err == nil {
+			t.Error("Expected error but got none")
+		}
+	})
+
+	t.Run("assign error", func(t *testing.T) {
+		client := &fakeOrgRolesClient{
+			usersWithRole:    map[int][]github.OrganizationRoleAssignment{1: {}},
+			assignUserRoleErr: fmt.Errorf("assign failed"),
+		}
+		err := configureRoleUserAssignments(client, "test-org", "test-role", 1, []string{"user"}, sets.Set[string]{})
+		if err == nil {
+			t.Error("Expected error but got none")
+		}
+	})
+
+	t.Run("remove error", func(t *testing.T) {
+		client := &fakeOrgRolesClient{
+			usersWithRole: map[int][]github.OrganizationRoleAssignment{
+				1: {{ID: 1, Login: "old-user"}},
+			},
+			removeUserRoleErr: fmt.Errorf("remove failed"),
+		}
+		err := configureRoleUserAssignments(client, "test-org", "test-role", 1, []string{}, sets.Set[string]{})
+		if err == nil {
+			t.Error("Expected error but got none")
+		}
+	})
+}
+
+// Test that configureOrgRoles validates roles before making mutations
+func TestConfigureOrgRolesValidatesBeforeMutating(t *testing.T) {
+	// Config references a role that doesn't exist AND a role that does
+	orgConfig := org.Config{
+		Admins: []string{"admin"},
+		Roles: map[string]org.Role{
+			"exists":     {Users: []string{"admin"}},
+			"not-exists": {Users: []string{"admin"}},
+		},
+	}
+
+	client := &fakeOrgRolesClient{
+		roles: []github.OrganizationRole{
+			{ID: 1, Name: "exists"},
+		},
+		usersWithRole: map[int][]github.OrganizationRoleAssignment{1: {}},
+	}
+
+	err := configureOrgRoles(client, "test-org", orgConfig, map[string]github.Team{}, sets.Set[string]{})
+	if err == nil {
+		t.Fatal("Expected error for non-existent role")
+	}
+	if !strings.Contains(err.Error(), "not-exists") {
+		t.Errorf("Expected error about 'not-exists', got: %v", err)
+	}
+
+	// Verify NO mutations were made (validation should have blocked them)
+	if len(client.assignedUserRoles) != 0 {
+		t.Errorf("Expected no mutations before validation, got assignments: %v", client.assignedUserRoles)
+	}
+	if len(client.assignedTeamRoles) != 0 {
+		t.Errorf("Expected no mutations before validation, got team assignments: %v", client.assignedTeamRoles)
+	}
+}
+
+// normalizeSlice returns a sorted copy of a string slice, treating nil as empty.
+func normalizeSlice(s []string) []string {
+	out := append([]string{}, s...)
+	sort.Strings(out)
+	return out
+}
+
+// slicesEqualUnordered compares two string slices ignoring order and treating nil as empty.
+func slicesEqualUnordered(a, b []string) bool {
 	if len(a) == 0 && len(b) == 0 {
 		return true
 	}
-	if len(a) != len(b) {
-		return false
-	}
-	for i := range a {
-		if a[i] != b[i] {
-			return false
-		}
-	}
-	return true
+	return slices.Equal(normalizeSlice(a), normalizeSlice(b))
 }

--- a/cmd/peribolos/main_test.go
+++ b/cmd/peribolos/main_test.go
@@ -2356,6 +2356,47 @@ func TestDumpOrgConfig(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "dump excludes roles with no assignments",
+			meta: github.Organization{
+				Name:                        "Hello",
+				DefaultRepositoryPermission: "write",
+			},
+			members: []string{"user1"},
+			admins:  []string{"admin"},
+			roles: []github.OrganizationRole{
+				{ID: 1, Name: "security-manager"},
+				{ID: 2, Name: "billing-manager"},
+				{ID: 3, Name: "all_repo_read"},
+			},
+			teamsWithRole: map[int][]github.OrganizationRoleAssignment{
+				1: {{ID: 1, Slug: "security-team"}},
+			},
+			usersWithRole: map[int][]github.OrganizationRoleAssignment{},
+			expected: org.Config{
+				Metadata: org.Metadata{
+					Name:                         &hello,
+					BillingEmail:                 &empty,
+					Company:                      &empty,
+					Email:                        &empty,
+					Description:                  &empty,
+					Location:                     &empty,
+					HasOrganizationProjects:      &no,
+					HasRepositoryProjects:        &no,
+					DefaultRepositoryPermission:  &perm,
+					MembersCanCreateRepositories: &no,
+				},
+				Members: []string{"user1"},
+				Admins:  []string{"admin"},
+				Teams:   map[string]org.Team{},
+				Repos:   map[string]org.Repo{},
+				Roles: map[string]org.Role{
+					"security-manager": {
+						Teams: []string{"security-team"},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tc := range cases {

--- a/cmd/peribolos/main_test.go
+++ b/cmd/peribolos/main_test.go
@@ -24,6 +24,7 @@ import (
 	"reflect"
 	"slices"
 	"sort"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -108,6 +109,10 @@ func TestOptions(t *testing.T) {
 		{
 			name: "reject --fix-team-members without --fix-teams",
 			args: []string{"--config-path=foo", "--fix-team-members"},
+		},
+		{
+			name: "reject --fix-org-roles without --fix-teams",
+			args: []string{"--config-path=foo", "--fix-org-roles"},
 		},
 		{
 			name: "allow dump without config",
@@ -1950,6 +1955,9 @@ func TestDumpOrgConfig(t *testing.T) {
 		maintainers           map[string][]string
 		repoPermissions       map[string][]github.Repo
 		repos                 []github.FullRepo
+		roles                 []github.OrganizationRole
+		teamsWithRole         map[int][]github.OrganizationRoleAssignment
+		usersWithRole         map[int][]github.OrganizationRoleAssignment
 		expected              org.Config
 		err                   bool
 	}{
@@ -2299,6 +2307,55 @@ func TestDumpOrgConfig(t *testing.T) {
 				Repos:   map[string]org.Repo{},
 			},
 		},
+		{
+			name: "dump organization with roles",
+			meta: github.Organization{
+				Name:                        "Hello",
+				DefaultRepositoryPermission: "write",
+			},
+			members: []string{"user1", "user2"},
+			admins:  []string{"admin"},
+			roles: []github.OrganizationRole{
+				{ID: 1, Name: "security-manager"},
+				{ID: 2, Name: "billing-manager"},
+			},
+			teamsWithRole: map[int][]github.OrganizationRoleAssignment{
+				1: {{ID: 1, Slug: "security-team", Type: "Team"}},
+				2: {{ID: 2, Slug: "finance-team", Type: "Team"}},
+			},
+			usersWithRole: map[int][]github.OrganizationRoleAssignment{
+				1: {{ID: 3, Login: "security-admin", Type: "User"}},
+				2: {{ID: 4, Login: "finance-admin", Type: "User"}},
+			},
+			expected: org.Config{
+				Metadata: org.Metadata{
+					Name:                         &hello,
+					BillingEmail:                 &empty,
+					Company:                      &empty,
+					Email:                        &empty,
+					Description:                  &empty,
+					Location:                     &empty,
+					HasOrganizationProjects:      &no,
+					HasRepositoryProjects:        &no,
+					DefaultRepositoryPermission:  &perm,
+					MembersCanCreateRepositories: &no,
+				},
+				Members: []string{"user1", "user2"},
+				Admins:  []string{"admin"},
+				Teams:   map[string]org.Team{},
+				Repos:   map[string]org.Repo{},
+				Roles: map[string]org.Role{
+					"security-manager": {
+						Teams: []string{"security-team"},
+						Users: []string{"security-admin"},
+					},
+					"billing-manager": {
+						Teams: []string{"finance-team"},
+						Users: []string{"finance-admin"},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tc := range cases {
@@ -2317,6 +2374,9 @@ func TestDumpOrgConfig(t *testing.T) {
 				maintainers:     tc.maintainers,
 				repoPermissions: tc.repoPermissions,
 				repos:           tc.repos,
+				roles:           tc.roles,
+				teamsWithRole:   tc.teamsWithRole,
+				usersWithRole:   tc.usersWithRole,
 			}
 			actual, err := dumpOrgConfig(fc, orgName, tc.ignoreSecretTeams, tc.ignoreEnterpriseTeams, "")
 			switch {
@@ -2348,6 +2408,9 @@ type fakeDumpClient struct {
 	maintainers     map[string][]string
 	repoPermissions map[string][]github.Repo
 	repos           []github.FullRepo
+	roles           []github.OrganizationRole
+	teamsWithRole   map[int][]github.OrganizationRoleAssignment
+	usersWithRole   map[int][]github.OrganizationRoleAssignment
 }
 
 func (c fakeDumpClient) GetOrg(name string) (*github.Organization, error) {
@@ -2469,6 +2532,27 @@ func (c fakeDumpClient) ListRepoInvitations(org, repo string) ([]github.Collabor
 	return []github.CollaboratorRepoInvitation{}, nil
 }
 
+func (c fakeDumpClient) ListOrganizationRoles(org string) ([]github.OrganizationRole, error) {
+	if org != c.name {
+		return nil, fmt.Errorf("bad org: %s", org)
+	}
+	return c.roles, nil
+}
+
+func (c fakeDumpClient) ListTeamsWithRole(org string, roleID int) ([]github.OrganizationRoleAssignment, error) {
+	if org != c.name {
+		return nil, fmt.Errorf("bad org: %s", org)
+	}
+	return c.teamsWithRole[roleID], nil
+}
+
+func (c fakeDumpClient) ListUsersWithRole(org string, roleID int) ([]github.OrganizationRoleAssignment, error) {
+	if org != c.name {
+		return nil, fmt.Errorf("bad org: %s", org)
+	}
+	return c.usersWithRole[roleID], nil
+}
+
 func fixup(ret *org.Config) {
 	if ret == nil {
 		return
@@ -2480,6 +2564,11 @@ func fixup(ret *org.Config) {
 		sort.Strings(team.Maintainers)
 		sort.Strings(team.Previously)
 		ret.Teams[name] = team
+	}
+	for name, role := range ret.Roles {
+		sort.Strings(role.Teams)
+		sort.Strings(role.Users)
+		ret.Roles[name] = role
 	}
 }
 
@@ -4312,4 +4401,684 @@ func TestConfigureCollaborators_PermissionMatrix_PendingInvitationUpdates(t *tes
 			})
 		}
 	}
+}
+
+// Test organization roles functionality - comprehensive tests
+func TestOrganizationRoles(t *testing.T) {
+	// Test that the functions exist and can be called
+	// This ensures the functions compile and have correct signatures
+	t.Log("Organization roles functions exist and compile correctly")
+
+	// Test basic config structures
+	t.Run("role config structure", func(t *testing.T) {
+		// Test org.Role structure
+		role := org.Role{
+			Teams: []string{"team1", "team2"},
+			Users: []string{"user1", "user2"},
+		}
+
+		if len(role.Teams) != 2 {
+			t.Errorf("Expected 2 teams, got %d", len(role.Teams))
+		}
+		if len(role.Users) != 2 {
+			t.Errorf("Expected 2 users, got %d", len(role.Users))
+		}
+
+		// Test org.Config with roles
+		config := org.Config{
+			Roles: map[string]org.Role{
+				"security-manager": role,
+			},
+		}
+
+		if len(config.Roles) != 1 {
+			t.Errorf("Expected 1 role, got %d", len(config.Roles))
+		}
+
+		secRole, exists := config.Roles["security-manager"]
+		if !exists {
+			t.Error("security-manager role should exist")
+		}
+		if len(secRole.Teams) != 2 {
+			t.Errorf("Expected 2 teams in security-manager role, got %d", len(secRole.Teams))
+		}
+	})
+}
+
+// Test organization roles fail-fast scenarios
+func TestOrganizationRolesFailFast(t *testing.T) {
+	t.Run("validate role assignments correctly handle missing entities", func(t *testing.T) {
+		// Test role mapping logic
+		roleMap := map[string]int{
+			"existing-role": 1,
+		}
+
+		// This would fail - role doesn't exist
+		if roleID, exists := roleMap["non-existent-role"]; exists {
+			t.Errorf("Expected role 'non-existent-role' to not exist, but got ID %d", roleID)
+		}
+
+		// This would succeed - role exists
+		if _, exists := roleMap["existing-role"]; !exists {
+			t.Error("Expected role 'existing-role' to exist")
+		}
+
+		// Test team validation logic
+		githubTeams := map[string]github.Team{
+			"existing-team": {ID: 1, Slug: "existing-team", Name: "Existing Team"},
+		}
+
+		// This would fail - team doesn't exist
+		if _, exists := githubTeams["non-existent-team"]; exists {
+			t.Error("Expected team 'non-existent-team' to not exist")
+		}
+
+		// This would succeed - team exists
+		if _, exists := githubTeams["existing-team"]; !exists {
+			t.Error("Expected team 'existing-team' to exist")
+		}
+	})
+
+	t.Run("error messages contain expected information", func(t *testing.T) {
+		// Test that our error messages contain the expected information
+		testCases := []struct {
+			name             string
+			errorMsg         string
+			expectedContains []string
+		}{
+			{
+				name:             "role not found error",
+				errorMsg:         "role non-existent-role does not exist in organization test-org - check your configuration",
+				expectedContains: []string{"role", "non-existent-role", "does not exist", "organization", "test-org"},
+			},
+			{
+				name:             "team not found error",
+				errorMsg:         "team non-existent-team not found in organization test-org, cannot assign role security-manager - check your team configuration",
+				expectedContains: []string{"team", "non-existent-team", "not found", "organization", "test-org", "security-manager"},
+			},
+			{
+				name:             "user not org member error",
+				errorMsg:         "all users with role assignments must be org members: alice, bob",
+				expectedContains: []string{"users with role assignments", "must be org members", "alice", "bob"},
+			},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				for _, expected := range tc.expectedContains {
+					if !strings.Contains(tc.errorMsg, expected) {
+						t.Errorf("Expected error message to contain '%s', but message was: %s", expected, tc.errorMsg)
+					}
+				}
+			})
+		}
+	})
+
+	// Note: User/team reference validation is tested in pkg/config/org/org_test.go (TestValidateRoles)
+	// The validation happens at the start of configureOrg(), before any API calls are made
+
+	t.Run("fails when configured role does not exist in GitHub", func(t *testing.T) {
+		orgConfig := org.Config{
+			Admins: []string{"admin-user"},
+			Roles: map[string]org.Role{
+				"non-existent-role": {
+					Users: []string{"admin-user"},
+				},
+			},
+		}
+
+		client := &fakeOrgRolesClient{
+			roles: []github.OrganizationRole{
+				{ID: 1, Name: "other-role"},
+			},
+		}
+
+		githubTeams := map[string]github.Team{}
+		invitees := sets.Set[string]{}
+
+		err := configureOrgRoles(client, "test-org", orgConfig, githubTeams, invitees)
+		if err == nil {
+			t.Error("Expected error for non-existent role, but got none")
+		}
+		if !strings.Contains(err.Error(), "does not exist") {
+			t.Errorf("Expected error about role not existing, got: %v", err)
+		}
+		if !strings.Contains(err.Error(), "non-existent-role") {
+			t.Errorf("Expected error to mention the role name, got: %v", err)
+		}
+	})
+
+	t.Run("role name matching is case-insensitive", func(t *testing.T) {
+		orgConfig := org.Config{
+			Admins: []string{"admin-user"},
+			Roles: map[string]org.Role{
+				"Security-Manager": { // Different casing than what's in GitHub
+					Users: []string{"admin-user"},
+				},
+			},
+		}
+
+		client := &fakeOrgRolesClient{
+			roles: []github.OrganizationRole{
+				{ID: 1, Name: "security-manager"}, // Lowercase in GitHub
+			},
+			usersWithRole: map[int][]github.OrganizationRoleAssignment{
+				1: {}, // No current assignments
+			},
+		}
+
+		githubTeams := map[string]github.Team{}
+		invitees := sets.Set[string]{}
+
+		err := configureOrgRoles(client, "test-org", orgConfig, githubTeams, invitees)
+		if err != nil {
+			t.Errorf("Expected case-insensitive role matching to succeed, got error: %v", err)
+		}
+
+		// Verify the role was assigned
+		if len(client.assignedUserRoles) != 1 {
+			t.Errorf("Expected 1 user role assignment, got %d", len(client.assignedUserRoles))
+		}
+	})
+
+	t.Run("removes assignments for roles not in config", func(t *testing.T) {
+		// Config has NO roles - but GitHub has a role with assignments
+		orgConfig := org.Config{
+			Admins: []string{"admin-user"},
+			Roles:  map[string]org.Role{}, // Empty - no roles configured
+		}
+
+		client := &fakeOrgRolesClient{
+			roles: []github.OrganizationRole{
+				{ID: 1, Name: "security-manager"},
+			},
+			teamsWithRole: map[int][]github.OrganizationRoleAssignment{
+				1: {{ID: 10, Slug: "old-team", Type: "Team"}}, // Existing team assignment
+			},
+			usersWithRole: map[int][]github.OrganizationRoleAssignment{
+				1: {{ID: 5, Login: "old-user", Type: "User"}}, // Existing user assignment
+			},
+		}
+
+		githubTeams := map[string]github.Team{}
+		invitees := sets.Set[string]{}
+
+		err := configureOrgRoles(client, "test-org", orgConfig, githubTeams, invitees)
+		if err != nil {
+			t.Errorf("Unexpected error: %v", err)
+		}
+
+		// Verify the orphaned assignments were removed
+		if len(client.removedTeamRoles) != 1 {
+			t.Errorf("Expected 1 team role removal, got %d: %v", len(client.removedTeamRoles), client.removedTeamRoles)
+		}
+		if len(client.removedUserRoles) != 1 {
+			t.Errorf("Expected 1 user role removal, got %d: %v", len(client.removedUserRoles), client.removedUserRoles)
+		}
+
+		// Verify no new assignments were made
+		if len(client.assignedTeamRoles) != 0 {
+			t.Errorf("Expected no team assignments, got %d: %v", len(client.assignedTeamRoles), client.assignedTeamRoles)
+		}
+		if len(client.assignedUserRoles) != 0 {
+			t.Errorf("Expected no user assignments, got %d: %v", len(client.assignedUserRoles), client.assignedUserRoles)
+		}
+	})
+
+	t.Run("cleans up role when removed from config but keeps others", func(t *testing.T) {
+		// Config has only one role, but GitHub has two roles with assignments
+		orgConfig := org.Config{
+			Admins: []string{"admin-user"},
+			Roles: map[string]org.Role{
+				"billing-manager": {
+					Users: []string{"admin-user"}, // Keep this role
+				},
+			},
+		}
+
+		client := &fakeOrgRolesClient{
+			roles: []github.OrganizationRole{
+				{ID: 1, Name: "security-manager"}, // Not in config - should be cleaned up
+				{ID: 2, Name: "billing-manager"},  // In config - should be synced
+			},
+			teamsWithRole: map[int][]github.OrganizationRoleAssignment{
+				1: {{ID: 10, Slug: "security-team", Type: "Team"}}, // Should be removed
+				2: {},                                              // No teams
+			},
+			usersWithRole: map[int][]github.OrganizationRoleAssignment{
+				1: {{ID: 5, Login: "security-admin", Type: "User"}}, // Should be removed
+				2: {},                                               // No users yet
+			},
+		}
+
+		githubTeams := map[string]github.Team{}
+		invitees := sets.Set[string]{}
+
+		err := configureOrgRoles(client, "test-org", orgConfig, githubTeams, invitees)
+		if err != nil {
+			t.Errorf("Unexpected error: %v", err)
+		}
+
+		// Verify security-manager assignments were removed (role ID 1)
+		foundSecurityTeamRemoval := false
+		foundSecurityUserRemoval := false
+		for _, removal := range client.removedTeamRoles {
+			if strings.Contains(removal, "/1") { // roleID 1
+				foundSecurityTeamRemoval = true
+			}
+		}
+		for _, removal := range client.removedUserRoles {
+			if strings.Contains(removal, "/1") { // roleID 1
+				foundSecurityUserRemoval = true
+			}
+		}
+		if !foundSecurityTeamRemoval {
+			t.Errorf("Expected security-manager team assignment to be removed, removals: %v", client.removedTeamRoles)
+		}
+		if !foundSecurityUserRemoval {
+			t.Errorf("Expected security-manager user assignment to be removed, removals: %v", client.removedUserRoles)
+		}
+
+		// Verify billing-manager was assigned (role ID 2)
+		foundBillingUserAssignment := false
+		for _, assignment := range client.assignedUserRoles {
+			if strings.Contains(assignment, "/2") { // roleID 2
+				foundBillingUserAssignment = true
+			}
+		}
+		if !foundBillingUserAssignment {
+			t.Errorf("Expected billing-manager user assignment, assignments: %v", client.assignedUserRoles)
+		}
+	})
+}
+
+// fakeOrgRolesClient is a mock client for testing organization roles functionality
+type fakeOrgRolesClient struct {
+	roles                    []github.OrganizationRole
+	teamsWithRole            map[int][]github.OrganizationRoleAssignment
+	usersWithRole            map[int][]github.OrganizationRoleAssignment
+	assignedTeamRoles        []string // Track calls: "org/team-slug/roleID"
+	removedTeamRoles         []string // Track calls: "org/team-slug/roleID"
+	assignedUserRoles        []string // Track calls: "org/user/roleID"
+	removedUserRoles         []string // Track calls: "org/user/roleID"
+	assignTeamRoleErr        error
+	removeTeamRoleErr        error
+	assignUserRoleErr        error
+	removeUserRoleErr        error
+	listOrganizationRolesErr error
+	listTeamsWithRoleErr     error
+	listUsersWithRoleErr     error
+}
+
+func (f *fakeOrgRolesClient) ListOrganizationRoles(org string) ([]github.OrganizationRole, error) {
+	if f.listOrganizationRolesErr != nil {
+		return nil, f.listOrganizationRolesErr
+	}
+	return f.roles, nil
+}
+
+func (f *fakeOrgRolesClient) AssignOrganizationRoleToTeam(org, teamSlug string, roleID int) error {
+	if f.assignTeamRoleErr != nil {
+		return f.assignTeamRoleErr
+	}
+	f.assignedTeamRoles = append(f.assignedTeamRoles, fmt.Sprintf("%s/%s/%d", org, teamSlug, roleID))
+	return nil
+}
+
+func (f *fakeOrgRolesClient) RemoveOrganizationRoleFromTeam(org, teamSlug string, roleID int) error {
+	if f.removeTeamRoleErr != nil {
+		return f.removeTeamRoleErr
+	}
+	f.removedTeamRoles = append(f.removedTeamRoles, fmt.Sprintf("%s/%s/%d", org, teamSlug, roleID))
+	return nil
+}
+
+func (f *fakeOrgRolesClient) AssignOrganizationRoleToUser(org, user string, roleID int) error {
+	if f.assignUserRoleErr != nil {
+		return f.assignUserRoleErr
+	}
+	f.assignedUserRoles = append(f.assignedUserRoles, fmt.Sprintf("%s/%s/%d", org, user, roleID))
+	return nil
+}
+
+func (f *fakeOrgRolesClient) RemoveOrganizationRoleFromUser(org, user string, roleID int) error {
+	if f.removeUserRoleErr != nil {
+		return f.removeUserRoleErr
+	}
+	f.removedUserRoles = append(f.removedUserRoles, fmt.Sprintf("%s/%s/%d", org, user, roleID))
+	return nil
+}
+
+func (f *fakeOrgRolesClient) ListTeamsWithRole(org string, roleID int) ([]github.OrganizationRoleAssignment, error) {
+	if f.listTeamsWithRoleErr != nil {
+		return nil, f.listTeamsWithRoleErr
+	}
+	return f.teamsWithRole[roleID], nil
+}
+
+func (f *fakeOrgRolesClient) ListUsersWithRole(org string, roleID int) ([]github.OrganizationRoleAssignment, error) {
+	if f.listUsersWithRoleErr != nil {
+		return nil, f.listUsersWithRoleErr
+	}
+	return f.usersWithRole[roleID], nil
+}
+
+// Test configureRoleTeamAssignments
+func TestConfigureRoleTeamAssignments(t *testing.T) {
+	tests := []struct {
+		name           string
+		roleName       string
+		roleID         int
+		wantTeams      []string
+		currentTeams   []github.OrganizationRoleAssignment
+		githubTeams    map[string]github.Team
+		expectAssigned []string
+		expectRemoved  []string
+		listTeamsErr   error
+		assignErr      error
+		removeErr      error
+		expectError    bool
+	}{
+		{
+			name:           "no teams to configure",
+			roleName:       "security-manager",
+			roleID:         1,
+			wantTeams:      []string{},
+			currentTeams:   []github.OrganizationRoleAssignment{},
+			githubTeams:    map[string]github.Team{},
+			expectAssigned: []string{},
+			expectRemoved:  []string{},
+		},
+		{
+			name:         "add new team assignment",
+			roleName:     "security-manager",
+			roleID:       1,
+			wantTeams:    []string{"security-team"},
+			currentTeams: []github.OrganizationRoleAssignment{},
+			githubTeams: map[string]github.Team{
+				"security-team": {ID: 10, Slug: "security-team", Name: "Security Team"},
+			},
+			expectAssigned: []string{"test-org/security-team/1"},
+			expectRemoved:  []string{},
+		},
+		{
+			name:      "remove team assignment",
+			roleName:  "security-manager",
+			roleID:    1,
+			wantTeams: []string{},
+			currentTeams: []github.OrganizationRoleAssignment{
+				{ID: 10, Slug: "old-team", Type: "Team"},
+			},
+			githubTeams:    map[string]github.Team{},
+			expectAssigned: []string{},
+			expectRemoved:  []string{"test-org/old-team/1"},
+		},
+		{
+			name:      "add and remove teams",
+			roleName:  "security-manager",
+			roleID:    1,
+			wantTeams: []string{"new-team"},
+			currentTeams: []github.OrganizationRoleAssignment{
+				{ID: 10, Slug: "old-team", Type: "Team"},
+			},
+			githubTeams: map[string]github.Team{
+				"new-team": {ID: 20, Slug: "new-team", Name: "New Team"},
+			},
+			expectAssigned: []string{"test-org/new-team/1"},
+			expectRemoved:  []string{"test-org/old-team/1"},
+		},
+		{
+			name:         "fail when team does not exist",
+			roleName:     "security-manager",
+			roleID:       1,
+			wantTeams:    []string{"non-existent-team"},
+			currentTeams: []github.OrganizationRoleAssignment{},
+			githubTeams: map[string]github.Team{
+				"valid-team": {ID: 20, Slug: "valid-team", Name: "Valid Team"},
+			},
+			expectAssigned: []string{},
+			expectRemoved:  []string{},
+			expectError:    true,
+		},
+		{
+			name:      "no changes needed",
+			roleName:  "security-manager",
+			roleID:    1,
+			wantTeams: []string{"existing-team"},
+			currentTeams: []github.OrganizationRoleAssignment{
+				{ID: 10, Slug: "existing-team", Type: "Team"},
+			},
+			githubTeams: map[string]github.Team{
+				"existing-team": {ID: 10, Slug: "existing-team", Name: "Existing Team"},
+			},
+			expectAssigned: []string{},
+			expectRemoved:  []string{},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			client := &fakeOrgRolesClient{
+				teamsWithRole: map[int][]github.OrganizationRoleAssignment{
+					tc.roleID: tc.currentTeams,
+				},
+				listTeamsWithRoleErr: tc.listTeamsErr,
+				assignTeamRoleErr:    tc.assignErr,
+				removeTeamRoleErr:    tc.removeErr,
+			}
+
+			err := configureRoleTeamAssignments(client, "test-org", tc.roleName, tc.roleID, tc.wantTeams, tc.githubTeams)
+
+			if tc.expectError && err == nil {
+				t.Error("Expected error but got none")
+			}
+			if !tc.expectError && err != nil {
+				t.Errorf("Unexpected error: %v", err)
+			}
+
+			// Compare slices with nil-safe comparison
+			if !slicesEqual(client.assignedTeamRoles, tc.expectAssigned) {
+				t.Errorf("Assigned teams mismatch:\nExpected: %v\nGot: %v", tc.expectAssigned, client.assignedTeamRoles)
+			}
+
+			if !slicesEqual(client.removedTeamRoles, tc.expectRemoved) {
+				t.Errorf("Removed teams mismatch:\nExpected: %v\nGot: %v", tc.expectRemoved, client.removedTeamRoles)
+			}
+		})
+	}
+}
+
+// Test configureRoleUserAssignments with username normalization
+func TestConfigureRoleUserAssignments(t *testing.T) {
+	tests := []struct {
+		name           string
+		roleName       string
+		roleID         int
+		wantUsers      []string
+		currentUsers   []github.OrganizationRoleAssignment
+		expectAssigned []string
+		expectRemoved  []string
+		listUsersErr   error
+		assignErr      error
+		removeErr      error
+		expectError    bool
+	}{
+		{
+			name:           "no users to configure",
+			roleName:       "security-manager",
+			roleID:         1,
+			wantUsers:      []string{},
+			currentUsers:   []github.OrganizationRoleAssignment{},
+			expectAssigned: []string{},
+			expectRemoved:  []string{},
+		},
+		{
+			name:           "add new user assignment",
+			roleName:       "security-manager",
+			roleID:         1,
+			wantUsers:      []string{"new-user"},
+			currentUsers:   []github.OrganizationRoleAssignment{},
+			expectAssigned: []string{"test-org/new-user/1"},
+			expectRemoved:  []string{},
+		},
+		{
+			name:      "remove user assignment",
+			roleName:  "security-manager",
+			roleID:    1,
+			wantUsers: []string{},
+			currentUsers: []github.OrganizationRoleAssignment{
+				{ID: 5, Login: "old-user", Type: "User"},
+			},
+			expectAssigned: []string{},
+			expectRemoved:  []string{"test-org/old-user/1"},
+		},
+		{
+			name:      "add and remove users",
+			roleName:  "security-manager",
+			roleID:    1,
+			wantUsers: []string{"new-user"},
+			currentUsers: []github.OrganizationRoleAssignment{
+				{ID: 5, Login: "old-user", Type: "User"},
+			},
+			expectAssigned: []string{"test-org/new-user/1"},
+			expectRemoved:  []string{"test-org/old-user/1"},
+		},
+		{
+			name:      "username normalization - case insensitive matching",
+			roleName:  "security-manager",
+			roleID:    1,
+			wantUsers: []string{"NewUser"},
+			currentUsers: []github.OrganizationRoleAssignment{
+				{ID: 5, Login: "newuser", Type: "User"},
+			},
+			expectAssigned: []string{},
+			expectRemoved:  []string{},
+		},
+		{
+			name:           "preserves original username casing when adding",
+			roleName:       "security-manager",
+			roleID:         1,
+			wantUsers:      []string{"NewUser", "AnotherUser"},
+			currentUsers:   []github.OrganizationRoleAssignment{},
+			expectAssigned: []string{"test-org/NewUser/1", "test-org/AnotherUser/1"},
+			expectRemoved:  []string{},
+		},
+		{
+			name:      "preserves original username casing when removing",
+			roleName:  "security-manager",
+			roleID:    1,
+			wantUsers: []string{},
+			currentUsers: []github.OrganizationRoleAssignment{
+				{ID: 5, Login: "OldUser", Type: "User"},
+				{ID: 6, Login: "AnotherOldUser", Type: "User"},
+			},
+			expectAssigned: []string{},
+			expectRemoved:  []string{"test-org/OldUser/1", "test-org/AnotherOldUser/1"},
+		},
+		{
+			name:      "no changes needed",
+			roleName:  "security-manager",
+			roleID:    1,
+			wantUsers: []string{"existing-user"},
+			currentUsers: []github.OrganizationRoleAssignment{
+				{ID: 5, Login: "existing-user", Type: "User"},
+			},
+			expectAssigned: []string{},
+			expectRemoved:  []string{},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			client := &fakeOrgRolesClient{
+				usersWithRole: map[int][]github.OrganizationRoleAssignment{
+					tc.roleID: tc.currentUsers,
+				},
+				listUsersWithRoleErr: tc.listUsersErr,
+				assignUserRoleErr:    tc.assignErr,
+				removeUserRoleErr:    tc.removeErr,
+			}
+			invitees := sets.Set[string]{}
+
+			err := configureRoleUserAssignments(client, "test-org", tc.roleName, tc.roleID, tc.wantUsers, invitees)
+
+			if tc.expectError && err == nil {
+				t.Error("Expected error but got none")
+			}
+			if !tc.expectError && err != nil {
+				t.Errorf("Unexpected error: %v", err)
+			}
+
+			// Compare slices with nil-safe comparison (sort first since order is non-deterministic)
+			sort.Strings(client.assignedUserRoles)
+			expectedAssigned := append([]string{}, tc.expectAssigned...)
+			sort.Strings(expectedAssigned)
+			if !slicesEqual(client.assignedUserRoles, expectedAssigned) {
+				t.Errorf("Assigned users mismatch:\nExpected: %v\nGot: %v", expectedAssigned, client.assignedUserRoles)
+			}
+
+			sort.Strings(client.removedUserRoles)
+			expectedRemoved := append([]string{}, tc.expectRemoved...)
+			sort.Strings(expectedRemoved)
+			if !slicesEqual(client.removedUserRoles, expectedRemoved) {
+				t.Errorf("Removed users mismatch:\nExpected: %v\nGot: %v", expectedRemoved, client.removedUserRoles)
+			}
+		})
+	}
+}
+
+// Test that users with pending org invitations are skipped for role assignment
+func TestConfigureRoleUserAssignmentsSkipsPendingInvitees(t *testing.T) {
+	client := &fakeOrgRolesClient{
+		usersWithRole: map[int][]github.OrganizationRoleAssignment{
+			1: {}, // No current assignments
+		},
+	}
+
+	// User has a pending invitation to the org
+	invitees := sets.New[string]("pending-user")
+
+	err := configureRoleUserAssignments(client, "test-org", "security-manager", 1, []string{"pending-user", "existing-user"}, invitees)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+
+	// Verify only the non-pending user was assigned
+	if len(client.assignedUserRoles) != 1 {
+		t.Errorf("Expected 1 user role assignment, got %d: %v", len(client.assignedUserRoles), client.assignedUserRoles)
+	}
+
+	// The pending user should NOT have been assigned
+	for _, assignment := range client.assignedUserRoles {
+		if strings.Contains(assignment, "pending-user") {
+			t.Errorf("User with pending invitation should not have been assigned a role: %v", client.assignedUserRoles)
+		}
+	}
+
+	// The existing user SHOULD have been assigned
+	foundExistingUser := false
+	for _, assignment := range client.assignedUserRoles {
+		if strings.Contains(assignment, "existing-user") {
+			foundExistingUser = true
+		}
+	}
+	if !foundExistingUser {
+		t.Errorf("Expected existing-user to be assigned, got: %v", client.assignedUserRoles)
+	}
+}
+
+// slicesEqual compares two string slices treating nil and empty slices as equal
+func slicesEqual(a, b []string) bool {
+	if len(a) == 0 && len(b) == 0 {
+		return true
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }

--- a/cmd/peribolos/main_test.go
+++ b/cmd/peribolos/main_test.go
@@ -24,6 +24,7 @@ import (
 	"reflect"
 	"slices"
 	"sort"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -108,6 +109,10 @@ func TestOptions(t *testing.T) {
 		{
 			name: "reject --fix-team-members without --fix-teams",
 			args: []string{"--config-path=foo", "--fix-team-members"},
+		},
+		{
+			name: "reject --fix-org-roles without --fix-teams",
+			args: []string{"--config-path=foo", "--fix-org-roles"},
 		},
 		{
 			name: "allow dump without config",
@@ -1950,6 +1955,9 @@ func TestDumpOrgConfig(t *testing.T) {
 		maintainers           map[string][]string
 		repoPermissions       map[string][]github.Repo
 		repos                 []github.FullRepo
+		roles                 []github.OrganizationRole
+		teamsWithRole         map[int][]github.OrganizationRoleAssignment
+		usersWithRole         map[int][]github.OrganizationRoleAssignment
 		expected              org.Config
 		err                   bool
 	}{
@@ -2335,6 +2343,55 @@ func TestDumpOrgConfig(t *testing.T) {
 				Repos:   map[string]org.Repo{},
 			},
 		},
+		{
+			name: "dump organization with roles",
+			meta: github.Organization{
+				Name:                        "Hello",
+				DefaultRepositoryPermission: "write",
+			},
+			members: []string{"user1", "user2"},
+			admins:  []string{"admin"},
+			roles: []github.OrganizationRole{
+				{ID: 1, Name: "security-manager"},
+				{ID: 2, Name: "billing-manager"},
+			},
+			teamsWithRole: map[int][]github.OrganizationRoleAssignment{
+				1: {{ID: 1, Slug: "security-team", Type: "Team"}},
+				2: {{ID: 2, Slug: "finance-team", Type: "Team"}},
+			},
+			usersWithRole: map[int][]github.OrganizationRoleAssignment{
+				1: {{ID: 3, Login: "security-admin", Type: "User"}},
+				2: {{ID: 4, Login: "finance-admin", Type: "User"}},
+			},
+			expected: org.Config{
+				Metadata: org.Metadata{
+					Name:                         &hello,
+					BillingEmail:                 &empty,
+					Company:                      &empty,
+					Email:                        &empty,
+					Description:                  &empty,
+					Location:                     &empty,
+					HasOrganizationProjects:      &no,
+					HasRepositoryProjects:        &no,
+					DefaultRepositoryPermission:  &perm,
+					MembersCanCreateRepositories: &no,
+				},
+				Members: []string{"user1", "user2"},
+				Admins:  []string{"admin"},
+				Teams:   map[string]org.Team{},
+				Repos:   map[string]org.Repo{},
+				Roles: map[string]org.Role{
+					"security-manager": {
+						Teams: []string{"security-team"},
+						Users: []string{"security-admin"},
+					},
+					"billing-manager": {
+						Teams: []string{"finance-team"},
+						Users: []string{"finance-admin"},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tc := range cases {
@@ -2353,6 +2410,9 @@ func TestDumpOrgConfig(t *testing.T) {
 				maintainers:     tc.maintainers,
 				repoPermissions: tc.repoPermissions,
 				repos:           tc.repos,
+				roles:           tc.roles,
+				teamsWithRole:   tc.teamsWithRole,
+				usersWithRole:   tc.usersWithRole,
 			}
 			actual, err := dumpOrgConfig(fc, orgName, tc.ignoreSecretTeams, tc.ignoreEnterpriseTeams, "")
 			switch {
@@ -2384,6 +2444,9 @@ type fakeDumpClient struct {
 	maintainers     map[string][]string
 	repoPermissions map[string][]github.Repo
 	repos           []github.FullRepo
+	roles           []github.OrganizationRole
+	teamsWithRole   map[int][]github.OrganizationRoleAssignment
+	usersWithRole   map[int][]github.OrganizationRoleAssignment
 }
 
 func (c fakeDumpClient) GetOrg(name string) (*github.Organization, error) {
@@ -2505,6 +2568,27 @@ func (c fakeDumpClient) ListRepoInvitations(org, repo string) ([]github.Collabor
 	return []github.CollaboratorRepoInvitation{}, nil
 }
 
+func (c fakeDumpClient) ListOrganizationRoles(org string) ([]github.OrganizationRole, error) {
+	if org != c.name {
+		return nil, fmt.Errorf("bad org: %s", org)
+	}
+	return c.roles, nil
+}
+
+func (c fakeDumpClient) ListTeamsWithRole(org string, roleID int) ([]github.OrganizationRoleAssignment, error) {
+	if org != c.name {
+		return nil, fmt.Errorf("bad org: %s", org)
+	}
+	return c.teamsWithRole[roleID], nil
+}
+
+func (c fakeDumpClient) ListUsersWithRole(org string, roleID int) ([]github.OrganizationRoleAssignment, error) {
+	if org != c.name {
+		return nil, fmt.Errorf("bad org: %s", org)
+	}
+	return c.usersWithRole[roleID], nil
+}
+
 func fixup(ret *org.Config) {
 	if ret == nil {
 		return
@@ -2516,6 +2600,11 @@ func fixup(ret *org.Config) {
 		sort.Strings(team.Maintainers)
 		sort.Strings(team.Previously)
 		ret.Teams[name] = team
+	}
+	for name, role := range ret.Roles {
+		sort.Strings(role.Teams)
+		sort.Strings(role.Users)
+		ret.Roles[name] = role
 	}
 }
 
@@ -4416,4 +4505,684 @@ func TestConfigureCollaborators_PermissionMatrix_PendingInvitationUpdates(t *tes
 			})
 		}
 	}
+}
+
+// Test organization roles functionality - comprehensive tests
+func TestOrganizationRoles(t *testing.T) {
+	// Test that the functions exist and can be called
+	// This ensures the functions compile and have correct signatures
+	t.Log("Organization roles functions exist and compile correctly")
+
+	// Test basic config structures
+	t.Run("role config structure", func(t *testing.T) {
+		// Test org.Role structure
+		role := org.Role{
+			Teams: []string{"team1", "team2"},
+			Users: []string{"user1", "user2"},
+		}
+
+		if len(role.Teams) != 2 {
+			t.Errorf("Expected 2 teams, got %d", len(role.Teams))
+		}
+		if len(role.Users) != 2 {
+			t.Errorf("Expected 2 users, got %d", len(role.Users))
+		}
+
+		// Test org.Config with roles
+		config := org.Config{
+			Roles: map[string]org.Role{
+				"security-manager": role,
+			},
+		}
+
+		if len(config.Roles) != 1 {
+			t.Errorf("Expected 1 role, got %d", len(config.Roles))
+		}
+
+		secRole, exists := config.Roles["security-manager"]
+		if !exists {
+			t.Error("security-manager role should exist")
+		}
+		if len(secRole.Teams) != 2 {
+			t.Errorf("Expected 2 teams in security-manager role, got %d", len(secRole.Teams))
+		}
+	})
+}
+
+// Test organization roles fail-fast scenarios
+func TestOrganizationRolesFailFast(t *testing.T) {
+	t.Run("validate role assignments correctly handle missing entities", func(t *testing.T) {
+		// Test role mapping logic
+		roleMap := map[string]int{
+			"existing-role": 1,
+		}
+
+		// This would fail - role doesn't exist
+		if roleID, exists := roleMap["non-existent-role"]; exists {
+			t.Errorf("Expected role 'non-existent-role' to not exist, but got ID %d", roleID)
+		}
+
+		// This would succeed - role exists
+		if _, exists := roleMap["existing-role"]; !exists {
+			t.Error("Expected role 'existing-role' to exist")
+		}
+
+		// Test team validation logic
+		githubTeams := map[string]github.Team{
+			"existing-team": {ID: 1, Slug: "existing-team", Name: "Existing Team"},
+		}
+
+		// This would fail - team doesn't exist
+		if _, exists := githubTeams["non-existent-team"]; exists {
+			t.Error("Expected team 'non-existent-team' to not exist")
+		}
+
+		// This would succeed - team exists
+		if _, exists := githubTeams["existing-team"]; !exists {
+			t.Error("Expected team 'existing-team' to exist")
+		}
+	})
+
+	t.Run("error messages contain expected information", func(t *testing.T) {
+		// Test that our error messages contain the expected information
+		testCases := []struct {
+			name             string
+			errorMsg         string
+			expectedContains []string
+		}{
+			{
+				name:             "role not found error",
+				errorMsg:         "role non-existent-role does not exist in organization test-org - check your configuration",
+				expectedContains: []string{"role", "non-existent-role", "does not exist", "organization", "test-org"},
+			},
+			{
+				name:             "team not found error",
+				errorMsg:         "team non-existent-team not found in organization test-org, cannot assign role security-manager - check your team configuration",
+				expectedContains: []string{"team", "non-existent-team", "not found", "organization", "test-org", "security-manager"},
+			},
+			{
+				name:             "user not org member error",
+				errorMsg:         "all users with role assignments must be org members: alice, bob",
+				expectedContains: []string{"users with role assignments", "must be org members", "alice", "bob"},
+			},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				for _, expected := range tc.expectedContains {
+					if !strings.Contains(tc.errorMsg, expected) {
+						t.Errorf("Expected error message to contain '%s', but message was: %s", expected, tc.errorMsg)
+					}
+				}
+			})
+		}
+	})
+
+	// Note: User/team reference validation is tested in pkg/config/org/org_test.go (TestValidateRoles)
+	// The validation happens at the start of configureOrg(), before any API calls are made
+
+	t.Run("fails when configured role does not exist in GitHub", func(t *testing.T) {
+		orgConfig := org.Config{
+			Admins: []string{"admin-user"},
+			Roles: map[string]org.Role{
+				"non-existent-role": {
+					Users: []string{"admin-user"},
+				},
+			},
+		}
+
+		client := &fakeOrgRolesClient{
+			roles: []github.OrganizationRole{
+				{ID: 1, Name: "other-role"},
+			},
+		}
+
+		githubTeams := map[string]github.Team{}
+		invitees := sets.Set[string]{}
+
+		err := configureOrgRoles(client, "test-org", orgConfig, githubTeams, invitees)
+		if err == nil {
+			t.Error("Expected error for non-existent role, but got none")
+		}
+		if !strings.Contains(err.Error(), "does not exist") {
+			t.Errorf("Expected error about role not existing, got: %v", err)
+		}
+		if !strings.Contains(err.Error(), "non-existent-role") {
+			t.Errorf("Expected error to mention the role name, got: %v", err)
+		}
+	})
+
+	t.Run("role name matching is case-insensitive", func(t *testing.T) {
+		orgConfig := org.Config{
+			Admins: []string{"admin-user"},
+			Roles: map[string]org.Role{
+				"Security-Manager": { // Different casing than what's in GitHub
+					Users: []string{"admin-user"},
+				},
+			},
+		}
+
+		client := &fakeOrgRolesClient{
+			roles: []github.OrganizationRole{
+				{ID: 1, Name: "security-manager"}, // Lowercase in GitHub
+			},
+			usersWithRole: map[int][]github.OrganizationRoleAssignment{
+				1: {}, // No current assignments
+			},
+		}
+
+		githubTeams := map[string]github.Team{}
+		invitees := sets.Set[string]{}
+
+		err := configureOrgRoles(client, "test-org", orgConfig, githubTeams, invitees)
+		if err != nil {
+			t.Errorf("Expected case-insensitive role matching to succeed, got error: %v", err)
+		}
+
+		// Verify the role was assigned
+		if len(client.assignedUserRoles) != 1 {
+			t.Errorf("Expected 1 user role assignment, got %d", len(client.assignedUserRoles))
+		}
+	})
+
+	t.Run("removes assignments for roles not in config", func(t *testing.T) {
+		// Config has NO roles - but GitHub has a role with assignments
+		orgConfig := org.Config{
+			Admins: []string{"admin-user"},
+			Roles:  map[string]org.Role{}, // Empty - no roles configured
+		}
+
+		client := &fakeOrgRolesClient{
+			roles: []github.OrganizationRole{
+				{ID: 1, Name: "security-manager"},
+			},
+			teamsWithRole: map[int][]github.OrganizationRoleAssignment{
+				1: {{ID: 10, Slug: "old-team", Type: "Team"}}, // Existing team assignment
+			},
+			usersWithRole: map[int][]github.OrganizationRoleAssignment{
+				1: {{ID: 5, Login: "old-user", Type: "User"}}, // Existing user assignment
+			},
+		}
+
+		githubTeams := map[string]github.Team{}
+		invitees := sets.Set[string]{}
+
+		err := configureOrgRoles(client, "test-org", orgConfig, githubTeams, invitees)
+		if err != nil {
+			t.Errorf("Unexpected error: %v", err)
+		}
+
+		// Verify the orphaned assignments were removed
+		if len(client.removedTeamRoles) != 1 {
+			t.Errorf("Expected 1 team role removal, got %d: %v", len(client.removedTeamRoles), client.removedTeamRoles)
+		}
+		if len(client.removedUserRoles) != 1 {
+			t.Errorf("Expected 1 user role removal, got %d: %v", len(client.removedUserRoles), client.removedUserRoles)
+		}
+
+		// Verify no new assignments were made
+		if len(client.assignedTeamRoles) != 0 {
+			t.Errorf("Expected no team assignments, got %d: %v", len(client.assignedTeamRoles), client.assignedTeamRoles)
+		}
+		if len(client.assignedUserRoles) != 0 {
+			t.Errorf("Expected no user assignments, got %d: %v", len(client.assignedUserRoles), client.assignedUserRoles)
+		}
+	})
+
+	t.Run("cleans up role when removed from config but keeps others", func(t *testing.T) {
+		// Config has only one role, but GitHub has two roles with assignments
+		orgConfig := org.Config{
+			Admins: []string{"admin-user"},
+			Roles: map[string]org.Role{
+				"billing-manager": {
+					Users: []string{"admin-user"}, // Keep this role
+				},
+			},
+		}
+
+		client := &fakeOrgRolesClient{
+			roles: []github.OrganizationRole{
+				{ID: 1, Name: "security-manager"}, // Not in config - should be cleaned up
+				{ID: 2, Name: "billing-manager"},  // In config - should be synced
+			},
+			teamsWithRole: map[int][]github.OrganizationRoleAssignment{
+				1: {{ID: 10, Slug: "security-team", Type: "Team"}}, // Should be removed
+				2: {},                                              // No teams
+			},
+			usersWithRole: map[int][]github.OrganizationRoleAssignment{
+				1: {{ID: 5, Login: "security-admin", Type: "User"}}, // Should be removed
+				2: {},                                               // No users yet
+			},
+		}
+
+		githubTeams := map[string]github.Team{}
+		invitees := sets.Set[string]{}
+
+		err := configureOrgRoles(client, "test-org", orgConfig, githubTeams, invitees)
+		if err != nil {
+			t.Errorf("Unexpected error: %v", err)
+		}
+
+		// Verify security-manager assignments were removed (role ID 1)
+		foundSecurityTeamRemoval := false
+		foundSecurityUserRemoval := false
+		for _, removal := range client.removedTeamRoles {
+			if strings.Contains(removal, "/1") { // roleID 1
+				foundSecurityTeamRemoval = true
+			}
+		}
+		for _, removal := range client.removedUserRoles {
+			if strings.Contains(removal, "/1") { // roleID 1
+				foundSecurityUserRemoval = true
+			}
+		}
+		if !foundSecurityTeamRemoval {
+			t.Errorf("Expected security-manager team assignment to be removed, removals: %v", client.removedTeamRoles)
+		}
+		if !foundSecurityUserRemoval {
+			t.Errorf("Expected security-manager user assignment to be removed, removals: %v", client.removedUserRoles)
+		}
+
+		// Verify billing-manager was assigned (role ID 2)
+		foundBillingUserAssignment := false
+		for _, assignment := range client.assignedUserRoles {
+			if strings.Contains(assignment, "/2") { // roleID 2
+				foundBillingUserAssignment = true
+			}
+		}
+		if !foundBillingUserAssignment {
+			t.Errorf("Expected billing-manager user assignment, assignments: %v", client.assignedUserRoles)
+		}
+	})
+}
+
+// fakeOrgRolesClient is a mock client for testing organization roles functionality
+type fakeOrgRolesClient struct {
+	roles                    []github.OrganizationRole
+	teamsWithRole            map[int][]github.OrganizationRoleAssignment
+	usersWithRole            map[int][]github.OrganizationRoleAssignment
+	assignedTeamRoles        []string // Track calls: "org/team-slug/roleID"
+	removedTeamRoles         []string // Track calls: "org/team-slug/roleID"
+	assignedUserRoles        []string // Track calls: "org/user/roleID"
+	removedUserRoles         []string // Track calls: "org/user/roleID"
+	assignTeamRoleErr        error
+	removeTeamRoleErr        error
+	assignUserRoleErr        error
+	removeUserRoleErr        error
+	listOrganizationRolesErr error
+	listTeamsWithRoleErr     error
+	listUsersWithRoleErr     error
+}
+
+func (f *fakeOrgRolesClient) ListOrganizationRoles(org string) ([]github.OrganizationRole, error) {
+	if f.listOrganizationRolesErr != nil {
+		return nil, f.listOrganizationRolesErr
+	}
+	return f.roles, nil
+}
+
+func (f *fakeOrgRolesClient) AssignOrganizationRoleToTeam(org, teamSlug string, roleID int) error {
+	if f.assignTeamRoleErr != nil {
+		return f.assignTeamRoleErr
+	}
+	f.assignedTeamRoles = append(f.assignedTeamRoles, fmt.Sprintf("%s/%s/%d", org, teamSlug, roleID))
+	return nil
+}
+
+func (f *fakeOrgRolesClient) RemoveOrganizationRoleFromTeam(org, teamSlug string, roleID int) error {
+	if f.removeTeamRoleErr != nil {
+		return f.removeTeamRoleErr
+	}
+	f.removedTeamRoles = append(f.removedTeamRoles, fmt.Sprintf("%s/%s/%d", org, teamSlug, roleID))
+	return nil
+}
+
+func (f *fakeOrgRolesClient) AssignOrganizationRoleToUser(org, user string, roleID int) error {
+	if f.assignUserRoleErr != nil {
+		return f.assignUserRoleErr
+	}
+	f.assignedUserRoles = append(f.assignedUserRoles, fmt.Sprintf("%s/%s/%d", org, user, roleID))
+	return nil
+}
+
+func (f *fakeOrgRolesClient) RemoveOrganizationRoleFromUser(org, user string, roleID int) error {
+	if f.removeUserRoleErr != nil {
+		return f.removeUserRoleErr
+	}
+	f.removedUserRoles = append(f.removedUserRoles, fmt.Sprintf("%s/%s/%d", org, user, roleID))
+	return nil
+}
+
+func (f *fakeOrgRolesClient) ListTeamsWithRole(org string, roleID int) ([]github.OrganizationRoleAssignment, error) {
+	if f.listTeamsWithRoleErr != nil {
+		return nil, f.listTeamsWithRoleErr
+	}
+	return f.teamsWithRole[roleID], nil
+}
+
+func (f *fakeOrgRolesClient) ListUsersWithRole(org string, roleID int) ([]github.OrganizationRoleAssignment, error) {
+	if f.listUsersWithRoleErr != nil {
+		return nil, f.listUsersWithRoleErr
+	}
+	return f.usersWithRole[roleID], nil
+}
+
+// Test configureRoleTeamAssignments
+func TestConfigureRoleTeamAssignments(t *testing.T) {
+	tests := []struct {
+		name           string
+		roleName       string
+		roleID         int
+		wantTeams      []string
+		currentTeams   []github.OrganizationRoleAssignment
+		githubTeams    map[string]github.Team
+		expectAssigned []string
+		expectRemoved  []string
+		listTeamsErr   error
+		assignErr      error
+		removeErr      error
+		expectError    bool
+	}{
+		{
+			name:           "no teams to configure",
+			roleName:       "security-manager",
+			roleID:         1,
+			wantTeams:      []string{},
+			currentTeams:   []github.OrganizationRoleAssignment{},
+			githubTeams:    map[string]github.Team{},
+			expectAssigned: []string{},
+			expectRemoved:  []string{},
+		},
+		{
+			name:         "add new team assignment",
+			roleName:     "security-manager",
+			roleID:       1,
+			wantTeams:    []string{"security-team"},
+			currentTeams: []github.OrganizationRoleAssignment{},
+			githubTeams: map[string]github.Team{
+				"security-team": {ID: 10, Slug: "security-team", Name: "Security Team"},
+			},
+			expectAssigned: []string{"test-org/security-team/1"},
+			expectRemoved:  []string{},
+		},
+		{
+			name:      "remove team assignment",
+			roleName:  "security-manager",
+			roleID:    1,
+			wantTeams: []string{},
+			currentTeams: []github.OrganizationRoleAssignment{
+				{ID: 10, Slug: "old-team", Type: "Team"},
+			},
+			githubTeams:    map[string]github.Team{},
+			expectAssigned: []string{},
+			expectRemoved:  []string{"test-org/old-team/1"},
+		},
+		{
+			name:      "add and remove teams",
+			roleName:  "security-manager",
+			roleID:    1,
+			wantTeams: []string{"new-team"},
+			currentTeams: []github.OrganizationRoleAssignment{
+				{ID: 10, Slug: "old-team", Type: "Team"},
+			},
+			githubTeams: map[string]github.Team{
+				"new-team": {ID: 20, Slug: "new-team", Name: "New Team"},
+			},
+			expectAssigned: []string{"test-org/new-team/1"},
+			expectRemoved:  []string{"test-org/old-team/1"},
+		},
+		{
+			name:         "fail when team does not exist",
+			roleName:     "security-manager",
+			roleID:       1,
+			wantTeams:    []string{"non-existent-team"},
+			currentTeams: []github.OrganizationRoleAssignment{},
+			githubTeams: map[string]github.Team{
+				"valid-team": {ID: 20, Slug: "valid-team", Name: "Valid Team"},
+			},
+			expectAssigned: []string{},
+			expectRemoved:  []string{},
+			expectError:    true,
+		},
+		{
+			name:      "no changes needed",
+			roleName:  "security-manager",
+			roleID:    1,
+			wantTeams: []string{"existing-team"},
+			currentTeams: []github.OrganizationRoleAssignment{
+				{ID: 10, Slug: "existing-team", Type: "Team"},
+			},
+			githubTeams: map[string]github.Team{
+				"existing-team": {ID: 10, Slug: "existing-team", Name: "Existing Team"},
+			},
+			expectAssigned: []string{},
+			expectRemoved:  []string{},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			client := &fakeOrgRolesClient{
+				teamsWithRole: map[int][]github.OrganizationRoleAssignment{
+					tc.roleID: tc.currentTeams,
+				},
+				listTeamsWithRoleErr: tc.listTeamsErr,
+				assignTeamRoleErr:    tc.assignErr,
+				removeTeamRoleErr:    tc.removeErr,
+			}
+
+			err := configureRoleTeamAssignments(client, "test-org", tc.roleName, tc.roleID, tc.wantTeams, tc.githubTeams)
+
+			if tc.expectError && err == nil {
+				t.Error("Expected error but got none")
+			}
+			if !tc.expectError && err != nil {
+				t.Errorf("Unexpected error: %v", err)
+			}
+
+			// Compare slices with nil-safe comparison
+			if !slicesEqual(client.assignedTeamRoles, tc.expectAssigned) {
+				t.Errorf("Assigned teams mismatch:\nExpected: %v\nGot: %v", tc.expectAssigned, client.assignedTeamRoles)
+			}
+
+			if !slicesEqual(client.removedTeamRoles, tc.expectRemoved) {
+				t.Errorf("Removed teams mismatch:\nExpected: %v\nGot: %v", tc.expectRemoved, client.removedTeamRoles)
+			}
+		})
+	}
+}
+
+// Test configureRoleUserAssignments with username normalization
+func TestConfigureRoleUserAssignments(t *testing.T) {
+	tests := []struct {
+		name           string
+		roleName       string
+		roleID         int
+		wantUsers      []string
+		currentUsers   []github.OrganizationRoleAssignment
+		expectAssigned []string
+		expectRemoved  []string
+		listUsersErr   error
+		assignErr      error
+		removeErr      error
+		expectError    bool
+	}{
+		{
+			name:           "no users to configure",
+			roleName:       "security-manager",
+			roleID:         1,
+			wantUsers:      []string{},
+			currentUsers:   []github.OrganizationRoleAssignment{},
+			expectAssigned: []string{},
+			expectRemoved:  []string{},
+		},
+		{
+			name:           "add new user assignment",
+			roleName:       "security-manager",
+			roleID:         1,
+			wantUsers:      []string{"new-user"},
+			currentUsers:   []github.OrganizationRoleAssignment{},
+			expectAssigned: []string{"test-org/new-user/1"},
+			expectRemoved:  []string{},
+		},
+		{
+			name:      "remove user assignment",
+			roleName:  "security-manager",
+			roleID:    1,
+			wantUsers: []string{},
+			currentUsers: []github.OrganizationRoleAssignment{
+				{ID: 5, Login: "old-user", Type: "User"},
+			},
+			expectAssigned: []string{},
+			expectRemoved:  []string{"test-org/old-user/1"},
+		},
+		{
+			name:      "add and remove users",
+			roleName:  "security-manager",
+			roleID:    1,
+			wantUsers: []string{"new-user"},
+			currentUsers: []github.OrganizationRoleAssignment{
+				{ID: 5, Login: "old-user", Type: "User"},
+			},
+			expectAssigned: []string{"test-org/new-user/1"},
+			expectRemoved:  []string{"test-org/old-user/1"},
+		},
+		{
+			name:      "username normalization - case insensitive matching",
+			roleName:  "security-manager",
+			roleID:    1,
+			wantUsers: []string{"NewUser"},
+			currentUsers: []github.OrganizationRoleAssignment{
+				{ID: 5, Login: "newuser", Type: "User"},
+			},
+			expectAssigned: []string{},
+			expectRemoved:  []string{},
+		},
+		{
+			name:           "preserves original username casing when adding",
+			roleName:       "security-manager",
+			roleID:         1,
+			wantUsers:      []string{"NewUser", "AnotherUser"},
+			currentUsers:   []github.OrganizationRoleAssignment{},
+			expectAssigned: []string{"test-org/NewUser/1", "test-org/AnotherUser/1"},
+			expectRemoved:  []string{},
+		},
+		{
+			name:      "preserves original username casing when removing",
+			roleName:  "security-manager",
+			roleID:    1,
+			wantUsers: []string{},
+			currentUsers: []github.OrganizationRoleAssignment{
+				{ID: 5, Login: "OldUser", Type: "User"},
+				{ID: 6, Login: "AnotherOldUser", Type: "User"},
+			},
+			expectAssigned: []string{},
+			expectRemoved:  []string{"test-org/OldUser/1", "test-org/AnotherOldUser/1"},
+		},
+		{
+			name:      "no changes needed",
+			roleName:  "security-manager",
+			roleID:    1,
+			wantUsers: []string{"existing-user"},
+			currentUsers: []github.OrganizationRoleAssignment{
+				{ID: 5, Login: "existing-user", Type: "User"},
+			},
+			expectAssigned: []string{},
+			expectRemoved:  []string{},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			client := &fakeOrgRolesClient{
+				usersWithRole: map[int][]github.OrganizationRoleAssignment{
+					tc.roleID: tc.currentUsers,
+				},
+				listUsersWithRoleErr: tc.listUsersErr,
+				assignUserRoleErr:    tc.assignErr,
+				removeUserRoleErr:    tc.removeErr,
+			}
+			invitees := sets.Set[string]{}
+
+			err := configureRoleUserAssignments(client, "test-org", tc.roleName, tc.roleID, tc.wantUsers, invitees)
+
+			if tc.expectError && err == nil {
+				t.Error("Expected error but got none")
+			}
+			if !tc.expectError && err != nil {
+				t.Errorf("Unexpected error: %v", err)
+			}
+
+			// Compare slices with nil-safe comparison (sort first since order is non-deterministic)
+			sort.Strings(client.assignedUserRoles)
+			expectedAssigned := append([]string{}, tc.expectAssigned...)
+			sort.Strings(expectedAssigned)
+			if !slicesEqual(client.assignedUserRoles, expectedAssigned) {
+				t.Errorf("Assigned users mismatch:\nExpected: %v\nGot: %v", expectedAssigned, client.assignedUserRoles)
+			}
+
+			sort.Strings(client.removedUserRoles)
+			expectedRemoved := append([]string{}, tc.expectRemoved...)
+			sort.Strings(expectedRemoved)
+			if !slicesEqual(client.removedUserRoles, expectedRemoved) {
+				t.Errorf("Removed users mismatch:\nExpected: %v\nGot: %v", expectedRemoved, client.removedUserRoles)
+			}
+		})
+	}
+}
+
+// Test that users with pending org invitations are skipped for role assignment
+func TestConfigureRoleUserAssignmentsSkipsPendingInvitees(t *testing.T) {
+	client := &fakeOrgRolesClient{
+		usersWithRole: map[int][]github.OrganizationRoleAssignment{
+			1: {}, // No current assignments
+		},
+	}
+
+	// User has a pending invitation to the org
+	invitees := sets.New[string]("pending-user")
+
+	err := configureRoleUserAssignments(client, "test-org", "security-manager", 1, []string{"pending-user", "existing-user"}, invitees)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+
+	// Verify only the non-pending user was assigned
+	if len(client.assignedUserRoles) != 1 {
+		t.Errorf("Expected 1 user role assignment, got %d: %v", len(client.assignedUserRoles), client.assignedUserRoles)
+	}
+
+	// The pending user should NOT have been assigned
+	for _, assignment := range client.assignedUserRoles {
+		if strings.Contains(assignment, "pending-user") {
+			t.Errorf("User with pending invitation should not have been assigned a role: %v", client.assignedUserRoles)
+		}
+	}
+
+	// The existing user SHOULD have been assigned
+	foundExistingUser := false
+	for _, assignment := range client.assignedUserRoles {
+		if strings.Contains(assignment, "existing-user") {
+			foundExistingUser = true
+		}
+	}
+	if !foundExistingUser {
+		t.Errorf("Expected existing-user to be assigned, got: %v", client.assignedUserRoles)
+	}
+}
+
+// slicesEqual compares two string slices treating nil and empty slices as equal
+func slicesEqual(a, b []string) bool {
+	if len(a) == 0 && len(b) == 0 {
+		return true
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }

--- a/cmd/peribolos/main_test.go
+++ b/cmd/peribolos/main_test.go
@@ -2356,12 +2356,12 @@ func TestDumpOrgConfig(t *testing.T) {
 				{ID: 2, Name: "billing-manager"},
 			},
 			teamsWithRole: map[int][]github.OrganizationRoleAssignment{
-				1: {{ID: 1, Slug: "security-team", Type: "Team"}},
-				2: {{ID: 2, Slug: "finance-team", Type: "Team"}},
+				1: {{ID: 1, Slug: "security-team"}},
+				2: {{ID: 2, Slug: "finance-team"}},
 			},
 			usersWithRole: map[int][]github.OrganizationRoleAssignment{
-				1: {{ID: 3, Login: "security-admin", Type: "User"}},
-				2: {{ID: 4, Login: "finance-admin", Type: "User"}},
+				1: {{ID: 3, Login: "security-admin"}},
+				2: {{ID: 4, Login: "finance-admin"}},
 			},
 			expected: org.Config{
 				Metadata: org.Metadata{
@@ -4507,120 +4507,8 @@ func TestConfigureCollaborators_PermissionMatrix_PendingInvitationUpdates(t *tes
 	}
 }
 
-// Test organization roles functionality - comprehensive tests
-func TestOrganizationRoles(t *testing.T) {
-	// Test that the functions exist and can be called
-	// This ensures the functions compile and have correct signatures
-	t.Log("Organization roles functions exist and compile correctly")
-
-	// Test basic config structures
-	t.Run("role config structure", func(t *testing.T) {
-		// Test org.Role structure
-		role := org.Role{
-			Teams: []string{"team1", "team2"},
-			Users: []string{"user1", "user2"},
-		}
-
-		if len(role.Teams) != 2 {
-			t.Errorf("Expected 2 teams, got %d", len(role.Teams))
-		}
-		if len(role.Users) != 2 {
-			t.Errorf("Expected 2 users, got %d", len(role.Users))
-		}
-
-		// Test org.Config with roles
-		config := org.Config{
-			Roles: map[string]org.Role{
-				"security-manager": role,
-			},
-		}
-
-		if len(config.Roles) != 1 {
-			t.Errorf("Expected 1 role, got %d", len(config.Roles))
-		}
-
-		secRole, exists := config.Roles["security-manager"]
-		if !exists {
-			t.Error("security-manager role should exist")
-		}
-		if len(secRole.Teams) != 2 {
-			t.Errorf("Expected 2 teams in security-manager role, got %d", len(secRole.Teams))
-		}
-	})
-}
-
-// Test organization roles fail-fast scenarios
-func TestOrganizationRolesFailFast(t *testing.T) {
-	t.Run("validate role assignments correctly handle missing entities", func(t *testing.T) {
-		// Test role mapping logic
-		roleMap := map[string]int{
-			"existing-role": 1,
-		}
-
-		// This would fail - role doesn't exist
-		if roleID, exists := roleMap["non-existent-role"]; exists {
-			t.Errorf("Expected role 'non-existent-role' to not exist, but got ID %d", roleID)
-		}
-
-		// This would succeed - role exists
-		if _, exists := roleMap["existing-role"]; !exists {
-			t.Error("Expected role 'existing-role' to exist")
-		}
-
-		// Test team validation logic
-		githubTeams := map[string]github.Team{
-			"existing-team": {ID: 1, Slug: "existing-team", Name: "Existing Team"},
-		}
-
-		// This would fail - team doesn't exist
-		if _, exists := githubTeams["non-existent-team"]; exists {
-			t.Error("Expected team 'non-existent-team' to not exist")
-		}
-
-		// This would succeed - team exists
-		if _, exists := githubTeams["existing-team"]; !exists {
-			t.Error("Expected team 'existing-team' to exist")
-		}
-	})
-
-	t.Run("error messages contain expected information", func(t *testing.T) {
-		// Test that our error messages contain the expected information
-		testCases := []struct {
-			name             string
-			errorMsg         string
-			expectedContains []string
-		}{
-			{
-				name:             "role not found error",
-				errorMsg:         "role non-existent-role does not exist in organization test-org - check your configuration",
-				expectedContains: []string{"role", "non-existent-role", "does not exist", "organization", "test-org"},
-			},
-			{
-				name:             "team not found error",
-				errorMsg:         "team non-existent-team not found in organization test-org, cannot assign role security-manager - check your team configuration",
-				expectedContains: []string{"team", "non-existent-team", "not found", "organization", "test-org", "security-manager"},
-			},
-			{
-				name:             "user not org member error",
-				errorMsg:         "all users with role assignments must be org members: alice, bob",
-				expectedContains: []string{"users with role assignments", "must be org members", "alice", "bob"},
-			},
-		}
-
-		for _, tc := range testCases {
-			t.Run(tc.name, func(t *testing.T) {
-				for _, expected := range tc.expectedContains {
-					if !strings.Contains(tc.errorMsg, expected) {
-						t.Errorf("Expected error message to contain '%s', but message was: %s", expected, tc.errorMsg)
-					}
-				}
-			})
-		}
-	})
-
-	// Note: User/team reference validation is tested in pkg/config/org/org_test.go (TestValidateRoles)
-	// The validation happens at the start of configureOrg(), before any API calls are made
-
+// Test configureOrgRoles scenarios
+func TestConfigureOrgRoles(t *testing.T) {
 	t.Run("fails when configured role does not exist in GitHub", func(t *testing.T) {
 		orgConfig := org.Config{
 			Admins: []string{"admin-user"},
@@ -4697,10 +4585,10 @@ func TestOrganizationRolesFailFast(t *testing.T) {
 				{ID: 1, Name: "security-manager"},
 			},
 			teamsWithRole: map[int][]github.OrganizationRoleAssignment{
-				1: {{ID: 10, Slug: "old-team", Type: "Team"}}, // Existing team assignment
+				1: {{ID: 10, Slug: "old-team"}}, // Existing team assignment
 			},
 			usersWithRole: map[int][]github.OrganizationRoleAssignment{
-				1: {{ID: 5, Login: "old-user", Type: "User"}}, // Existing user assignment
+				1: {{ID: 5, Login: "old-user"}}, // Existing user assignment
 			},
 		}
 
@@ -4746,11 +4634,11 @@ func TestOrganizationRolesFailFast(t *testing.T) {
 				{ID: 2, Name: "billing-manager"},  // In config - should be synced
 			},
 			teamsWithRole: map[int][]github.OrganizationRoleAssignment{
-				1: {{ID: 10, Slug: "security-team", Type: "Team"}}, // Should be removed
+				1: {{ID: 10, Slug: "security-team"}}, // Should be removed
 				2: {},                                              // No teams
 			},
 			usersWithRole: map[int][]github.OrganizationRoleAssignment{
-				1: {{ID: 5, Login: "security-admin", Type: "User"}}, // Should be removed
+				1: {{ID: 5, Login: "security-admin"}}, // Should be removed
 				2: {},                                               // No users yet
 			},
 		}
@@ -4911,7 +4799,7 @@ func TestConfigureRoleTeamAssignments(t *testing.T) {
 			roleID:    1,
 			wantTeams: []string{},
 			currentTeams: []github.OrganizationRoleAssignment{
-				{ID: 10, Slug: "old-team", Type: "Team"},
+				{ID: 10, Slug: "old-team"},
 			},
 			githubTeams:    map[string]github.Team{},
 			expectAssigned: []string{},
@@ -4923,7 +4811,7 @@ func TestConfigureRoleTeamAssignments(t *testing.T) {
 			roleID:    1,
 			wantTeams: []string{"new-team"},
 			currentTeams: []github.OrganizationRoleAssignment{
-				{ID: 10, Slug: "old-team", Type: "Team"},
+				{ID: 10, Slug: "old-team"},
 			},
 			githubTeams: map[string]github.Team{
 				"new-team": {ID: 20, Slug: "new-team", Name: "New Team"},
@@ -4950,7 +4838,7 @@ func TestConfigureRoleTeamAssignments(t *testing.T) {
 			roleID:    1,
 			wantTeams: []string{"existing-team"},
 			currentTeams: []github.OrganizationRoleAssignment{
-				{ID: 10, Slug: "existing-team", Type: "Team"},
+				{ID: 10, Slug: "existing-team"},
 			},
 			githubTeams: map[string]github.Team{
 				"existing-team": {ID: 10, Slug: "existing-team", Name: "Existing Team"},
@@ -4981,11 +4869,11 @@ func TestConfigureRoleTeamAssignments(t *testing.T) {
 			}
 
 			// Compare slices with nil-safe comparison
-			if !slicesEqual(client.assignedTeamRoles, tc.expectAssigned) {
+			if !slicesEqualUnordered(client.assignedTeamRoles, tc.expectAssigned) {
 				t.Errorf("Assigned teams mismatch:\nExpected: %v\nGot: %v", tc.expectAssigned, client.assignedTeamRoles)
 			}
 
-			if !slicesEqual(client.removedTeamRoles, tc.expectRemoved) {
+			if !slicesEqualUnordered(client.removedTeamRoles, tc.expectRemoved) {
 				t.Errorf("Removed teams mismatch:\nExpected: %v\nGot: %v", tc.expectRemoved, client.removedTeamRoles)
 			}
 		})
@@ -5031,7 +4919,7 @@ func TestConfigureRoleUserAssignments(t *testing.T) {
 			roleID:    1,
 			wantUsers: []string{},
 			currentUsers: []github.OrganizationRoleAssignment{
-				{ID: 5, Login: "old-user", Type: "User"},
+				{ID: 5, Login: "old-user"},
 			},
 			expectAssigned: []string{},
 			expectRemoved:  []string{"test-org/old-user/1"},
@@ -5042,7 +4930,7 @@ func TestConfigureRoleUserAssignments(t *testing.T) {
 			roleID:    1,
 			wantUsers: []string{"new-user"},
 			currentUsers: []github.OrganizationRoleAssignment{
-				{ID: 5, Login: "old-user", Type: "User"},
+				{ID: 5, Login: "old-user"},
 			},
 			expectAssigned: []string{"test-org/new-user/1"},
 			expectRemoved:  []string{"test-org/old-user/1"},
@@ -5053,7 +4941,7 @@ func TestConfigureRoleUserAssignments(t *testing.T) {
 			roleID:    1,
 			wantUsers: []string{"NewUser"},
 			currentUsers: []github.OrganizationRoleAssignment{
-				{ID: 5, Login: "newuser", Type: "User"},
+				{ID: 5, Login: "newuser"},
 			},
 			expectAssigned: []string{},
 			expectRemoved:  []string{},
@@ -5073,8 +4961,8 @@ func TestConfigureRoleUserAssignments(t *testing.T) {
 			roleID:    1,
 			wantUsers: []string{},
 			currentUsers: []github.OrganizationRoleAssignment{
-				{ID: 5, Login: "OldUser", Type: "User"},
-				{ID: 6, Login: "AnotherOldUser", Type: "User"},
+				{ID: 5, Login: "OldUser"},
+				{ID: 6, Login: "AnotherOldUser"},
 			},
 			expectAssigned: []string{},
 			expectRemoved:  []string{"test-org/OldUser/1", "test-org/AnotherOldUser/1"},
@@ -5085,7 +4973,7 @@ func TestConfigureRoleUserAssignments(t *testing.T) {
 			roleID:    1,
 			wantUsers: []string{"existing-user"},
 			currentUsers: []github.OrganizationRoleAssignment{
-				{ID: 5, Login: "existing-user", Type: "User"},
+				{ID: 5, Login: "existing-user"},
 			},
 			expectAssigned: []string{},
 			expectRemoved:  []string{},
@@ -5113,19 +5001,12 @@ func TestConfigureRoleUserAssignments(t *testing.T) {
 				t.Errorf("Unexpected error: %v", err)
 			}
 
-			// Compare slices with nil-safe comparison (sort first since order is non-deterministic)
-			sort.Strings(client.assignedUserRoles)
-			expectedAssigned := append([]string{}, tc.expectAssigned...)
-			sort.Strings(expectedAssigned)
-			if !slicesEqual(client.assignedUserRoles, expectedAssigned) {
-				t.Errorf("Assigned users mismatch:\nExpected: %v\nGot: %v", expectedAssigned, client.assignedUserRoles)
+			if !slicesEqualUnordered(client.assignedUserRoles, tc.expectAssigned) {
+				t.Errorf("Assigned users mismatch:\nExpected: %v\nGot: %v", tc.expectAssigned, client.assignedUserRoles)
 			}
 
-			sort.Strings(client.removedUserRoles)
-			expectedRemoved := append([]string{}, tc.expectRemoved...)
-			sort.Strings(expectedRemoved)
-			if !slicesEqual(client.removedUserRoles, expectedRemoved) {
-				t.Errorf("Removed users mismatch:\nExpected: %v\nGot: %v", expectedRemoved, client.removedUserRoles)
+			if !slicesEqualUnordered(client.removedUserRoles, tc.expectRemoved) {
+				t.Errorf("Removed users mismatch:\nExpected: %v\nGot: %v", tc.expectRemoved, client.removedUserRoles)
 			}
 		})
 	}
@@ -5171,18 +5052,152 @@ func TestConfigureRoleUserAssignmentsSkipsPendingInvitees(t *testing.T) {
 	}
 }
 
-// slicesEqual compares two string slices treating nil and empty slices as equal
-func slicesEqual(a, b []string) bool {
+// Test that indirect user assignments are skipped
+func TestConfigureRoleUserAssignmentsSkipsIndirect(t *testing.T) {
+	client := &fakeOrgRolesClient{
+		usersWithRole: map[int][]github.OrganizationRoleAssignment{
+			1: {
+				{ID: 1, Login: "direct-user", Assignment: "direct"},
+				{ID: 2, Login: "indirect-user", Assignment: "indirect"},
+				{ID: 3, Login: "mixed-user", Assignment: "mixed"},
+			},
+		},
+	}
+
+	// Config wants no users — only direct and mixed assignments should be removed
+	err := configureRoleUserAssignments(client, "test-org", "test-role", 1, []string{}, sets.Set[string]{})
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	if !slicesEqualUnordered(client.removedUserRoles, []string{"test-org/direct-user/1", "test-org/mixed-user/1"}) {
+		t.Errorf("Expected direct-user and mixed-user removed, got: %v", client.removedUserRoles)
+	}
+}
+
+// Test error propagation in team assignments
+func TestConfigureRoleTeamAssignmentsErrors(t *testing.T) {
+	t.Run("list teams error", func(t *testing.T) {
+		client := &fakeOrgRolesClient{
+			listTeamsWithRoleErr: fmt.Errorf("api error"),
+		}
+		err := configureRoleTeamAssignments(client, "test-org", "test-role", 1, []string{"team"}, map[string]github.Team{})
+		if err == nil {
+			t.Error("Expected error but got none")
+		}
+	})
+
+	t.Run("assign error", func(t *testing.T) {
+		client := &fakeOrgRolesClient{
+			teamsWithRole:     map[int][]github.OrganizationRoleAssignment{1: {}},
+			assignTeamRoleErr: fmt.Errorf("assign failed"),
+		}
+		githubTeams := map[string]github.Team{
+			"my-team": {ID: 1, Slug: "my-team"},
+		}
+		err := configureRoleTeamAssignments(client, "test-org", "test-role", 1, []string{"my-team"}, githubTeams)
+		if err == nil {
+			t.Error("Expected error but got none")
+		}
+	})
+
+	t.Run("remove error", func(t *testing.T) {
+		client := &fakeOrgRolesClient{
+			teamsWithRole: map[int][]github.OrganizationRoleAssignment{
+				1: {{ID: 1, Slug: "old-team"}},
+			},
+			removeTeamRoleErr: fmt.Errorf("remove failed"),
+		}
+		err := configureRoleTeamAssignments(client, "test-org", "test-role", 1, []string{}, map[string]github.Team{})
+		if err == nil {
+			t.Error("Expected error but got none")
+		}
+	})
+}
+
+// Test error propagation in user assignments
+func TestConfigureRoleUserAssignmentsErrors(t *testing.T) {
+	t.Run("list users error", func(t *testing.T) {
+		client := &fakeOrgRolesClient{
+			listUsersWithRoleErr: fmt.Errorf("api error"),
+		}
+		err := configureRoleUserAssignments(client, "test-org", "test-role", 1, []string{"user"}, sets.Set[string]{})
+		if err == nil {
+			t.Error("Expected error but got none")
+		}
+	})
+
+	t.Run("assign error", func(t *testing.T) {
+		client := &fakeOrgRolesClient{
+			usersWithRole:    map[int][]github.OrganizationRoleAssignment{1: {}},
+			assignUserRoleErr: fmt.Errorf("assign failed"),
+		}
+		err := configureRoleUserAssignments(client, "test-org", "test-role", 1, []string{"user"}, sets.Set[string]{})
+		if err == nil {
+			t.Error("Expected error but got none")
+		}
+	})
+
+	t.Run("remove error", func(t *testing.T) {
+		client := &fakeOrgRolesClient{
+			usersWithRole: map[int][]github.OrganizationRoleAssignment{
+				1: {{ID: 1, Login: "old-user"}},
+			},
+			removeUserRoleErr: fmt.Errorf("remove failed"),
+		}
+		err := configureRoleUserAssignments(client, "test-org", "test-role", 1, []string{}, sets.Set[string]{})
+		if err == nil {
+			t.Error("Expected error but got none")
+		}
+	})
+}
+
+// Test that configureOrgRoles validates roles before making mutations
+func TestConfigureOrgRolesValidatesBeforeMutating(t *testing.T) {
+	// Config references a role that doesn't exist AND a role that does
+	orgConfig := org.Config{
+		Admins: []string{"admin"},
+		Roles: map[string]org.Role{
+			"exists":     {Users: []string{"admin"}},
+			"not-exists": {Users: []string{"admin"}},
+		},
+	}
+
+	client := &fakeOrgRolesClient{
+		roles: []github.OrganizationRole{
+			{ID: 1, Name: "exists"},
+		},
+		usersWithRole: map[int][]github.OrganizationRoleAssignment{1: {}},
+	}
+
+	err := configureOrgRoles(client, "test-org", orgConfig, map[string]github.Team{}, sets.Set[string]{})
+	if err == nil {
+		t.Fatal("Expected error for non-existent role")
+	}
+	if !strings.Contains(err.Error(), "not-exists") {
+		t.Errorf("Expected error about 'not-exists', got: %v", err)
+	}
+
+	// Verify NO mutations were made (validation should have blocked them)
+	if len(client.assignedUserRoles) != 0 {
+		t.Errorf("Expected no mutations before validation, got assignments: %v", client.assignedUserRoles)
+	}
+	if len(client.assignedTeamRoles) != 0 {
+		t.Errorf("Expected no mutations before validation, got team assignments: %v", client.assignedTeamRoles)
+	}
+}
+
+// normalizeSlice returns a sorted copy of a string slice, treating nil as empty.
+func normalizeSlice(s []string) []string {
+	out := append([]string{}, s...)
+	sort.Strings(out)
+	return out
+}
+
+// slicesEqualUnordered compares two string slices ignoring order and treating nil as empty.
+func slicesEqualUnordered(a, b []string) bool {
 	if len(a) == 0 && len(b) == 0 {
 		return true
 	}
-	if len(a) != len(b) {
-		return false
-	}
-	for i := range a {
-		if a[i] != b[i] {
-			return false
-		}
-	}
-	return true
+	return slices.Equal(normalizeSlice(a), normalizeSlice(b))
 }

--- a/cmd/peribolos/main_test.go
+++ b/cmd/peribolos/main_test.go
@@ -2433,6 +2433,46 @@ func TestDumpOrgConfig(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:                  "role assignments exclude ignored enterprise teams",
+			ignoreEnterpriseTeams: true,
+			meta: github.Organization{
+				Name:                        "Hello",
+				DefaultRepositoryPermission: "write",
+			},
+			members: []string{"user1"},
+			admins:  []string{"admin"},
+			teams: []github.Team{
+				{ID: 1, Name: "Enterprise Team", Slug: "enterprise-team", Type: github.TeamTypeEnterprise},
+			},
+			roles: []github.OrganizationRole{
+				{ID: 1, Name: "security-manager"},
+			},
+			teamsWithRole: map[int][]github.OrganizationRoleAssignment{
+				// The only assignment is to an ignored enterprise team, so the role
+				// must not appear in the dump (rather than leaking the raw slug).
+				1: {{ID: 1, Slug: "enterprise-team"}},
+			},
+			usersWithRole: map[int][]github.OrganizationRoleAssignment{},
+			expected: org.Config{
+				Metadata: org.Metadata{
+					Name:                         &hello,
+					BillingEmail:                 &empty,
+					Company:                      &empty,
+					Email:                        &empty,
+					Description:                  &empty,
+					Location:                     &empty,
+					HasOrganizationProjects:      &no,
+					HasRepositoryProjects:        &no,
+					DefaultRepositoryPermission:  &perm,
+					MembersCanCreateRepositories: &no,
+				},
+				Members: []string{"user1"},
+				Admins:  []string{"admin"},
+				Teams:   map[string]org.Team{},
+				Repos:   map[string]org.Repo{},
+			},
+		},
 	}
 
 	for _, tc := range cases {
@@ -4614,8 +4654,10 @@ func TestConfigureOrgRoles(t *testing.T) {
 		}
 	})
 
-	t.Run("removes assignments for roles not in config", func(t *testing.T) {
-		// Config has NO roles - but GitHub has a role with assignments
+	t.Run("leaves assignments for roles not in config untouched", func(t *testing.T) {
+		// Config has NO roles - GitHub has a role with assignments. peribolos must
+		// not touch roles it was not asked to manage (including GitHub built-in
+		// predefined roles).
 		orgConfig := org.Config{
 			Admins: []string{"admin-user"},
 			Roles:  map[string]org.Role{}, // Empty - no roles configured
@@ -4641,15 +4683,13 @@ func TestConfigureOrgRoles(t *testing.T) {
 			t.Errorf("Unexpected error: %v", err)
 		}
 
-		// Verify the orphaned assignments were removed
-		if len(client.removedTeamRoles) != 1 {
-			t.Errorf("Expected 1 team role removal, got %d: %v", len(client.removedTeamRoles), client.removedTeamRoles)
+		// Nothing should be removed or assigned for roles absent from config.
+		if len(client.removedTeamRoles) != 0 {
+			t.Errorf("Expected no team role removals, got %d: %v", len(client.removedTeamRoles), client.removedTeamRoles)
 		}
-		if len(client.removedUserRoles) != 1 {
-			t.Errorf("Expected 1 user role removal, got %d: %v", len(client.removedUserRoles), client.removedUserRoles)
+		if len(client.removedUserRoles) != 0 {
+			t.Errorf("Expected no user role removals, got %d: %v", len(client.removedUserRoles), client.removedUserRoles)
 		}
-
-		// Verify no new assignments were made
 		if len(client.assignedTeamRoles) != 0 {
 			t.Errorf("Expected no team assignments, got %d: %v", len(client.assignedTeamRoles), client.assignedTeamRoles)
 		}
@@ -4658,29 +4698,31 @@ func TestConfigureOrgRoles(t *testing.T) {
 		}
 	})
 
-	t.Run("cleans up role when removed from config but keeps others", func(t *testing.T) {
-		// Config has only one role, but GitHub has two roles with assignments
+	t.Run("syncs configured roles and leaves unconfigured roles untouched", func(t *testing.T) {
+		// Config declares only billing-manager; GitHub has two roles. The
+		// unconfigured security-manager must be left entirely untouched, while
+		// billing-manager is synced to the desired state.
 		orgConfig := org.Config{
 			Admins: []string{"admin-user"},
 			Roles: map[string]org.Role{
 				"billing-manager": {
-					Users: []string{"admin-user"}, // Keep this role
+					Users: []string{"admin-user"}, // Sync this role
 				},
 			},
 		}
 
 		client := &fakeOrgRolesClient{
 			roles: []github.OrganizationRole{
-				{ID: 1, Name: "security-manager"}, // Not in config - should be cleaned up
-				{ID: 2, Name: "billing-manager"},  // In config - should be synced
+				{ID: 1, Name: "security-manager"}, // Not in config - must be left alone
+				{ID: 2, Name: "billing-manager"},  // In config - must be synced
 			},
 			teamsWithRole: map[int][]github.OrganizationRoleAssignment{
-				1: {{ID: 10, Slug: "security-team"}}, // Should be removed
-				2: {},                                              // No teams
+				1: {{ID: 10, Slug: "security-team"}}, // Must NOT be removed
+				2: {},                                // No teams
 			},
 			usersWithRole: map[int][]github.OrganizationRoleAssignment{
-				1: {{ID: 5, Login: "security-admin"}}, // Should be removed
-				2: {},                                               // No users yet
+				1: {{ID: 5, Login: "security-admin"}}, // Must NOT be removed
+				2: {},                                 // No users yet
 			},
 		}
 
@@ -4692,27 +4734,19 @@ func TestConfigureOrgRoles(t *testing.T) {
 			t.Errorf("Unexpected error: %v", err)
 		}
 
-		// Verify security-manager assignments were removed (role ID 1)
-		foundSecurityTeamRemoval := false
-		foundSecurityUserRemoval := false
+		// security-manager (role ID 1) must not be touched at all.
 		for _, removal := range client.removedTeamRoles {
-			if strings.Contains(removal, "/1") { // roleID 1
-				foundSecurityTeamRemoval = true
+			if strings.Contains(removal, "/1") {
+				t.Errorf("Did not expect security-manager team assignment to be removed, removals: %v", client.removedTeamRoles)
 			}
 		}
 		for _, removal := range client.removedUserRoles {
-			if strings.Contains(removal, "/1") { // roleID 1
-				foundSecurityUserRemoval = true
+			if strings.Contains(removal, "/1") {
+				t.Errorf("Did not expect security-manager user assignment to be removed, removals: %v", client.removedUserRoles)
 			}
 		}
-		if !foundSecurityTeamRemoval {
-			t.Errorf("Expected security-manager team assignment to be removed, removals: %v", client.removedTeamRoles)
-		}
-		if !foundSecurityUserRemoval {
-			t.Errorf("Expected security-manager user assignment to be removed, removals: %v", client.removedUserRoles)
-		}
 
-		// Verify billing-manager was assigned (role ID 2)
+		// billing-manager (role ID 2) must get admin-user assigned.
 		foundBillingUserAssignment := false
 		for _, assignment := range client.assignedUserRoles {
 			if strings.Contains(assignment, "/2") { // roleID 2

--- a/cmd/peribolos/main_test.go
+++ b/cmd/peribolos/main_test.go
@@ -2392,6 +2392,47 @@ func TestDumpOrgConfig(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "dump excludes roles with no assignments",
+			meta: github.Organization{
+				Name:                        "Hello",
+				DefaultRepositoryPermission: "write",
+			},
+			members: []string{"user1"},
+			admins:  []string{"admin"},
+			roles: []github.OrganizationRole{
+				{ID: 1, Name: "security-manager"},
+				{ID: 2, Name: "billing-manager"},
+				{ID: 3, Name: "all_repo_read"},
+			},
+			teamsWithRole: map[int][]github.OrganizationRoleAssignment{
+				1: {{ID: 1, Slug: "security-team"}},
+			},
+			usersWithRole: map[int][]github.OrganizationRoleAssignment{},
+			expected: org.Config{
+				Metadata: org.Metadata{
+					Name:                         &hello,
+					BillingEmail:                 &empty,
+					Company:                      &empty,
+					Email:                        &empty,
+					Description:                  &empty,
+					Location:                     &empty,
+					HasOrganizationProjects:      &no,
+					HasRepositoryProjects:        &no,
+					DefaultRepositoryPermission:  &perm,
+					MembersCanCreateRepositories: &no,
+				},
+				Members: []string{"user1"},
+				Admins:  []string{"admin"},
+				Teams:   map[string]org.Team{},
+				Repos:   map[string]org.Repo{},
+				Roles: map[string]org.Role{
+					"security-manager": {
+						Teams: []string{"security-team"},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tc := range cases {

--- a/pkg/config/org/org.go
+++ b/pkg/config/org/org.go
@@ -129,6 +129,16 @@ func (c *Config) ValidateRoles() error {
 		availableUsers[github.NormLogin(user)] = true
 	}
 
+	// Detect case-insensitive role name collisions
+	seenRoles := make(map[string]string) // lowercase -> original
+	for roleName := range c.Roles {
+		lower := strings.ToLower(roleName)
+		if existing, ok := seenRoles[lower]; ok {
+			return fmt.Errorf("role name collision: %q and %q differ only in case", existing, roleName)
+		}
+		seenRoles[lower] = roleName
+	}
+
 	// Validate each role's team and user references
 	var errors []string
 	for roleName, role := range c.Roles {

--- a/pkg/config/org/org.go
+++ b/pkg/config/org/org.go
@@ -175,13 +175,24 @@ func (c *Config) ValidateRoles() error {
 		seenRoles[lower] = roleName
 	}
 
-	// Validate each role's team and user references
+	// Validate each role's team and user references.
+	//
+	// User membership is only validated when the config actually declares org
+	// membership (Members/Admins). --fix-org-roles requires --fix-teams but not
+	// --fix-org-members, so membership may be managed elsewhere; in that case we
+	// cannot know the full member set and skip the user check rather than
+	// rejecting valid configs. Team references are always validated because
+	// --fix-org-roles implies --fix-teams, so config teams are authoritative.
+	validateUsers := len(c.Members) > 0 || len(c.Admins) > 0
 	var errors []string
 	for roleName, role := range c.Roles {
 		for _, teamSlug := range role.Teams {
 			if !availableTeams[strings.ToLower(teamSlug)] {
 				errors = append(errors, fmt.Sprintf("role %q references undefined team %q", roleName, teamSlug))
 			}
+		}
+		if !validateUsers {
+			continue
 		}
 		for _, user := range role.Users {
 			if !availableUsers[github.NormLogin(user)] {

--- a/pkg/config/org/org.go
+++ b/pkg/config/org/org.go
@@ -165,6 +165,16 @@ func (c *Config) ValidateRoles() error {
 		availableUsers[github.NormLogin(user)] = true
 	}
 
+	// Detect case-insensitive role name collisions
+	seenRoles := make(map[string]string) // lowercase -> original
+	for roleName := range c.Roles {
+		lower := strings.ToLower(roleName)
+		if existing, ok := seenRoles[lower]; ok {
+			return fmt.Errorf("role name collision: %q and %q differ only in case", existing, roleName)
+		}
+		seenRoles[lower] = roleName
+	}
+
 	// Validate each role's team and user references
 	var errors []string
 	for roleName, role := range c.Roles {

--- a/pkg/config/org/org.go
+++ b/pkg/config/org/org.go
@@ -19,6 +19,7 @@ package org
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	"sigs.k8s.io/prow/pkg/github"
@@ -122,6 +123,68 @@ type Config struct {
 	Members []string        `json:"members,omitempty"`
 	Admins  []string        `json:"admins,omitempty"`
 	Repos   map[string]Repo `json:"repos,omitempty"`
+	Roles   map[string]Role `json:"roles,omitempty"`
+}
+
+// Role declares an organization role and its assignments to teams and users
+//
+// See https://docs.github.com/en/rest/orgs/organization-roles#assign-an-organization-role-to-a-team
+// See https://docs.github.com/en/rest/orgs/organization-roles#assign-an-organization-role-to-a-user
+type Role struct {
+	// Teams is a list of team names (from config keys) that have this role assigned
+	Teams []string `json:"teams,omitempty"`
+	// Users is a list of usernames that have this role assigned
+	Users []string `json:"users,omitempty"`
+}
+
+// ValidateRoles checks that all teams and users referenced in role assignments exist in the configuration
+func (c *Config) ValidateRoles() error {
+	if len(c.Roles) == 0 {
+		return nil
+	}
+
+	// Build a set of all team slugs (including nested teams)
+	availableTeams := make(map[string]bool)
+	var collectTeams func(teams map[string]Team)
+	collectTeams = func(teams map[string]Team) {
+		for name, team := range teams {
+			availableTeams[strings.ToLower(name)] = true
+			if len(team.Children) > 0 {
+				collectTeams(team.Children)
+			}
+		}
+	}
+	collectTeams(c.Teams)
+
+	// Build a set of all org members (normalized)
+	availableUsers := make(map[string]bool)
+	for _, user := range c.Admins {
+		availableUsers[github.NormLogin(user)] = true
+	}
+	for _, user := range c.Members {
+		availableUsers[github.NormLogin(user)] = true
+	}
+
+	// Validate each role's team and user references
+	var errors []string
+	for roleName, role := range c.Roles {
+		for _, teamSlug := range role.Teams {
+			if !availableTeams[strings.ToLower(teamSlug)] {
+				errors = append(errors, fmt.Sprintf("role %q references undefined team %q", roleName, teamSlug))
+			}
+		}
+		for _, user := range role.Users {
+			if !availableUsers[github.NormLogin(user)] {
+				errors = append(errors, fmt.Sprintf("role %q references user %q who is not an org member", roleName, user))
+			}
+		}
+	}
+
+	if len(errors) > 0 {
+		return fmt.Errorf("role validation failed:\n  - %s", strings.Join(errors, "\n  - "))
+	}
+
+	return nil
 }
 
 // TeamMetadata declares metadata about the github team.

--- a/pkg/config/org/org_test.go
+++ b/pkg/config/org/org_test.go
@@ -330,6 +330,21 @@ func TestValidateRoles(t *testing.T) {
 			},
 			expectError: false,
 		},
+		{
+			name: "case-insensitive role name collision",
+			config: Config{
+				Teams: map[string]Team{
+					"team1": {},
+				},
+				Admins: []string{"user1"},
+				Roles: map[string]Role{
+					"Security-Manager": {Teams: []string{"team1"}},
+					"security-manager": {Users: []string{"user1"}},
+				},
+			},
+			expectError: true,
+			errorPart:   "role name collision",
+		},
 	}
 
 	for _, tc := range tests {

--- a/pkg/config/org/org_test.go
+++ b/pkg/config/org/org_test.go
@@ -401,6 +401,21 @@ func TestValidateRoles(t *testing.T) {
 			},
 			expectError: false,
 		},
+		{
+			name: "case-insensitive role name collision",
+			config: Config{
+				Teams: map[string]Team{
+					"team1": {},
+				},
+				Admins: []string{"user1"},
+				Roles: map[string]Role{
+					"Security-Manager": {Teams: []string{"team1"}},
+					"security-manager": {Users: []string{"user1"}},
+				},
+			},
+			expectError: true,
+			errorPart:   "role name collision",
+		},
 	}
 
 	for _, tc := range tests {

--- a/pkg/config/org/org_test.go
+++ b/pkg/config/org/org_test.go
@@ -416,6 +416,41 @@ func TestValidateRoles(t *testing.T) {
 			expectError: true,
 			errorPart:   "role name collision",
 		},
+		{
+			name: "role user not validated when membership is not declared",
+			config: Config{
+				Teams: map[string]Team{
+					"security-team": {},
+				},
+				// No Members/Admins declared: org membership is managed elsewhere
+				// (--fix-org-roles requires --fix-teams, not --fix-org-members),
+				// so role user references cannot and must not be validated here.
+				Roles: map[string]Role{
+					"security-manager": {
+						Teams: []string{"security-team"},
+						Users: []string{"externally-managed-user"},
+					},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "role team still validated when membership is not declared",
+			config: Config{
+				Teams: map[string]Team{
+					"security-team": {},
+				},
+				// No Members/Admins, but an undefined team must still fail.
+				Roles: map[string]Role{
+					"security-manager": {
+						Teams: []string{"missing-team"},
+						Users: []string{"externally-managed-user"},
+					},
+				},
+			},
+			expectError: true,
+			errorPart:   "missing-team",
+		},
 	}
 
 	for _, tc := range tests {

--- a/pkg/config/org/org_test.go
+++ b/pkg/config/org/org_test.go
@@ -19,6 +19,7 @@ package org
 import (
 	"encoding/json"
 	"reflect"
+	"strings"
 	"testing"
 
 	"k8s.io/apimachinery/pkg/util/diff"
@@ -198,6 +199,223 @@ func TestRepoUnmarshalJSON(t *testing.T) {
 			}
 			if !reflect.DeepEqual(tc.expected, actual) {
 				t.Errorf("result differs from expected:\n%s", diff.Diff(tc.expected, actual))
+			}
+		})
+	}
+}
+
+func TestValidateRoles(t *testing.T) {
+	tests := []struct {
+		name        string
+		config      Config
+		expectError bool
+		errorPart   string
+	}{
+		{
+			name: "no roles - should pass",
+			config: Config{
+				Teams: map[string]Team{
+					"team1": {Members: []string{"user1"}},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "valid role with existing team",
+			config: Config{
+				Teams: map[string]Team{
+					"security-team": {Members: []string{"user1"}},
+				},
+				Admins: []string{"user1"},
+				Roles: map[string]Role{
+					"security-manager": {
+						Teams: []string{"security-team"},
+						Users: []string{"user1"},
+					},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "invalid role with non-existent team",
+			config: Config{
+				Teams: map[string]Team{
+					"existing-team": {Members: []string{"user1"}},
+				},
+				Members: []string{"user1"},
+				Roles: map[string]Role{
+					"security-manager": {
+						Teams: []string{"non-existent-team"},
+					},
+				},
+			},
+			expectError: true,
+			errorPart:   "non-existent-team",
+		},
+		{
+			name: "multiple roles with mixed valid and invalid teams",
+			config: Config{
+				Teams: map[string]Team{
+					"valid-team": {Members: []string{"user1"}},
+				},
+				Members: []string{"user1"},
+				Roles: map[string]Role{
+					"role1": {
+						Teams: []string{"valid-team"},
+					},
+					"role2": {
+						Teams: []string{"invalid-team"},
+					},
+				},
+			},
+			expectError: true,
+			errorPart:   "invalid-team",
+		},
+		{
+			name: "role with nested team reference",
+			config: Config{
+				Teams: map[string]Team{
+					"parent-team": {
+						Members: []string{"user1"},
+						Children: map[string]Team{
+							"child-team": {
+								Members: []string{"user2"},
+							},
+						},
+					},
+				},
+				Members: []string{"user1", "user2"},
+				Roles: map[string]Role{
+					"security-manager": {
+						Teams: []string{"child-team"},
+					},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "role with only users (no teams)",
+			config: Config{
+				Teams: map[string]Team{
+					"some-team": {Members: []string{"user1"}},
+				},
+				Admins:  []string{"user1"},
+				Members: []string{"user2"},
+				Roles: map[string]Role{
+					"security-manager": {
+						Users: []string{"user1", "user2"},
+					},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "role references user who is not org member",
+			config: Config{
+				Admins:  []string{"admin-user"},
+				Members: []string{"member-user"},
+				Roles: map[string]Role{
+					"security-manager": {
+						Users: []string{"non-member-user"},
+					},
+				},
+			},
+			expectError: true,
+			errorPart:   "non-member-user",
+		},
+		{
+			name: "role references user with different casing - should pass",
+			config: Config{
+				Admins: []string{"AdminUser"},
+				Roles: map[string]Role{
+					"security-manager": {
+						Users: []string{"adminuser"}, // Different casing but same user
+					},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "role with both valid and invalid users",
+			config: Config{
+				Admins: []string{"valid-user"},
+				Roles: map[string]Role{
+					"security-manager": {
+						Users: []string{"valid-user", "invalid-user"},
+					},
+				},
+			},
+			expectError: true,
+			errorPart:   "invalid-user",
+		},
+		{
+			name: "role with case-insensitive team matching",
+			config: Config{
+				Teams: map[string]Team{
+					"Security-Team": {Members: []string{"user1"}},
+				},
+				Admins: []string{"user1"},
+				Roles: map[string]Role{
+					"admin": {
+						Teams: []string{"security-team"}, // Different case
+					},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "role with deeply nested teams",
+			config: Config{
+				Teams: map[string]Team{
+					"level1": {
+						Children: map[string]Team{
+							"level2": {
+								Children: map[string]Team{
+									"level3": {Members: []string{"user1"}},
+								},
+							},
+						},
+					},
+				},
+				Members: []string{"user1"},
+				Roles: map[string]Role{
+					"role1": {
+						Teams: []string{"level3"},
+					},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "role with duplicate team references (should pass)",
+			config: Config{
+				Teams: map[string]Team{
+					"team1": {Members: []string{"user1"}},
+				},
+				Admins: []string{"user1"},
+				Roles: map[string]Role{
+					"role1": {
+						Teams: []string{"team1", "team1"},
+					},
+				},
+			},
+			expectError: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.config.ValidateRoles()
+			if tc.expectError {
+				if err == nil {
+					t.Error("Expected error but got none")
+				} else if tc.errorPart != "" && !strings.Contains(err.Error(), tc.errorPart) {
+					t.Errorf("Expected error to contain %q, but got: %v", tc.errorPart, err)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Unexpected error: %v", err)
+				}
 			}
 		})
 	}

--- a/pkg/github/client.go
+++ b/pkg/github/client.go
@@ -5425,6 +5425,12 @@ func (c *client) ListRepoInvitations(org, repo string) ([]CollaboratorRepoInvita
 	return ret, nil
 }
 
+// orgRolesResponse is the wrapper object returned by the list organization roles API.
+type orgRolesResponse struct {
+	TotalCount int                `json:"total_count"`
+	Roles      []OrganizationRole `json:"roles"`
+}
+
 // ListOrganizationRoles lists all organization roles
 //
 // https://docs.github.com/en/rest/orgs/organization-roles#list-organization-roles
@@ -5435,26 +5441,22 @@ func (c *client) ListOrganizationRoles(org string) ([]OrganizationRole, error) {
 	}
 
 	path := fmt.Sprintf("/orgs/%s/organization-roles", org)
-
-	// The API returns a wrapper object with total_count and roles array
-	type orgRolesResponse struct {
-		TotalCount int                `json:"total_count"`
-		Roles      []OrganizationRole `json:"roles"`
-	}
-
-	var response orgRolesResponse
-	_, err := c.request(&request{
-		method:    http.MethodGet,
-		path:      path,
-		org:       org,
-		exitCodes: []int{200},
-	}, &response)
-
+	var roles []OrganizationRole
+	err := c.readPaginatedResults(
+		path,
+		acceptNone,
+		org,
+		func() interface{} {
+			return &orgRolesResponse{}
+		},
+		func(obj interface{}) {
+			roles = append(roles, obj.(*orgRolesResponse).Roles...)
+		},
+	)
 	if err != nil {
 		return nil, err
 	}
-
-	return response.Roles, nil
+	return roles, nil
 }
 
 // AssignOrganizationRoleToTeam assigns an organization role to a team
@@ -5462,10 +5464,6 @@ func (c *client) ListOrganizationRoles(org string) ([]OrganizationRole, error) {
 // https://docs.github.com/en/rest/orgs/organization-roles#assign-an-organization-role-to-a-team
 func (c *client) AssignOrganizationRoleToTeam(org, teamSlug string, roleID int) error {
 	c.log("AssignOrganizationRoleToTeam", org, teamSlug, roleID)
-	if c.dry {
-		return nil
-	}
-
 	_, err := c.request(&request{
 		method:    http.MethodPut,
 		path:      fmt.Sprintf("/orgs/%s/organization-roles/teams/%s/%d", org, teamSlug, roleID),
@@ -5480,10 +5478,6 @@ func (c *client) AssignOrganizationRoleToTeam(org, teamSlug string, roleID int) 
 // https://docs.github.com/en/rest/orgs/organization-roles#remove-an-organization-role-from-a-team
 func (c *client) RemoveOrganizationRoleFromTeam(org, teamSlug string, roleID int) error {
 	c.log("RemoveOrganizationRoleFromTeam", org, teamSlug, roleID)
-	if c.dry {
-		return nil
-	}
-
 	_, err := c.request(&request{
 		method:    http.MethodDelete,
 		path:      fmt.Sprintf("/orgs/%s/organization-roles/teams/%s/%d", org, teamSlug, roleID),
@@ -5498,10 +5492,6 @@ func (c *client) RemoveOrganizationRoleFromTeam(org, teamSlug string, roleID int
 // https://docs.github.com/en/rest/orgs/organization-roles#assign-an-organization-role-to-a-user
 func (c *client) AssignOrganizationRoleToUser(org, user string, roleID int) error {
 	c.log("AssignOrganizationRoleToUser", org, user, roleID)
-	if c.dry {
-		return nil
-	}
-
 	_, err := c.request(&request{
 		method:    http.MethodPut,
 		path:      fmt.Sprintf("/orgs/%s/organization-roles/users/%s/%d", org, user, roleID),
@@ -5516,10 +5506,6 @@ func (c *client) AssignOrganizationRoleToUser(org, user string, roleID int) erro
 // https://docs.github.com/en/rest/orgs/organization-roles#remove-an-organization-role-from-a-user
 func (c *client) RemoveOrganizationRoleFromUser(org, user string, roleID int) error {
 	c.log("RemoveOrganizationRoleFromUser", org, user, roleID)
-	if c.dry {
-		return nil
-	}
-
 	_, err := c.request(&request{
 		method:    http.MethodDelete,
 		path:      fmt.Sprintf("/orgs/%s/organization-roles/users/%s/%d", org, user, roleID),
@@ -5529,16 +5515,14 @@ func (c *client) RemoveOrganizationRoleFromUser(org, user string, roleID int) er
 	return err
 }
 
-// ListTeamsWithRole lists all teams assigned to a specific organization role
-//
-// https://docs.github.com/en/rest/orgs/organization-roles#list-teams-assigned-to-an-organization-role
-func (c *client) ListTeamsWithRole(org string, roleID int) ([]OrganizationRoleAssignment, error) {
-	c.log("ListTeamsWithRole", org, roleID)
+// listRoleAssignments is a shared helper for listing teams or users assigned to a role.
+func (c *client) listRoleAssignments(org string, roleID int, entityType string) ([]OrganizationRoleAssignment, error) {
+	c.log("listRoleAssignments", org, roleID, entityType)
 	if c.fake {
 		return nil, nil
 	}
 
-	path := fmt.Sprintf("/orgs/%s/organization-roles/%d/teams", org, roleID)
+	path := fmt.Sprintf("/orgs/%s/organization-roles/%d/%s", org, roleID, entityType)
 	var assignments []OrganizationRoleAssignment
 	err := c.readPaginatedResults(
 		path,
@@ -5557,30 +5541,16 @@ func (c *client) ListTeamsWithRole(org string, roleID int) ([]OrganizationRoleAs
 	return assignments, nil
 }
 
+// ListTeamsWithRole lists all teams assigned to a specific organization role
+//
+// https://docs.github.com/en/rest/orgs/organization-roles#list-teams-assigned-to-an-organization-role
+func (c *client) ListTeamsWithRole(org string, roleID int) ([]OrganizationRoleAssignment, error) {
+	return c.listRoleAssignments(org, roleID, "teams")
+}
+
 // ListUsersWithRole lists all users assigned to a specific organization role
 //
 // https://docs.github.com/en/rest/orgs/organization-roles#list-users-assigned-to-an-organization-role
 func (c *client) ListUsersWithRole(org string, roleID int) ([]OrganizationRoleAssignment, error) {
-	c.log("ListUsersWithRole", org, roleID)
-	if c.fake {
-		return nil, nil
-	}
-
-	path := fmt.Sprintf("/orgs/%s/organization-roles/%d/users", org, roleID)
-	var assignments []OrganizationRoleAssignment
-	err := c.readPaginatedResults(
-		path,
-		acceptNone,
-		org,
-		func() interface{} {
-			return &[]OrganizationRoleAssignment{}
-		},
-		func(obj interface{}) {
-			assignments = append(assignments, *(obj.(*[]OrganizationRoleAssignment))...)
-		},
-	)
-	if err != nil {
-		return nil, err
-	}
-	return assignments, nil
+	return c.listRoleAssignments(org, roleID, "users")
 }

--- a/pkg/github/client.go
+++ b/pkg/github/client.go
@@ -76,6 +76,17 @@ type OrganizationClient interface {
 	RemoveOrgMembership(org, user string) error
 }
 
+// OrganizationRolesClient interface for organization roles related API actions
+type OrganizationRolesClient interface {
+	ListOrganizationRoles(org string) ([]OrganizationRole, error)
+	AssignOrganizationRoleToTeam(org, teamSlug string, roleID int) error
+	RemoveOrganizationRoleFromTeam(org, teamSlug string, roleID int) error
+	AssignOrganizationRoleToUser(org, user string, roleID int) error
+	RemoveOrganizationRoleFromUser(org, user string, roleID int) error
+	ListTeamsWithRole(org string, roleID int) ([]OrganizationRoleAssignment, error)
+	ListUsersWithRole(org string, roleID int) ([]OrganizationRoleAssignment, error)
+}
+
 // HookClient interface for hook related API actions
 type HookClient interface {
 	ListOrgHooks(org string) ([]Hook, error)
@@ -277,6 +288,7 @@ type Client interface {
 	IssueClient
 	CommentClient
 	OrganizationClient
+	OrganizationRolesClient
 	TeamClient
 	ProjectClient
 	MilestoneClient
@@ -5411,4 +5423,164 @@ func (c *client) ListRepoInvitations(org, repo string) ([]CollaboratorRepoInvita
 		return nil, err
 	}
 	return ret, nil
+}
+
+// ListOrganizationRoles lists all organization roles
+//
+// https://docs.github.com/en/rest/orgs/organization-roles#list-organization-roles
+func (c *client) ListOrganizationRoles(org string) ([]OrganizationRole, error) {
+	c.log("ListOrganizationRoles", org)
+	if c.fake {
+		return nil, nil
+	}
+
+	path := fmt.Sprintf("/orgs/%s/organization-roles", org)
+
+	// The API returns a wrapper object with total_count and roles array
+	type orgRolesResponse struct {
+		TotalCount int                `json:"total_count"`
+		Roles      []OrganizationRole `json:"roles"`
+	}
+
+	var response orgRolesResponse
+	_, err := c.request(&request{
+		method:    http.MethodGet,
+		path:      path,
+		org:       org,
+		exitCodes: []int{200},
+	}, &response)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return response.Roles, nil
+}
+
+// AssignOrganizationRoleToTeam assigns an organization role to a team
+//
+// https://docs.github.com/en/rest/orgs/organization-roles#assign-an-organization-role-to-a-team
+func (c *client) AssignOrganizationRoleToTeam(org, teamSlug string, roleID int) error {
+	c.log("AssignOrganizationRoleToTeam", org, teamSlug, roleID)
+	if c.dry {
+		return nil
+	}
+
+	_, err := c.request(&request{
+		method:    http.MethodPut,
+		path:      fmt.Sprintf("/orgs/%s/organization-roles/teams/%s/%d", org, teamSlug, roleID),
+		org:       org,
+		exitCodes: []int{204},
+	}, nil)
+	return err
+}
+
+// RemoveOrganizationRoleFromTeam removes an organization role from a team
+//
+// https://docs.github.com/en/rest/orgs/organization-roles#remove-an-organization-role-from-a-team
+func (c *client) RemoveOrganizationRoleFromTeam(org, teamSlug string, roleID int) error {
+	c.log("RemoveOrganizationRoleFromTeam", org, teamSlug, roleID)
+	if c.dry {
+		return nil
+	}
+
+	_, err := c.request(&request{
+		method:    http.MethodDelete,
+		path:      fmt.Sprintf("/orgs/%s/organization-roles/teams/%s/%d", org, teamSlug, roleID),
+		org:       org,
+		exitCodes: []int{204},
+	}, nil)
+	return err
+}
+
+// AssignOrganizationRoleToUser assigns an organization role to a user
+//
+// https://docs.github.com/en/rest/orgs/organization-roles#assign-an-organization-role-to-a-user
+func (c *client) AssignOrganizationRoleToUser(org, user string, roleID int) error {
+	c.log("AssignOrganizationRoleToUser", org, user, roleID)
+	if c.dry {
+		return nil
+	}
+
+	_, err := c.request(&request{
+		method:    http.MethodPut,
+		path:      fmt.Sprintf("/orgs/%s/organization-roles/users/%s/%d", org, user, roleID),
+		org:       org,
+		exitCodes: []int{204},
+	}, nil)
+	return err
+}
+
+// RemoveOrganizationRoleFromUser removes an organization role from a user
+//
+// https://docs.github.com/en/rest/orgs/organization-roles#remove-an-organization-role-from-a-user
+func (c *client) RemoveOrganizationRoleFromUser(org, user string, roleID int) error {
+	c.log("RemoveOrganizationRoleFromUser", org, user, roleID)
+	if c.dry {
+		return nil
+	}
+
+	_, err := c.request(&request{
+		method:    http.MethodDelete,
+		path:      fmt.Sprintf("/orgs/%s/organization-roles/users/%s/%d", org, user, roleID),
+		org:       org,
+		exitCodes: []int{204},
+	}, nil)
+	return err
+}
+
+// ListTeamsWithRole lists all teams assigned to a specific organization role
+//
+// https://docs.github.com/en/rest/orgs/organization-roles#list-teams-assigned-to-an-organization-role
+func (c *client) ListTeamsWithRole(org string, roleID int) ([]OrganizationRoleAssignment, error) {
+	c.log("ListTeamsWithRole", org, roleID)
+	if c.fake {
+		return nil, nil
+	}
+
+	path := fmt.Sprintf("/orgs/%s/organization-roles/%d/teams", org, roleID)
+	var assignments []OrganizationRoleAssignment
+	err := c.readPaginatedResults(
+		path,
+		acceptNone,
+		org,
+		func() interface{} {
+			return &[]OrganizationRoleAssignment{}
+		},
+		func(obj interface{}) {
+			assignments = append(assignments, *(obj.(*[]OrganizationRoleAssignment))...)
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+	return assignments, nil
+}
+
+// ListUsersWithRole lists all users assigned to a specific organization role
+//
+// https://docs.github.com/en/rest/orgs/organization-roles#list-users-assigned-to-an-organization-role
+func (c *client) ListUsersWithRole(org string, roleID int) ([]OrganizationRoleAssignment, error) {
+	c.log("ListUsersWithRole", org, roleID)
+	if c.fake {
+		return nil, nil
+	}
+
+	path := fmt.Sprintf("/orgs/%s/organization-roles/%d/users", org, roleID)
+	var assignments []OrganizationRoleAssignment
+	err := c.readPaginatedResults(
+		path,
+		acceptNone,
+		org,
+		func() interface{} {
+			return &[]OrganizationRoleAssignment{}
+		},
+		func(obj interface{}) {
+			assignments = append(assignments, *(obj.(*[]OrganizationRoleAssignment))...)
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+	return assignments, nil
 }

--- a/pkg/github/client.go
+++ b/pkg/github/client.go
@@ -5517,6 +5517,12 @@ func (c *client) ListRepoInvitations(org, repo string) ([]CollaboratorRepoInvita
 	return ret, nil
 }
 
+// orgRolesResponse is the wrapper object returned by the list organization roles API.
+type orgRolesResponse struct {
+	TotalCount int                `json:"total_count"`
+	Roles      []OrganizationRole `json:"roles"`
+}
+
 // ListOrganizationRoles lists all organization roles
 //
 // https://docs.github.com/en/rest/orgs/organization-roles#list-organization-roles
@@ -5527,26 +5533,22 @@ func (c *client) ListOrganizationRoles(org string) ([]OrganizationRole, error) {
 	}
 
 	path := fmt.Sprintf("/orgs/%s/organization-roles", org)
-
-	// The API returns a wrapper object with total_count and roles array
-	type orgRolesResponse struct {
-		TotalCount int                `json:"total_count"`
-		Roles      []OrganizationRole `json:"roles"`
-	}
-
-	var response orgRolesResponse
-	_, err := c.request(&request{
-		method:    http.MethodGet,
-		path:      path,
-		org:       org,
-		exitCodes: []int{200},
-	}, &response)
-
+	var roles []OrganizationRole
+	err := c.readPaginatedResults(
+		path,
+		acceptNone,
+		org,
+		func() interface{} {
+			return &orgRolesResponse{}
+		},
+		func(obj interface{}) {
+			roles = append(roles, obj.(*orgRolesResponse).Roles...)
+		},
+	)
 	if err != nil {
 		return nil, err
 	}
-
-	return response.Roles, nil
+	return roles, nil
 }
 
 // AssignOrganizationRoleToTeam assigns an organization role to a team
@@ -5554,10 +5556,6 @@ func (c *client) ListOrganizationRoles(org string) ([]OrganizationRole, error) {
 // https://docs.github.com/en/rest/orgs/organization-roles#assign-an-organization-role-to-a-team
 func (c *client) AssignOrganizationRoleToTeam(org, teamSlug string, roleID int) error {
 	c.log("AssignOrganizationRoleToTeam", org, teamSlug, roleID)
-	if c.dry {
-		return nil
-	}
-
 	_, err := c.request(&request{
 		method:    http.MethodPut,
 		path:      fmt.Sprintf("/orgs/%s/organization-roles/teams/%s/%d", org, teamSlug, roleID),
@@ -5572,10 +5570,6 @@ func (c *client) AssignOrganizationRoleToTeam(org, teamSlug string, roleID int) 
 // https://docs.github.com/en/rest/orgs/organization-roles#remove-an-organization-role-from-a-team
 func (c *client) RemoveOrganizationRoleFromTeam(org, teamSlug string, roleID int) error {
 	c.log("RemoveOrganizationRoleFromTeam", org, teamSlug, roleID)
-	if c.dry {
-		return nil
-	}
-
 	_, err := c.request(&request{
 		method:    http.MethodDelete,
 		path:      fmt.Sprintf("/orgs/%s/organization-roles/teams/%s/%d", org, teamSlug, roleID),
@@ -5590,10 +5584,6 @@ func (c *client) RemoveOrganizationRoleFromTeam(org, teamSlug string, roleID int
 // https://docs.github.com/en/rest/orgs/organization-roles#assign-an-organization-role-to-a-user
 func (c *client) AssignOrganizationRoleToUser(org, user string, roleID int) error {
 	c.log("AssignOrganizationRoleToUser", org, user, roleID)
-	if c.dry {
-		return nil
-	}
-
 	_, err := c.request(&request{
 		method:    http.MethodPut,
 		path:      fmt.Sprintf("/orgs/%s/organization-roles/users/%s/%d", org, user, roleID),
@@ -5608,10 +5598,6 @@ func (c *client) AssignOrganizationRoleToUser(org, user string, roleID int) erro
 // https://docs.github.com/en/rest/orgs/organization-roles#remove-an-organization-role-from-a-user
 func (c *client) RemoveOrganizationRoleFromUser(org, user string, roleID int) error {
 	c.log("RemoveOrganizationRoleFromUser", org, user, roleID)
-	if c.dry {
-		return nil
-	}
-
 	_, err := c.request(&request{
 		method:    http.MethodDelete,
 		path:      fmt.Sprintf("/orgs/%s/organization-roles/users/%s/%d", org, user, roleID),
@@ -5621,16 +5607,14 @@ func (c *client) RemoveOrganizationRoleFromUser(org, user string, roleID int) er
 	return err
 }
 
-// ListTeamsWithRole lists all teams assigned to a specific organization role
-//
-// https://docs.github.com/en/rest/orgs/organization-roles#list-teams-assigned-to-an-organization-role
-func (c *client) ListTeamsWithRole(org string, roleID int) ([]OrganizationRoleAssignment, error) {
-	c.log("ListTeamsWithRole", org, roleID)
+// listRoleAssignments is a shared helper for listing teams or users assigned to a role.
+func (c *client) listRoleAssignments(org string, roleID int, entityType string) ([]OrganizationRoleAssignment, error) {
+	c.log("listRoleAssignments", org, roleID, entityType)
 	if c.fake {
 		return nil, nil
 	}
 
-	path := fmt.Sprintf("/orgs/%s/organization-roles/%d/teams", org, roleID)
+	path := fmt.Sprintf("/orgs/%s/organization-roles/%d/%s", org, roleID, entityType)
 	var assignments []OrganizationRoleAssignment
 	err := c.readPaginatedResults(
 		path,
@@ -5649,30 +5633,16 @@ func (c *client) ListTeamsWithRole(org string, roleID int) ([]OrganizationRoleAs
 	return assignments, nil
 }
 
+// ListTeamsWithRole lists all teams assigned to a specific organization role
+//
+// https://docs.github.com/en/rest/orgs/organization-roles#list-teams-assigned-to-an-organization-role
+func (c *client) ListTeamsWithRole(org string, roleID int) ([]OrganizationRoleAssignment, error) {
+	return c.listRoleAssignments(org, roleID, "teams")
+}
+
 // ListUsersWithRole lists all users assigned to a specific organization role
 //
 // https://docs.github.com/en/rest/orgs/organization-roles#list-users-assigned-to-an-organization-role
 func (c *client) ListUsersWithRole(org string, roleID int) ([]OrganizationRoleAssignment, error) {
-	c.log("ListUsersWithRole", org, roleID)
-	if c.fake {
-		return nil, nil
-	}
-
-	path := fmt.Sprintf("/orgs/%s/organization-roles/%d/users", org, roleID)
-	var assignments []OrganizationRoleAssignment
-	err := c.readPaginatedResults(
-		path,
-		acceptNone,
-		org,
-		func() interface{} {
-			return &[]OrganizationRoleAssignment{}
-		},
-		func(obj interface{}) {
-			assignments = append(assignments, *(obj.(*[]OrganizationRoleAssignment))...)
-		},
-	)
-	if err != nil {
-		return nil, err
-	}
-	return assignments, nil
+	return c.listRoleAssignments(org, roleID, "users")
 }

--- a/pkg/github/client.go
+++ b/pkg/github/client.go
@@ -76,6 +76,17 @@ type OrganizationClient interface {
 	RemoveOrgMembership(org, user string) error
 }
 
+// OrganizationRolesClient interface for organization roles related API actions
+type OrganizationRolesClient interface {
+	ListOrganizationRoles(org string) ([]OrganizationRole, error)
+	AssignOrganizationRoleToTeam(org, teamSlug string, roleID int) error
+	RemoveOrganizationRoleFromTeam(org, teamSlug string, roleID int) error
+	AssignOrganizationRoleToUser(org, user string, roleID int) error
+	RemoveOrganizationRoleFromUser(org, user string, roleID int) error
+	ListTeamsWithRole(org string, roleID int) ([]OrganizationRoleAssignment, error)
+	ListUsersWithRole(org string, roleID int) ([]OrganizationRoleAssignment, error)
+}
+
 // HookClient interface for hook related API actions
 type HookClient interface {
 	ListOrgHooks(org string) ([]Hook, error)
@@ -279,6 +290,7 @@ type Client interface {
 	IssueClient
 	CommentClient
 	OrganizationClient
+	OrganizationRolesClient
 	TeamClient
 	ProjectClient
 	MilestoneClient
@@ -5503,4 +5515,164 @@ func (c *client) ListRepoInvitations(org, repo string) ([]CollaboratorRepoInvita
 		return nil, err
 	}
 	return ret, nil
+}
+
+// ListOrganizationRoles lists all organization roles
+//
+// https://docs.github.com/en/rest/orgs/organization-roles#list-organization-roles
+func (c *client) ListOrganizationRoles(org string) ([]OrganizationRole, error) {
+	c.log("ListOrganizationRoles", org)
+	if c.fake {
+		return nil, nil
+	}
+
+	path := fmt.Sprintf("/orgs/%s/organization-roles", org)
+
+	// The API returns a wrapper object with total_count and roles array
+	type orgRolesResponse struct {
+		TotalCount int                `json:"total_count"`
+		Roles      []OrganizationRole `json:"roles"`
+	}
+
+	var response orgRolesResponse
+	_, err := c.request(&request{
+		method:    http.MethodGet,
+		path:      path,
+		org:       org,
+		exitCodes: []int{200},
+	}, &response)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return response.Roles, nil
+}
+
+// AssignOrganizationRoleToTeam assigns an organization role to a team
+//
+// https://docs.github.com/en/rest/orgs/organization-roles#assign-an-organization-role-to-a-team
+func (c *client) AssignOrganizationRoleToTeam(org, teamSlug string, roleID int) error {
+	c.log("AssignOrganizationRoleToTeam", org, teamSlug, roleID)
+	if c.dry {
+		return nil
+	}
+
+	_, err := c.request(&request{
+		method:    http.MethodPut,
+		path:      fmt.Sprintf("/orgs/%s/organization-roles/teams/%s/%d", org, teamSlug, roleID),
+		org:       org,
+		exitCodes: []int{204},
+	}, nil)
+	return err
+}
+
+// RemoveOrganizationRoleFromTeam removes an organization role from a team
+//
+// https://docs.github.com/en/rest/orgs/organization-roles#remove-an-organization-role-from-a-team
+func (c *client) RemoveOrganizationRoleFromTeam(org, teamSlug string, roleID int) error {
+	c.log("RemoveOrganizationRoleFromTeam", org, teamSlug, roleID)
+	if c.dry {
+		return nil
+	}
+
+	_, err := c.request(&request{
+		method:    http.MethodDelete,
+		path:      fmt.Sprintf("/orgs/%s/organization-roles/teams/%s/%d", org, teamSlug, roleID),
+		org:       org,
+		exitCodes: []int{204},
+	}, nil)
+	return err
+}
+
+// AssignOrganizationRoleToUser assigns an organization role to a user
+//
+// https://docs.github.com/en/rest/orgs/organization-roles#assign-an-organization-role-to-a-user
+func (c *client) AssignOrganizationRoleToUser(org, user string, roleID int) error {
+	c.log("AssignOrganizationRoleToUser", org, user, roleID)
+	if c.dry {
+		return nil
+	}
+
+	_, err := c.request(&request{
+		method:    http.MethodPut,
+		path:      fmt.Sprintf("/orgs/%s/organization-roles/users/%s/%d", org, user, roleID),
+		org:       org,
+		exitCodes: []int{204},
+	}, nil)
+	return err
+}
+
+// RemoveOrganizationRoleFromUser removes an organization role from a user
+//
+// https://docs.github.com/en/rest/orgs/organization-roles#remove-an-organization-role-from-a-user
+func (c *client) RemoveOrganizationRoleFromUser(org, user string, roleID int) error {
+	c.log("RemoveOrganizationRoleFromUser", org, user, roleID)
+	if c.dry {
+		return nil
+	}
+
+	_, err := c.request(&request{
+		method:    http.MethodDelete,
+		path:      fmt.Sprintf("/orgs/%s/organization-roles/users/%s/%d", org, user, roleID),
+		org:       org,
+		exitCodes: []int{204},
+	}, nil)
+	return err
+}
+
+// ListTeamsWithRole lists all teams assigned to a specific organization role
+//
+// https://docs.github.com/en/rest/orgs/organization-roles#list-teams-assigned-to-an-organization-role
+func (c *client) ListTeamsWithRole(org string, roleID int) ([]OrganizationRoleAssignment, error) {
+	c.log("ListTeamsWithRole", org, roleID)
+	if c.fake {
+		return nil, nil
+	}
+
+	path := fmt.Sprintf("/orgs/%s/organization-roles/%d/teams", org, roleID)
+	var assignments []OrganizationRoleAssignment
+	err := c.readPaginatedResults(
+		path,
+		acceptNone,
+		org,
+		func() interface{} {
+			return &[]OrganizationRoleAssignment{}
+		},
+		func(obj interface{}) {
+			assignments = append(assignments, *(obj.(*[]OrganizationRoleAssignment))...)
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+	return assignments, nil
+}
+
+// ListUsersWithRole lists all users assigned to a specific organization role
+//
+// https://docs.github.com/en/rest/orgs/organization-roles#list-users-assigned-to-an-organization-role
+func (c *client) ListUsersWithRole(org string, roleID int) ([]OrganizationRoleAssignment, error) {
+	c.log("ListUsersWithRole", org, roleID)
+	if c.fake {
+		return nil, nil
+	}
+
+	path := fmt.Sprintf("/orgs/%s/organization-roles/%d/users", org, roleID)
+	var assignments []OrganizationRoleAssignment
+	err := c.readPaginatedResults(
+		path,
+		acceptNone,
+		org,
+		func() interface{} {
+			return &[]OrganizationRoleAssignment{}
+		},
+		func(obj interface{}) {
+			assignments = append(assignments, *(obj.(*[]OrganizationRoleAssignment))...)
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+	return assignments, nil
 }

--- a/pkg/github/fakegithub/fakegithub.go
+++ b/pkg/github/fakegithub/fakegithub.go
@@ -1393,3 +1393,33 @@ func (f *FakeClient) RequestReview(org, repo string, number int, logins []string
 	f.ReviewersRequested = logins
 	return nil
 }
+
+// Organization roles stubs
+
+func (f *FakeClient) ListOrganizationRoles(org string) ([]github.OrganizationRole, error) {
+	return nil, nil
+}
+
+func (f *FakeClient) AssignOrganizationRoleToTeam(org, teamSlug string, roleID int) error {
+	return nil
+}
+
+func (f *FakeClient) RemoveOrganizationRoleFromTeam(org, teamSlug string, roleID int) error {
+	return nil
+}
+
+func (f *FakeClient) AssignOrganizationRoleToUser(org, user string, roleID int) error {
+	return nil
+}
+
+func (f *FakeClient) RemoveOrganizationRoleFromUser(org, user string, roleID int) error {
+	return nil
+}
+
+func (f *FakeClient) ListTeamsWithRole(org string, roleID int) ([]github.OrganizationRoleAssignment, error) {
+	return nil, nil
+}
+
+func (f *FakeClient) ListUsersWithRole(org string, roleID int) ([]github.OrganizationRoleAssignment, error) {
+	return nil, nil
+}

--- a/pkg/github/fakegithub/fakegithub.go
+++ b/pkg/github/fakegithub/fakegithub.go
@@ -1429,3 +1429,33 @@ func (f *FakeClient) RequestReview(org, repo string, number int, logins []string
 	f.ReviewersRequested = logins
 	return nil
 }
+
+// Organization roles stubs
+
+func (f *FakeClient) ListOrganizationRoles(org string) ([]github.OrganizationRole, error) {
+	return nil, nil
+}
+
+func (f *FakeClient) AssignOrganizationRoleToTeam(org, teamSlug string, roleID int) error {
+	return nil
+}
+
+func (f *FakeClient) RemoveOrganizationRoleFromTeam(org, teamSlug string, roleID int) error {
+	return nil
+}
+
+func (f *FakeClient) AssignOrganizationRoleToUser(org, user string, roleID int) error {
+	return nil
+}
+
+func (f *FakeClient) RemoveOrganizationRoleFromUser(org, user string, roleID int) error {
+	return nil
+}
+
+func (f *FakeClient) ListTeamsWithRole(org string, roleID int) ([]github.OrganizationRoleAssignment, error) {
+	return nil, nil
+}
+
+func (f *FakeClient) ListUsersWithRole(org string, roleID int) ([]github.OrganizationRoleAssignment, error) {
+	return nil, nil
+}

--- a/pkg/github/types.go
+++ b/pkg/github/types.go
@@ -1773,13 +1773,11 @@ type OrganizationRole struct {
 	Permissions []string `json:"permissions"`
 }
 
-// OrganizationRoleAssignment represents a role assignment to a team or user
+// OrganizationRoleAssignment represents a role assignment to a team or user.
+// For teams: id, slug, assignment are populated. For users: id, login, assignment are populated.
 type OrganizationRoleAssignment struct {
 	ID         int    `json:"id"`
 	Login      string `json:"login,omitempty"`
 	Slug       string `json:"slug,omitempty"`
-	Type       string `json:"type"` // "User" or "Team"
-	RoleID     int    `json:"role_id"`
-	RoleName   string `json:"role_name"`
-	Assignment string `json:"assignment"` // "direct" or "indirect" (indirect = via team membership)
+	Assignment string `json:"assignment,omitempty"` // "direct", "indirect", or "mixed"
 }

--- a/pkg/github/types.go
+++ b/pkg/github/types.go
@@ -1764,3 +1764,22 @@ type Layers struct {
 	MediaType string `json:"media_type"`
 	Size      int    `json:"size"`
 }
+
+// OrganizationRole represents an organization role
+type OrganizationRole struct {
+	ID          int      `json:"id"`
+	Name        string   `json:"name"`
+	Description string   `json:"description"`
+	Permissions []string `json:"permissions"`
+}
+
+// OrganizationRoleAssignment represents a role assignment to a team or user
+type OrganizationRoleAssignment struct {
+	ID         int    `json:"id"`
+	Login      string `json:"login,omitempty"`
+	Slug       string `json:"slug,omitempty"`
+	Type       string `json:"type"` // "User" or "Team"
+	RoleID     int    `json:"role_id"`
+	RoleName   string `json:"role_name"`
+	Assignment string `json:"assignment"` // "direct" or "indirect" (indirect = via team membership)
+}

--- a/pkg/github/types.go
+++ b/pkg/github/types.go
@@ -1829,13 +1829,11 @@ type OrganizationRole struct {
 	Permissions []string `json:"permissions"`
 }
 
-// OrganizationRoleAssignment represents a role assignment to a team or user
+// OrganizationRoleAssignment represents a role assignment to a team or user.
+// For teams: id, slug, assignment are populated. For users: id, login, assignment are populated.
 type OrganizationRoleAssignment struct {
 	ID         int    `json:"id"`
 	Login      string `json:"login,omitempty"`
 	Slug       string `json:"slug,omitempty"`
-	Type       string `json:"type"` // "User" or "Team"
-	RoleID     int    `json:"role_id"`
-	RoleName   string `json:"role_name"`
-	Assignment string `json:"assignment"` // "direct" or "indirect" (indirect = via team membership)
+	Assignment string `json:"assignment,omitempty"` // "direct", "indirect", or "mixed"
 }

--- a/pkg/github/types.go
+++ b/pkg/github/types.go
@@ -1820,3 +1820,22 @@ type BlameRange struct {
 	AuthorLogin  string
 	Date         time.Time
 }
+
+// OrganizationRole represents an organization role
+type OrganizationRole struct {
+	ID          int      `json:"id"`
+	Name        string   `json:"name"`
+	Description string   `json:"description"`
+	Permissions []string `json:"permissions"`
+}
+
+// OrganizationRoleAssignment represents a role assignment to a team or user
+type OrganizationRoleAssignment struct {
+	ID         int    `json:"id"`
+	Login      string `json:"login,omitempty"`
+	Slug       string `json:"slug,omitempty"`
+	Type       string `json:"type"` // "User" or "Team"
+	RoleID     int    `json:"role_id"`
+	RoleName   string `json:"role_name"`
+	Assignment string `json:"assignment"` // "direct" or "indirect" (indirect = via team membership)
+}


### PR DESCRIPTION
# Add Organization Roles Support to Peribolos

This PR adds support for managing GitHub organization custom roles in Peribolos, enabling declarative configuration of role assignments to teams and users.

## Changes

### 1. Configuration Schema (`pkg/config/org/org.go`)
- Added `Roles` field to `Config` struct for declaring role assignments
- Implemented `ValidateRoles()` for pre-flight validation with case-insensitive team/user matching
- Uses `github.NormLogin()` for consistent username normalization

### 2. GitHub API Client (`pkg/github/client.go`)
Added methods for organization role management:
- `ListOrganizationRoles()`, `ListTeamsWithRole()`, `ListUsersWithRole()`
- `AssignOrganizationRoleToTeam()`, `RemoveOrganizationRoleFromTeam()`
- `AssignOrganizationRoleToUser()`, `RemoveOrganizationRoleFromUser()`

All mutating operations respect dry-run mode.

### 3. Main Implementation (`cmd/peribolos/main.go`)
- Added `--fix-org-roles` flag to enable role management (gatekeeper)
- Implemented `configureOrgRoles()` 
- Team name -> slug resolution for correct API calls
- Slug -> team name mapping in dump mode for idempotent configurations
- Roles configured after teams are fully populated

### 4. Test Coverage (`pkg/config/org/org_test.go`, `cmd/peribolos/main_test.go`)
- 12 validation test cases (nested teams, case-insensitivity, duplicates)
- 6 team assignment test cases
- 8 user assignment test cases

## Behavior

- **Only roles declared in config are managed.** Roles absent from the config, including GitHub's built-in predefined roles (`all_repo_*`) and any roles managed outside peribolos, are left untouched. peribolos never removes assignments from a role it was not asked to manage.
- **To remove all assignments from a role, declare it in config with no teams or users.** Assignments are reconciled to the declared state, so an empty role clears its assignments.
- **Indirect (team-derived) user assignments are preserved.** A user who holds a role via team membership is not removed for being absent from a role's `users` list; only direct assignments are reconciled.
- **`--fix-org-roles` requires `--fix-teams`** so role team names can be resolved to slugs from the reconciled team set. A role's user references are validated only when the config declares org membership (`members`/`admins`); when membership is managed elsewhere those references are not validated. Team references are always validated.
- **Dumping roles is best-effort.** If the organization role APIs are unavailable (for example a token without the required scope), roles are omitted from the dump rather than failing the whole dump. Teams excluded via `--ignore-secret-teams`/`--ignore-enterprise-teams` are also excluded from dumped role assignments.

## Example Configuration

```yaml
orgs:
  my-org:
    teams:
      security-team:
        members: [user1, user2]
      compliance-team:
        members: [user3, user4]

    admins:
      - admin-user

    roles:
      security-manager:
        teams: [security-team]
        users: [admin-user]

      billing-manager:
        teams: [compliance-team]
        users: [admin-user]
```

## Usage

```bash
# Validate configuration only
peribolos --config-path=org.yaml

# Apply with dry-run
peribolos --config-path=org.yaml --fix-org-roles --confirm=false

# Apply changes
peribolos --config-path=org.yaml --fix-org-roles --confirm=true

# Dump current organization state
peribolos --dump my-org --github-token-path=token
```

>Note: this PR was created with the assistance of AI tooling
