### PR TITLE
Update gimme and fix codegen determinism

### DIFF
--- a/hack/make-rules/update/codegen.sh
+++ b/hack/make-rules/update/codegen.sh
@@ -158,7 +158,7 @@ gen-informer() {
 gen-spyglass-bindata() {
   cd pkg/spyglass/lenses/common/
   echo "Generating spyglass bindata..." >&2
-  $go_bindata -pkg=common static/
+  $go_bindata -modtime 1 -pkg=common static/
   gofmt -s -w ./
   cd - >/dev/null
 }

--- a/hack/third_party/gimme/gimme
+++ b/hack/third_party/gimme/gimme
@@ -285,7 +285,7 @@ _extract() {
 
 # _setup_bootstrap
 _setup_bootstrap() {
-	local versions=("1.14" "1.13" "1.12" "1.11" "1.10" "1.9" "1.8" "1.7" "1.6" "1.5" "1.4")
+	local versions=("1.23" "1.22" "1.21" "1.20" "1.19" "1.18" "1.17" "1.16" "1.15" "1.14" "1.13" "1.12" "1.11" "1.10" "1.9" "1.8" "1.7" "1.6" "1.5" "1.4")
 
 	# try existing
 	for v in "${versions[@]}"; do
@@ -785,7 +785,7 @@ _to_goarch() {
 : "${GIMME_GO_GIT_REMOTE:=https://github.com/golang/go.git}"
 : "${GIMME_TYPE:=auto}" # 'auto', 'binary', 'source', or 'git'
 : "${GIMME_BINARY_OSX:=osx10.8}"
-: "${GIMME_DOWNLOAD_BASE:=https://storage.googleapis.com/golang}"
+: "${GIMME_DOWNLOAD_BASE:=https://dl.google.com/go}"
 : "${GIMME_LIST_KNOWN:=https://golang.org/dl}"
 : "${GIMME_KNOWN_CACHE_MAX:=10800}"
 

--- a/pkg/spyglass/lenses/common/bindata.go
+++ b/pkg/spyglass/lenses/common/bindata.go
@@ -93,7 +93,7 @@ func staticSpyglassLensHtml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "static/spyglass-lens.html", size: 616, mode: os.FileMode(420), modTime: time.Unix(1757524878, 0)}
+	info := bindataFileInfo{name: "static/spyglass-lens.html", size: 616, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }


### PR DESCRIPTION
Updated gimme to support Go 1.24.x and added `-modtime 1` flag to go-bindata for deterministic timestamps.

Go 1.25.x has a regression in `go/doc` package that breaks godoc comment extraction. The old gimme couldn't install Go 1.24.0 from `.go-version`, causing CI to use Go 1.25.3 and generate files without comments.