### PR TITLE
feat(release-note): handle ready for review

### DIFF
--- a/pkg/plugins/releasenote/releasenote.go
+++ b/pkg/plugins/releasenote/releasenote.go
@@ -222,7 +222,8 @@ func shouldHandlePR(pr *github.PullRequestEvent) bool {
 	// Only consider events that edit the PR body or add a label
 	if pr.Action != github.PullRequestActionOpened &&
 		pr.Action != github.PullRequestActionEdited &&
-		pr.Action != github.PullRequestActionLabeled {
+		pr.Action != github.PullRequestActionLabeled &&
+		pr.Action != github.PullRequestActionReadyForReview {
 		return false
 	}
 

--- a/pkg/plugins/releasenote/releasenote_test.go
+++ b/pkg/plugins/releasenote/releasenote_test.go
@@ -481,6 +481,13 @@ func TestReleaseNotePR(t *testing.T) {
 			initialLabels:    []string{},
 			IssueLabelsAdded: []string{},
 		},
+		{
+			name:               "do-not-merge/release-note-label-needed, converted from draft to ready for review",
+			body:               "```release-note\nnone\n```",
+			initialLabels:      []string{labels.ReleaseNoteLabelNeeded},
+			IssueLabelsAdded:   []string{labels.ReleaseNoteNone},
+			IssueLabelsRemoved: []string{labels.ReleaseNoteLabelNeeded},
+		},
 	}
 	for _, test := range tests {
 		if test.branch == "" {
@@ -643,6 +650,12 @@ func TestShouldHandlePR(t *testing.T) {
 			action:         github.PullRequestActionLabeled,
 			label:          "do-not-merge/cherry-pick-not-approved",
 			expectedResult: false,
+		},
+		{
+			name:           "Pull Request Action: Ready for review",
+			action:         github.PullRequestActionReadyForReview,
+			label:          labels.ReleaseNoteLabelNeeded,
+			expectedResult: true,
 		},
 	}
 


### PR DESCRIPTION
When the PR is created as draft initially it has the label `do-not-merge/release-note-label-needed` - when it then is later set to ready for review the PR labels aren't updated.

This change handles the update.

Fixes #568 