### PR TITLE
fix(tide): app-qualified author for bot PR details link

### DIFF
--- a/pkg/tide/status.go
+++ b/pkg/tide/status.go
@@ -394,7 +394,11 @@ func targetURL(c *config.Config, crc *CodeReviewCommon, log *logrus.Entry) strin
 		if err != nil {
 			log.WithError(err).Error("Failed to parse PR status base URL")
 		} else {
-			prQuery := fmt.Sprintf("is:pr repo:%s author:%s head:%s", pr.Repository.NameWithOwner, crc.AuthorLogin, crc.HeadRefName)
+			authorLogin := crc.AuthorLogin
+			if string(pr.AuthorMetadata.TypeName) == github.UserTypeBot && !strings.HasPrefix(authorLogin, "app/") {
+				authorLogin = "app/" + authorLogin
+			}
+			prQuery := fmt.Sprintf("is:pr repo:%s author:%s head:%s", pr.Repository.NameWithOwner, authorLogin, crc.HeadRefName)
 			values := parseURL.Query()
 			values.Set("query", prQuery)
 			parseURL.RawQuery = values.Encode()

--- a/pkg/tide/tide.go
+++ b/pkg/tide/tide.go
@@ -1916,6 +1916,9 @@ type PullRequest struct {
 	Author struct {
 		Login githubql.String
 	}
+	AuthorMetadata struct {
+		TypeName githubql.String `graphql:"__typename"`
+	} `graphql:"authorMetadata:author"`
 	BaseRef struct {
 		Name   githubql.String
 		Prefix githubql.String


### PR DESCRIPTION
  - add GraphQL `authorMetadata.__typename` to detect `bot` authors
  - build Tide PR dashboard query with `author:app/<login>` for bot PRs
  - keep non-bot behavior unchanged and avoid double `app/` prefix
  - extend existing `TestTargetUrl` coverage for bot author cases
  
  Fixes : #177 