### PR TITLE
feat(clonerefs): add sparse-checkout mode

### DIFF
--- a/config/prow/cluster/prowjob-crd/prowjob_customresourcedefinition.yaml
+++ b/config/prow/cluster/prowjob-crd/prowjob_customresourcedefinition.yaml
@@ -1716,6 +1716,20 @@ spec:
                         SkipSubmodules determines if submodules should be
                         cloned when the job is run. Defaults to false.
                       type: boolean
+                    sparse_checkout_files:
+                      description: |-
+                        SparseCheckoutFiles limits the working tree to only the listed paths.
+                        Accepts the same patterns as git sparse-checkout set: file names,
+                        directory names, and gitignore-style globs (e.g. "Makefile",
+                        "pkg/operator", "config/**/*.yaml").
+                        When set, clonerefs will:
+                          1. run git sparse-checkout init to enable sparse mode
+                          2. run git fetch with --depth 1 --filter=blob:none --no-tags
+                          3. run git sparse-checkout set <paths> before checkout
+                        Only the blobs needed for the requested paths are downloaded.
+                      items:
+                        type: string
+                      type: array
                     workdir:
                       description: |-
                         WorkDir defines if the location of the cloned
@@ -9800,6 +9814,20 @@ spec:
                       SkipSubmodules determines if submodules should be
                       cloned when the job is run. Defaults to false.
                     type: boolean
+                  sparse_checkout_files:
+                    description: |-
+                      SparseCheckoutFiles limits the working tree to only the listed paths.
+                      Accepts the same patterns as git sparse-checkout set: file names,
+                      directory names, and gitignore-style globs (e.g. "Makefile",
+                      "pkg/operator", "config/**/*.yaml").
+                      When set, clonerefs will:
+                        1. run git sparse-checkout init to enable sparse mode
+                        2. run git fetch with --depth 1 --filter=blob:none --no-tags
+                        3. run git sparse-checkout set <paths> before checkout
+                      Only the blobs needed for the requested paths are downloaded.
+                    items:
+                      type: string
+                    type: array
                   workdir:
                     description: |-
                       WorkDir defines if the location of the cloned

--- a/pkg/apis/prowjobs/v1/types.go
+++ b/pkg/apis/prowjobs/v1/types.go
@@ -1232,6 +1232,18 @@ type Refs struct {
 	// using the --filter=blob:none flag. If unspecified, defaults to
 	// DecorationConfig.BloblessFetch.
 	BloblessFetch *bool `json:"blobless_fetch,omitempty"`
+	// SparseCheckoutFiles limits the working tree to only the listed paths.
+	// Accepts the same patterns as git sparse-checkout set: file names,
+	// directory names, and gitignore-style globs (e.g. "Makefile",
+	// "pkg/operator", "config/**/*.yaml").
+	//
+	// When set, clonerefs will:
+	//   1. run git sparse-checkout init to enable sparse mode
+	//   2. run git fetch with --depth 1 --filter=blob:none --no-tags
+	//   3. run git sparse-checkout set <paths> before checkout
+	//
+	// Only the blobs needed for the requested paths are downloaded.
+	SparseCheckoutFiles []string `json:"sparse_checkout_files,omitempty"`
 }
 
 func (r Refs) String() string {

--- a/pkg/apis/prowjobs/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/prowjobs/v1/zz_generated.deepcopy.go
@@ -567,6 +567,11 @@ func (in *Refs) DeepCopyInto(out *Refs) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.SparseCheckoutFiles != nil {
+		in, out := &in.SparseCheckoutFiles, &out.SparseCheckoutFiles
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 


### PR DESCRIPTION
Adds `SparseCheckoutFiles` to Refs, which limits the working tree to specific files or directories without a full clone.                                                                                                               

  When set, clonerefs:
  - runs git sparse-checkout init + git fetch --filter=blob:none --no-tags --depth 1
  - applies git sparse-checkout set <paths> before checkout

  Benchmarked against kubernetes/kubernetes fetching a single Makefile:

| | time | RSS | files | disk |                                                                                                                                                                                                      
  |---|---|---|---|---|                                                                                                                                                                                                              
  | regular clone | 35s | 121 MB | 28,358 | 400 MB |                                                                                                                                                                                   
  | sparse checkout | 1.7s | 31 MB | 16 | 5 MB | 

  Usage:
  ```
  refs:
    org: kubernetes
    repo: kubernetes
    base_ref: main
    sparse_checkout_files:
      - Makefile
      - pkg/operator

