### PR TITLE
`jira` plugin: remove extra slash in link

### DIFF
--- a/pkg/jira/fakejira/fake.go
+++ b/pkg/jira/fakejira/fake.go
@@ -82,7 +82,9 @@ func (f *FakeClient) JiraClient() *jira.Client {
 	panic("not implemented")
 }
 
-const FakeJiraUrl = "https://my-jira.com"
+// FakeJiraUrl is the return value for FakeClient.JiraURL.
+// JiraURL of the real client returns the base URL with a trailing slash.
+const FakeJiraUrl = "https://my-jira.com/"
 
 func (f *FakeClient) JiraURL() string {
 	return FakeJiraUrl

--- a/pkg/plugins/jira/jira.go
+++ b/pkg/plugins/jira/jira.go
@@ -28,6 +28,7 @@ import (
 
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
+
 	"sigs.k8s.io/prow/pkg/config"
 	"sigs.k8s.io/prow/pkg/github"
 	jiraclient "sigs.k8s.io/prow/pkg/jira"
@@ -214,7 +215,7 @@ func insertLinksIntoComment(body string, issueNames []string, jiraBaseURL string
 
 func insertLinksIntoLine(line string, issueNames []string, jiraBaseURL string) string {
 	for _, issue := range issueNames {
-		replacement := fmt.Sprintf("[%s](%s/browse/%s)", issue, jiraBaseURL, issue)
+		replacement := fmt.Sprintf("[%s](%s/browse/%s)", issue, strings.TrimSuffix(jiraBaseURL, "/"), issue)
 		line = replaceStringIfNeeded(line, issue, replacement)
 	}
 	return line


### PR DESCRIPTION
The `JiraURL` method of the Jira client returns the base URL with a trailing slash.
This leads to the `jira` plugin inserting broken links into GitHub issues with an extra slash, e.g., `https://jira.my//browse/PROJECT-123`, causing 404s when clicking the link.

This PR trims the trailing slash before constructing the link target accordingly.

/kind bug