### PR TITLE
Jenkins: Check building before accepting result

### DIFF
--- a/pkg/jenkins/jenkins.go
+++ b/pkg/jenkins/jenkins.go
@@ -96,6 +96,7 @@ type Build struct {
 	} `json:"task"`
 	Number   int     `json:"number"`
 	Result   *string `json:"result"`
+	Building bool    `json:"building"`
 	enqueued bool
 }
 
@@ -122,8 +123,11 @@ type JobInfo struct {
 }
 
 // IsRunning means the job started but has not finished.
+// We check Building first to handle Jenkins matrix builds where
+// result can be set to SUCCESS while the build is still running
+// (when one matrix cell completes before others).
 func (jb *Build) IsRunning() bool {
-	return jb.Result == nil && !jb.enqueued
+	return jb.Building || (jb.Result == nil && !jb.enqueued)
 }
 
 // IsSuccess means the job passed
@@ -722,7 +726,7 @@ func (c *Client) GetEnqueuedBuilds(jobs []BuildQueryParams) (map[string]Build, e
 func (c *Client) GetBuilds(job string) (map[string]Build, error) {
 	c.logger.Debugf("GetBuilds(%v)", job)
 
-	data, err := c.Get(fmt.Sprintf("/job/%s/api/json?tree=builds[number,result,actions[parameters[name,value]]]", job))
+	data, err := c.Get(fmt.Sprintf("/job/%s/api/json?tree=builds[number,result,building,actions[parameters[name,value]]]", job))
 	if err != nil {
 		// Ignore 404s so we will not block processing the rest of the jobs.
 		if _, isNotFound := err.(NotFoundError); isNotFound {

--- a/pkg/jenkins/jenkins_test.go
+++ b/pkg/jenkins/jenkins_test.go
@@ -713,3 +713,165 @@ func TestGetBuildWithParametersPath(t *testing.T) {
 		})
 	}
 }
+
+func TestIsRunning(t *testing.T) {
+	tests := []struct {
+		name     string
+		build    Build
+		expected bool
+	}{
+		{
+			name:     "building true, result nil - should be running",
+			build:    Build{Building: true, Result: nil},
+			expected: true,
+		},
+		{
+			name:     "building true, result SUCCESS - should still be running",
+			build:    Build{Building: true, Result: strP(success)},
+			expected: true,
+		},
+		{
+			name:     "building true, result FAILURE - should still be running",
+			build:    Build{Building: true, Result: strP(failure)},
+			expected: true,
+		},
+		{
+			name:     "building false, result SUCCESS - completed successfully",
+			build:    Build{Building: false, Result: strP(success)},
+			expected: false,
+		},
+		{
+			name:     "building false, result FAILURE - completed with failure",
+			build:    Build{Building: false, Result: strP(failure)},
+			expected: false,
+		},
+		{
+			name:     "building false, result nil - not yet started (legacy behavior)",
+			build:    Build{Building: false, Result: nil},
+			expected: true,
+		},
+		{
+			name:     "building false, result nil, enqueued - waiting in queue",
+			build:    Build{Building: false, Result: nil, enqueued: true},
+			expected: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result := test.build.IsRunning()
+			if result != test.expected {
+				t.Errorf("IsRunning() = %v, expected %v", result, test.expected)
+			}
+		})
+	}
+}
+
+func TestIsSuccess(t *testing.T) {
+	tests := []struct {
+		name     string
+		build    Build
+		expected bool
+	}{
+		{
+			name:     "result SUCCESS - is success",
+			build:    Build{Result: strP(success)},
+			expected: true,
+		},
+		{
+			name:     "result FAILURE - not success",
+			build:    Build{Result: strP(failure)},
+			expected: false,
+		},
+		{
+			name:     "result nil - not success",
+			build:    Build{Result: nil},
+			expected: false,
+		},
+		{
+			name:     "building true with result SUCCESS - technically success but should check IsRunning first",
+			build:    Build{Building: true, Result: strP(success)},
+			expected: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result := test.build.IsSuccess()
+			if result != test.expected {
+				t.Errorf("IsSuccess() = %v, expected %v", result, test.expected)
+			}
+		})
+	}
+}
+
+func TestIsFailure(t *testing.T) {
+	tests := []struct {
+		name     string
+		build    Build
+		expected bool
+	}{
+		{
+			name:     "result FAILURE - is failure",
+			build:    Build{Result: strP(failure)},
+			expected: true,
+		},
+		{
+			name:     "result UNSTABLE - is failure",
+			build:    Build{Result: strP(unstable)},
+			expected: true,
+		},
+		{
+			name:     "result SUCCESS - not failure",
+			build:    Build{Result: strP(success)},
+			expected: false,
+		},
+		{
+			name:     "result nil - not failure",
+			build:    Build{Result: nil},
+			expected: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result := test.build.IsFailure()
+			if result != test.expected {
+				t.Errorf("IsFailure() = %v, expected %v", result, test.expected)
+			}
+		})
+	}
+}
+
+func TestIsAborted(t *testing.T) {
+	tests := []struct {
+		name     string
+		build    Build
+		expected bool
+	}{
+		{
+			name:     "result ABORTED - is aborted",
+			build:    Build{Result: strP(aborted)},
+			expected: true,
+		},
+		{
+			name:     "result SUCCESS - not aborted",
+			build:    Build{Result: strP(success)},
+			expected: false,
+		},
+		{
+			name:     "result nil - not aborted",
+			build:    Build{Result: nil},
+			expected: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result := test.build.IsAborted()
+			if result != test.expected {
+				t.Errorf("IsAborted() = %v, expected %v", result, test.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
In some cases, jenkins may report a result for a job while it is still building. This can happen in matrix pipelines when one branch finishes before the rest. To avoid false results, we need to check if the job is still building before we accept the result. Otherwise we may mark a job as successful after only one branch has succeeded.

This commit uncludes the building status in the API query and checks it as part of IsRunning. It also adds unit tests for IsRunning, IsSuccess, IsFailure and IsAborted.

Fixes #142