### PR TITLE
Fix runlocal GCS bucket configuration to match prow.k8s.io

### DIFF
--- a/test/integration/config/prow/deck.yaml
+++ b/test/integration/config/prow/deck.yaml
@@ -1,6 +1,6 @@
 # This is the production config for prow.k8s.io config required by cmd/deck to work properly.
 plank:
-  job_url_template: 'https://prow.k8s.io/view/gs/kubernetes-jenkins/{{if eq .Spec.Type "presubmit"}}pr-logs/pull{{else if eq .Spec.Type "batch"}}pr-logs/pull{{else}}logs{{end}}{{if .Spec.Refs}}{{if ne .Spec.Refs.Org ""}}{{if ne .Spec.Refs.Org "kubernetes"}}/{{if and (eq .Spec.Refs.Org "kubernetes-sigs") (ne .Spec.Refs.Repo "poseidon")}}sigs.k8s.io{{else}}{{.Spec.Refs.Org}}{{end}}_{{.Spec.Refs.Repo}}{{else if ne .Spec.Refs.Repo "kubernetes"}}/{{.Spec.Refs.Repo}}{{end}}{{end}}{{end}}{{if eq .Spec.Type "presubmit"}}/{{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}}{{else if eq .Spec.Type "batch"}}/batch{{end}}/{{.Spec.Job}}/{{.Status.BuildID}}/'
+  job_url_template: 'https://prow.k8s.io/view/gs/kubernetes-ci-logs/{{if eq .Spec.Type "presubmit"}}pr-logs/pull{{else if eq .Spec.Type "batch"}}pr-logs/pull{{else}}logs{{end}}{{if .Spec.Refs}}{{if ne .Spec.Refs.Org ""}}{{if ne .Spec.Refs.Org "kubernetes"}}/{{if and (eq .Spec.Refs.Org "kubernetes-sigs") (ne .Spec.Refs.Repo "poseidon")}}sigs.k8s.io{{else}}{{.Spec.Refs.Org}}{{end}}_{{.Spec.Refs.Repo}}{{else if ne .Spec.Refs.Repo "kubernetes"}}/{{.Spec.Refs.Repo}}{{end}}{{end}}{{end}}{{if eq .Spec.Type "presubmit"}}/{{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}}{{else if eq .Spec.Type "batch"}}/batch{{end}}/{{.Spec.Job}}/{{.Status.BuildID}}/'
   report_templates:
     '*': '[Full PR test history](https://prow.k8s.io/pr-history?org={{.Spec.Refs.Org}}&repo={{.Spec.Refs.Repo}}&pr={{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}}). [Your PR dashboard](https://prow.k8s.io/pr?query=is%3Apr%20state%3Aopen%20author%3A{{with index .Spec.Refs.Pulls 0}}{{.Author}}{{end}}). Please help us cut down on flakes by [linking to](https://git.k8s.io/community/contributors/devel/sig-testing/flaky-tests.md#filing-issues-for-flaky-tests) an [open issue](https://github.com/{{.Spec.Refs.Org}}/{{.Spec.Refs.Repo}}/issues?q=is:issue+is:open) when you hit one in your PR.'
   job_url_prefix_config:
@@ -19,7 +19,7 @@ plank:
         entrypoint: "gcr.io/k8s-prow/entrypoint:v20240415-7013691e3"
         sidecar: "gcr.io/k8s-prow/sidecar:v20240415-7013691e3"
       gcs_configuration:
-        bucket: "kubernetes-jenkins"
+        bucket: "kubernetes-ci-logs"
         path_strategy: "legacy"
         default_org: "kubernetes"
         default_repo: "kubernetes"
@@ -181,6 +181,8 @@ deck:
   # false
   skip_storage_path_validation: false
   additional_allowed_buckets:
+    - kubernetes-jenkins
+    - kubernetes-ci-logs
     - k8s-ovn
     - containerd-integration
     - ppc64le-kubernetes


### PR DESCRIPTION
Noticed when testing https://github.com/kubernetes-sigs/prow/pull/596

The runlocal script pulls pregenerated data from prow.k8s.io, which stores artifacts in the kubernetes-ci-logs GCS bucket. However, the local deck.yaml was not allowiwng access to `kubernetes-ci-logs` bucket, causing local Spyglass to fail when trying to fetch job artifacts from it, showing infinite spinner.

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>
