### PR TITLE
No longer check at mentions in commit messages and PR title

### DIFF
--- a/pkg/plugins/invalidcommitmsg/invalidcommitmsg.go
+++ b/pkg/plugins/invalidcommitmsg/invalidcommitmsg.go
@@ -15,8 +15,7 @@ limitations under the License.
 */
 
 // Package invalidcommitmsg adds the "do-not-merge/invalid-commit-message"
-// label on PRs containing commit messages with @mentions or
-// keywords that can automatically close issues.
+// label on PRs containing commit messages with keywords that can automatically close issues.
 package invalidcommitmsg
 
 import (
@@ -36,7 +35,7 @@ import (
 const (
 	pluginName                  = "invalidcommitmsg"
 	invalidCommitMsgLabel       = "do-not-merge/invalid-commit-message"
-	invalidCommitMsgCommentBody = `[Keywords](https://help.github.com/articles/closing-issues-using-keywords) which can automatically close issues and at(@) or hashtag(#) mentions are not allowed in commit messages.
+	invalidCommitMsgCommentBody = `[Keywords](https://help.github.com/articles/closing-issues-using-keywords) which can automatically close issues and hashtag(#) mentions are not allowed in commit messages.
 
 **The list of commits with invalid commit messages**:
 
@@ -48,7 +47,7 @@ const (
 </details>
 `
 	invalidCommitMsgCommentPruneBody = "**The list of commits with invalid commit messages**:"
-	invalidTitleCommentBody          = `[Keywords](https://help.github.com/articles/closing-issues-using-keywords) which can automatically close issues and at(@) mentions are not allowed in the title of a Pull Request.
+	invalidTitleCommentBody          = `[Keywords](https://help.github.com/articles/closing-issues-using-keywords) which can automatically close issues are not allowed in the title of a Pull Request.
 
 You can edit the title by writing **/retitle <new-title>** in a comment.
 
@@ -61,10 +60,7 @@ When GitHub merges a Pull Request, the title is included in the merge commit. To
 	invalidTitleCommentPruneBody = "not allowed in the title of a Pull Request"
 )
 
-var (
-	CloseIssueRegex = regexp.MustCompile(`((?i)(clos(?:e[sd]?))|(fix(?:(es|ed)?))|(resolv(?:e[sd]?)))[\s:]+(\w+/\w+)?#(\d+)`)
-	AtMentionRegex  = regexp.MustCompile(`\B([@][\w_-]+)`)
-)
+var CloseIssueRegex = regexp.MustCompile(`((?i)(clos(?:e[sd]?))|(fix(?:(es|ed)?))|(resolv(?:e[sd]?)))[\s:]+(\w+/\w+)?#(\d+)`)
 
 func init() {
 	plugins.RegisterPullRequestHandler(pluginName, handlePullRequest, helpProvider)
@@ -73,7 +69,7 @@ func init() {
 func helpProvider(config *plugins.Configuration, _ []config.OrgRepo) (*pluginhelp.PluginHelp, error) {
 	// Only the Description field is specified because this plugin is not triggered with commands and is not configurable.
 	return &pluginhelp.PluginHelp{
-			Description: "The invalidcommitmsg plugin applies the '" + invalidCommitMsgLabel + "' label to pull requests whose commit messages and titles contain @ mentions or keywords which can automatically close issues.",
+			Description: "The invalidcommitmsg plugin applies the '" + invalidCommitMsgLabel + "' label to pull requests whose commit messages and titles contain keywords which can automatically close issues.",
 		},
 		nil
 }
@@ -125,12 +121,12 @@ func handle(gc githubClient, log *logrus.Entry, pr github.PullRequestEvent, cp c
 
 	var invalidCommits []github.RepositoryCommit
 	for _, commit := range allCommits {
-		if CloseIssueRegex.MatchString(commit.Commit.Message) || AtMentionRegex.MatchString(commit.Commit.Message) {
+		if CloseIssueRegex.MatchString(commit.Commit.Message) {
 			invalidCommits = append(invalidCommits, commit)
 		}
 	}
 
-	invalidPRTitle := CloseIssueRegex.MatchString(title) || AtMentionRegex.MatchString(title)
+	invalidPRTitle := CloseIssueRegex.MatchString(title)
 
 	// if we have the label but all commits and the PR title is valid,
 	// remove the label and prune comments

--- a/pkg/plugins/invalidcommitmsg/invalidcommitmsg_test.go
+++ b/pkg/plugins/invalidcommitmsg/invalidcommitmsg_test.go
@@ -48,16 +48,13 @@ func makeFakePullRequestEvent(action github.PullRequestEventAction, title string
 	}
 }
 
-var invalidCommitComment = `k/k#3:[Keywords](https://help.github.com/articles/closing-issues-using-keywords) which can automatically close issues and at(@) or hashtag(#) mentions are not allowed in commit messages.
+var invalidCommitComment = `k/k#3:[Keywords](https://help.github.com/articles/closing-issues-using-keywords) which can automatically close issues and hashtag(#) mentions are not allowed in commit messages.
 
 **The list of commits with invalid commit messages**:
 
-- [sha1](https://github.com/k/k/commits/sha1) this is a @mention
-- [sha2](https://github.com/k/k/commits/sha2) this @menti-on has a hyphen
-- [sha3](https://github.com/k/k/commits/sha3) this @Menti-On has mixed case letters
-- [sha4](https://github.com/k/k/commits/sha4) fixes k/k#9999
-- [sha5](https://github.com/k/k/commits/sha5) Close k/k#9999
-- [sha6](https://github.com/k/k/commits/sha6) resolved k/k#9999
+- [sha1](https://github.com/k/k/commits/sha1) fixes k/k#9999
+- [sha2](https://github.com/k/k/commits/sha2) Close k/k#9999
+- [sha3](https://github.com/k/k/commits/sha3) resolved k/k#9999
 
 <details>
 
@@ -65,7 +62,7 @@ Instructions for interacting with me using PR comments are available [here](http
 </details>
 `
 
-var invalidPRTitleComment = `k/k#3:[Keywords](https://help.github.com/articles/closing-issues-using-keywords) which can automatically close issues and at(@) mentions are not allowed in the title of a Pull Request.
+var invalidPRTitleComment = `k/k#3:[Keywords](https://help.github.com/articles/closing-issues-using-keywords) which can automatically close issues are not allowed in the title of a Pull Request.
 
 You can edit the title by writing **/retitle <new-title>** in a comment.
 
@@ -101,8 +98,6 @@ func TestHandlePullRequest(t *testing.T) {
 			commits: []github.RepositoryCommit{
 				{SHA: "sha1", Commit: github.GitCommit{Message: "this is a valid message"}},
 				{SHA: "sha2", Commit: github.GitCommit{Message: "fixing k/k#9999"}},
-				{SHA: "sha3", Commit: github.GitCommit{Message: "not a @ mention"}},
-				{SHA: "sha4", Commit: github.GitCommit{Message: "escape @\u200bmention with zero width unicode"}},
 			},
 			hasInvalidCommitMessageLabel: false,
 		},
@@ -110,13 +105,9 @@ func TestHandlePullRequest(t *testing.T) {
 			name:   "msg contains invalid keywords -> add label and comment",
 			action: github.PullRequestActionOpened,
 			commits: []github.RepositoryCommit{
-				{SHA: "sha1", Commit: github.GitCommit{Message: "this is a @mention"}},
-				{SHA: "sha2", Commit: github.GitCommit{Message: "this @menti-on has a hyphen"}},
-				{SHA: "sha3", Commit: github.GitCommit{Message: "this @Menti-On has mixed case letters"}},
-				{SHA: "sha4", Commit: github.GitCommit{Message: "fixes k/k#9999"}},
-				{SHA: "sha5", Commit: github.GitCommit{Message: "Close k/k#9999"}},
-				{SHA: "sha6", Commit: github.GitCommit{Message: "resolved k/k#9999"}},
-				{SHA: "sha7", Commit: github.GitCommit{Message: "this is an email@address and is valid"}},
+				{SHA: "sha1", Commit: github.GitCommit{Message: "fixes k/k#9999"}},
+				{SHA: "sha2", Commit: github.GitCommit{Message: "Close k/k#9999"}},
+				{SHA: "sha3", Commit: github.GitCommit{Message: "resolved k/k#9999"}},
 			},
 			hasInvalidCommitMessageLabel: false,
 
@@ -143,17 +134,6 @@ func TestHandlePullRequest(t *testing.T) {
 			hasInvalidCommitMessageLabel: false,
 		},
 		{
-			name:   "contains invalid title with @mention -> add label and comment",
-			action: github.PullRequestActionOpened,
-			commits: []github.RepositoryCommit{
-				{SHA: "sha1", Commit: github.GitCommit{Message: "this is a valid message"}},
-			},
-			title:                        "title with @mention",
-			hasInvalidCommitMessageLabel: false,
-			addedLabel:                   fmt.Sprintf("k/k#3:%s", invalidCommitMsgLabel),
-			addedComments:                []string{invalidPRTitleComment},
-		},
-		{
 			name:   "contains invalid title with fixes keyword -> add label and comment",
 			action: github.PullRequestActionOpened,
 			commits: []github.RepositoryCommit{
@@ -168,15 +148,11 @@ func TestHandlePullRequest(t *testing.T) {
 			name:   "contains invalid title and invalid commits -> add label and 2 comments",
 			action: github.PullRequestActionOpened,
 			commits: []github.RepositoryCommit{
-				{SHA: "sha1", Commit: github.GitCommit{Message: "this is a @mention"}},
-				{SHA: "sha2", Commit: github.GitCommit{Message: "this @menti-on has a hyphen"}},
-				{SHA: "sha3", Commit: github.GitCommit{Message: "this @Menti-On has mixed case letters"}},
-				{SHA: "sha4", Commit: github.GitCommit{Message: "fixes k/k#9999"}},
-				{SHA: "sha5", Commit: github.GitCommit{Message: "Close k/k#9999"}},
-				{SHA: "sha6", Commit: github.GitCommit{Message: "resolved k/k#9999"}},
-				{SHA: "sha7", Commit: github.GitCommit{Message: "this is an email@address and is valid"}},
+				{SHA: "sha1", Commit: github.GitCommit{Message: "fixes k/k#9999"}},
+				{SHA: "sha2", Commit: github.GitCommit{Message: "Close k/k#9999"}},
+				{SHA: "sha3", Commit: github.GitCommit{Message: "resolved k/k#9999"}},
 			},
-			title:                        "title with @mention",
+			title:                        "fixes #9999",
 			hasInvalidCommitMessageLabel: false,
 			addedLabel:                   fmt.Sprintf("k/k#3:%s", invalidCommitMsgLabel),
 			addedComments:                []string{invalidCommitComment, invalidPRTitleComment},
@@ -187,7 +163,7 @@ func TestHandlePullRequest(t *testing.T) {
 			commits: []github.RepositoryCommit{
 				{SHA: "sha", Commit: github.GitCommit{Message: "this is a valid message"}},
 			},
-			title:                        "title with @mention",
+			title:                        "fixes #9999",
 			hasInvalidCommitMessageLabel: true,
 			addedComments:                []string{invalidPRTitleComment},
 		},
@@ -195,13 +171,9 @@ func TestHandlePullRequest(t *testing.T) {
 			name:   "invalid commits and valid title, and has label -> keep label and add comment",
 			action: github.PullRequestActionOpened,
 			commits: []github.RepositoryCommit{
-				{SHA: "sha1", Commit: github.GitCommit{Message: "this is a @mention"}},
-				{SHA: "sha2", Commit: github.GitCommit{Message: "this @menti-on has a hyphen"}},
-				{SHA: "sha3", Commit: github.GitCommit{Message: "this @Menti-On has mixed case letters"}},
-				{SHA: "sha4", Commit: github.GitCommit{Message: "fixes k/k#9999"}},
-				{SHA: "sha5", Commit: github.GitCommit{Message: "Close k/k#9999"}},
-				{SHA: "sha6", Commit: github.GitCommit{Message: "resolved k/k#9999"}},
-				{SHA: "sha7", Commit: github.GitCommit{Message: "this is an email@address and is valid"}},
+				{SHA: "sha1", Commit: github.GitCommit{Message: "fixes k/k#9999"}},
+				{SHA: "sha2", Commit: github.GitCommit{Message: "Close k/k#9999"}},
+				{SHA: "sha3", Commit: github.GitCommit{Message: "resolved k/k#9999"}},
 			},
 			title:                        "valid title",
 			hasInvalidCommitMessageLabel: true,

--- a/pkg/plugins/retitle/retitle.go
+++ b/pkg/plugins/retitle/retitle.go
@@ -139,8 +139,8 @@ func handleGenericComment(gc githubClient, isTrusted func(string) (bool, error),
 		return gc.CreateComment(org, repo, number, plugins.FormatResponseRaw(gce.Body, gce.HTMLURL, user, `Titles may not be empty.`))
 	}
 
-	if invalidcommitmsg.AtMentionRegex.MatchString(newTitle) || invalidcommitmsg.CloseIssueRegex.MatchString(newTitle) {
-		return gc.CreateComment(org, repo, number, plugins.FormatResponseRaw(gce.Body, gce.HTMLURL, user, `Titles may not contain [keywords](https://help.github.com/articles/closing-issues-using-keywords) which can automatically close issues and at(@) mentions.`))
+	if invalidcommitmsg.CloseIssueRegex.MatchString(newTitle) {
+		return gc.CreateComment(org, repo, number, plugins.FormatResponseRaw(gce.Body, gce.HTMLURL, user, `Titles may not contain [keywords](https://help.github.com/articles/closing-issues-using-keywords) which can automatically close issues.`))
 	}
 
 	if gce.IsPR {

--- a/pkg/plugins/retitle/retitle_test.go
+++ b/pkg/plugins/retitle/retitle_test.go
@@ -121,26 +121,6 @@ Instructions for interacting with me using PR comments are available [here](http
 </details>`,
 		},
 		{
-			name:   "new comment on open issue comments with a title with @mention",
-			state:  "open",
-			action: github.GenericCommentActionCreated,
-			body:   "/retitle Add @mention to OWNERS",
-			trusted: func(user string) (bool, error) {
-				return true, nil
-			},
-			expectedComment: `org/repo#1:@user: Titles may not contain [keywords](https://help.github.com/articles/closing-issues-using-keywords) which can automatically close issues and at(@) mentions.
-
-<details>
-
-In response to [this]():
-
->/retitle Add @mention to OWNERS
-
-
-Instructions for interacting with me using PR comments are available [here](https://git.k8s.io/community/contributors/guide/pull-requests.md).  If you have questions or suggestions related to my behavior, please file an issue against the [kubernetes-sigs/prow](https://github.com/kubernetes-sigs/prow/issues/new?title=Prow%20issue:) repository.
-</details>`,
-		},
-		{
 			name:   "new comment on open issue comments with a title with invalid keyword",
 			state:  "open",
 			action: github.GenericCommentActionCreated,
@@ -148,7 +128,7 @@ Instructions for interacting with me using PR comments are available [here](http
 			trusted: func(user string) (bool, error) {
 				return true, nil
 			},
-			expectedComment: `org/repo#1:@user: Titles may not contain [keywords](https://help.github.com/articles/closing-issues-using-keywords) which can automatically close issues and at(@) mentions.
+			expectedComment: `org/repo#1:@user: Titles may not contain [keywords](https://help.github.com/articles/closing-issues-using-keywords) which can automatically close issues.
 
 <details>
 


### PR DESCRIPTION
As the Github changelog https://github.blog/changelog/2025-11-07-removing-notifications-for-mentions-in-commit-messages/ with the comment https://github.com/kubernetes-sigs/prow/issues/571#issuecomment-3656761089 and the [confirmation from GH staff](https://github.com/kubernetes-sigs/prow/issues/571#issuecomment-3805719155). 

So we can no longer check at(@) mentions in commit messages and PR title.

Fixes: #571