### PR TITLE
Fix message when PR needs ok-to-test

### DIFF
--- a/pkg/plugins/trigger/pull-request.go
+++ b/pkg/plugins/trigger/pull-request.go
@@ -290,7 +290,7 @@ I understand the commands that are listed [here](https://go.k8s.io/bot-commands?
 
 %s
 </details>
-`, author, github.DefaultHost, org, org, more, joinOrgURL, labels.OkToTest, encodedRepoFullName, plugins.AboutThisBotWithoutCommands)
+`, author, org, github.DefaultHost, org, more, joinOrgURL, labels.OkToTest, encodedRepoFullName, plugins.AboutThisBotWithoutCommands)
 
 		l, err := ghc.GetIssueLabels(org, repo, pr.Number)
 		if err != nil {


### PR DESCRIPTION
spotted this reordering in https://github.com/kubernetes/dns/pull/737#issuecomment-3686585465