### PR TITLE
Expose `SearchV2JqlWithContext` via jira.Client interface

### DIFF
--- a/pkg/jira/fakejira/fake.go
+++ b/pkg/jira/fakejira/fake.go
@@ -356,8 +356,9 @@ func (f *FakeClient) UpdateStatus(issueID, statusName string) error {
 }
 
 type SearchRequest struct {
-	query   string
-	options *jira.SearchOptions
+	query     string
+	options   *jira.SearchOptions
+	optionsV2 *jira.SearchOptionsV2
 }
 
 type SearchResponse struct {
@@ -370,6 +371,14 @@ func (f *FakeClient) SearchWithContext(ctx context.Context, jql string, options 
 	resp, expected := f.SearchResponses[SearchRequest{query: jql, options: options}]
 	if !expected {
 		return nil, nil, fmt.Errorf("the query: %s is not registered", jql)
+	}
+	return resp.issues, resp.response, resp.error
+}
+
+func (f *FakeClient) SearchV2JqlWithContext(ctx context.Context, jql string, options *jira.SearchOptionsV2) ([]jira.Issue, *jira.Response, error) {
+	resp, expected := f.SearchResponses[SearchRequest{query: jql, optionsV2: options}]
+	if !expected {
+		return nil, nil, fmt.Errorf("the V2 query: %s is not registered", jql)
 	}
 	return resp.issues, resp.response, resp.error
 }


### PR DESCRIPTION
This PR adds the `SearchV2JqlWithContext` method to the `jira.Client` interface to expose it, directly, for downstream consumers. 

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED