### PR TITLE
Approve GitHub Actions workflow runs on /ok-to-test

### DIFF
--- a/pkg/plugins/trigger/trigger.go
+++ b/pkg/plugins/trigger/trigger.go
@@ -161,6 +161,8 @@ type githubClient interface {
 	RemoveLabel(org, repo string, number int, label string) error
 	TriggerGitHubWorkflow(org, repo string, id int) error
 	TriggerFailedGitHubWorkflow(org, repo string, id int) error
+	GetPendingApprovalActionRuns(org, repo, branchName, headSHA string) ([]github.WorkflowRun, error)
+	ApproveGitHubWorkflowRun(org, repo string, id int) error
 	DeleteStaleComments(org, repo string, number int, comments []github.IssueComment, isStale func(github.IssueComment) bool) error
 	GetIssueLabels(org, repo string, number int) ([]github.Label, error)
 }


### PR DESCRIPTION
## Summary

When `/ok-to-test` is issued by a trusted user and `TriggerGitHubWorkflows` is enabled, automatically approve any pending GitHub Actions workflow runs for the PR. This enables a unified workflow where `/ok-to-test` both triggers Prow jobs AND approves GitHub Actions workflows from fork PRs.

## Changes

### GitHub Client (`pkg/github/client.go`)
- Added `GetPendingApprovalActionRuns` method to retrieve workflow runs with `status=action_required` for a PR's head SHA
- Added `ApproveGitHubWorkflowRun` method to approve pending workflow runs via GitHub API
- Updated `Client` interface to include both new methods

### Trigger Plugin (`pkg/plugins/trigger/`)
- Added approval logic in `generic-comment.go` that triggers on `/ok-to-test` when `TriggerGitHubWorkflows=true`
- Added `approveGitHubActionsWorkflowRuns` helper function that:
  - Fetches pending workflow runs for the PR head SHA
  - Approves each run asynchronously using goroutines
  - Handles errors gracefully (403/404 logged at info level, others at error level)
  - Logs SHA used in lookup for debugging PR head sync issues
- Updated `githubClient` interface in `trigger.go` to include new methods

### Fake Client (`pkg/github/fakegithub/fakegithub.go`)
- Added `PendingApprovalRuns` field to track pending runs by "org/repo/branch/sha"
- Added `ApprovedWorkflowRuns` field to track approval attempts
- Implemented fake versions of both new methods for testing

### Tests
- **GitHub Client Tests** (`pkg/github/client_test.go`):
  - `TestGetPendingApprovalActionRuns` - Verifies API calls with correct query parameters (status=action_required, event filters)
  - `TestApproveGitHubWorkflowRun` - Tests successful approval and error cases (201, 403, 404)

- **Trigger Plugin Tests** (`pkg/plugins/trigger/generic-comment_test.go`):
  - `TestApproveGitHubActionsWorkflowRuns` - Comprehensive test covering:
    - Approval triggers on `/ok-to-test` with `TriggerGitHubWorkflows=true` ✓
    - No approval when `TriggerGitHubWorkflows=false` ✓
    - No approval on `/test all` or `/retest` ✓
    - No approval when `IgnoreOkToTest=true` ✓
    - Handles multiple pending runs ✓
    - Gracefully handles no pending runs ✓

## Behavior

**When approval is triggered:**
- Only on `/ok-to-test` command (not `/test all` or `/retest`)
- Only when `TriggerGitHubWorkflows` configuration flag is enabled
- Only for `pull_request` and `pull_request_target` triggered workflows

**Error handling:**
- 403 (already approved) and 404 (run completed) errors are logged at info level as expected cases
- Unexpected errors are logged at error level
- Errors do not block the `/ok-to-test` command from proceeding

**Design rationale:**
- Reuses existing `TriggerGitHubWorkflows` flag (semantic expansion - existing users automatically get this behavior)
- Asynchronous approval via goroutines prevents blocking the main workflow
- Best-effort approach ensures the core `/ok-to-test` functionality isn't impacted by approval failures

## Testing

All tests pass:
```bash
go test ./pkg/github/... -run 'TestGetPendingApprovalActionRuns|TestApproveGitHubWorkflowRun' -v
go test ./pkg/plugins/trigger/... -run 'TestApproveGitHubActionsWorkflowRuns' -v
```

No regressions in existing test suites:
```bash
go test ./pkg/github/...
go test ./pkg/plugins/trigger/...
```