### PR TITLE
Fix `An unknown state job break job-bar on "Prow Status" page`

### DIFF
--- a/cmd/deck/static/prow/prow.ts
+++ b/cmd/deck/static/prow/prow.ts
@@ -47,6 +47,10 @@ function optionsForRepo(repository: string): RepoOptions {
   };
 
   for (const build of allBuilds.items) {
+    if (build.status == null) {
+      continue;
+    }
+
     const {
       spec: {
         cluster = "",


### PR DESCRIPTION
Fix: https://github.com/kubernetes-sigs/prow/issues/545

This should fix the deck bug, but I wasn't 100% sure on the safe logic for Sinker cleanup (https://github.com/kubernetes-sigs/prow/issues/545#issuecomment-3687445345) - I assume some time should pass to make sure it's abandoned/garbage job and not just a new one, but I'm not sure what that required time should be. I'm happy to add this logic here if I get confirmation on this approach and a tip on the required time amount.