### PR TITLE
feat(releaseNote): Make Release Note URL configurable

### DIFF
--- a/pkg/plugins/config.go
+++ b/pkg/plugins/config.go
@@ -530,14 +530,14 @@ type Heart struct {
 
 // ReleaseNote contains the configuration options for the release note plugin
 type ReleaseNote struct {
-	// URL is the URL to the release note documentation that users should follow.
-	// Defaults to the Kubernetes community release note guide.
-	URL string `json:"url,omitempty"`
+	// GuidelinesURL is the URL to the release note guidelines that users should follow
+	// Defaults to the Kubernetes community guide: https://git.k8s.io/community/contributors/guide/release-notes.md
+	GuidelinesURL string `json:"guidelines_url,omitempty"`
 }
 
 func (r *ReleaseNote) setDefaults() {
-	if r.URL == "" {
-		r.URL = "https://git.k8s.io/community/contributors/guide/release-notes.md"
+	if r.GuidelinesURL == "" {
+		r.GuidelinesURL = "https://git.k8s.io/community/contributors/guide/release-notes.md"
 	}
 }
 

--- a/pkg/plugins/plugin-config-documented.yaml
+++ b/pkg/plugins/plugin-config-documented.yaml
@@ -554,9 +554,9 @@ project_manager:
                           # State must be open, closed or all
                           state: ' '
 release_note:
-    # URL is the URL to the release note documentation that users should follow.
-    # Defaults to the Kubernetes community release note guide.
-    url: ' '
+    # GuidelinesURL is the URL to the release note guidelines that users should follow
+    # Defaults to the Kubernetes community guide: https://git.k8s.io/community/contributors/guide/release-notes.md
+    guidelines_url: ' '
 repo_milestone:
     "":
         maintainers_friendly_name: ' '

--- a/pkg/plugins/plugins_test.go
+++ b/pkg/plugins/plugins_test.go
@@ -253,7 +253,7 @@ func TestLoad(t *testing.T) {
 				HelpGuidelinesURL: "https://git.k8s.io/community/contributors/guide/help-wanted.md",
 			},
 			ReleaseNote: ReleaseNote{
-				URL: "https://git.k8s.io/community/contributors/guide/release-notes.md",
+				GuidelinesURL: "https://git.k8s.io/community/contributors/guide/release-notes.md",
 			},
 		}
 		for _, modify := range m {

--- a/pkg/plugins/releasenote/releasenote.go
+++ b/pkg/plugins/releasenote/releasenote.go
@@ -72,7 +72,7 @@ func init() {
 }
 
 func helpProvider(config *plugins.Configuration, _ []config.OrgRepo) (*pluginhelp.PluginHelp, error) {
-	url := config.ReleaseNote.URL
+	url := config.ReleaseNote.GuidelinesURL
 	pluginHelp := &pluginhelp.PluginHelp{
 		Description: `The releasenote plugin implements a release note process that uses a markdown 'release-note' code block to associate a release note with a pull request. Until the 'release-note' block in the pull request body is populated the PR will be assigned the '` + labels.ReleaseNoteLabelNeeded + `' label.
 <br>There are three valid types of release notes that can replace this label:
@@ -215,7 +215,7 @@ func removeOtherLabels(remover func(string) error, label string, labelSet []stri
 }
 
 func handlePullRequest(pc plugins.Agent, pr github.PullRequestEvent) error {
-	return handlePR(pc.GitHubClient, pc.Logger, pc.PluginConfig.ReleaseNote.URL, &pr)
+	return handlePR(pc.GitHubClient, pc.Logger, pc.PluginConfig.ReleaseNote.GuidelinesURL, &pr)
 }
 
 func shouldHandlePR(pr *github.PullRequestEvent) bool {

--- a/pkg/plugins/releasenote/releasenote_test.go
+++ b/pkg/plugins/releasenote/releasenote_test.go
@@ -273,16 +273,16 @@ func newFakeClient(body, branch string, initialLabels, comments []string, parent
 
 func TestReleaseNotePR(t *testing.T) {
 	tests := []struct {
-		name                 string
-		initialLabels        []string
-		body                 string
-		branch               string // Defaults to master
-		parentPRs            map[int]string
-		issueComments        []string
-		IssueLabelsAdded     []string
-		IssueLabelsRemoved   []string
-		merged               bool
-		expectedURLInComment string // If set, verify this URL appears in bot comment
+		name                           string
+		initialLabels                  []string
+		body                           string
+		branch                         string // Defaults to master
+		parentPRs                      map[int]string
+		issueComments                  []string
+		IssueLabelsAdded               []string
+		IssueLabelsRemoved             []string
+		merged                         bool
+		expectedGuidelinesURLInComment string // If set, overiddes default GuidelinesURL
 	}{
 		{
 			name:          "LGTM with release-note",
@@ -490,11 +490,11 @@ func TestReleaseNotePR(t *testing.T) {
 			IssueLabelsRemoved: []string{labels.ReleaseNoteLabelNeeded},
 		},
 		{
-			name:                 "release-note-none, with custom release note URL",
-			body:                 "",
-			initialLabels:        []string{},
-			IssueLabelsAdded:     []string{labels.ReleaseNoteLabelNeeded},
-			expectedURLInComment: "https://example.com/release-notes",
+			name:                           "release-note-none, with custom release note URL",
+			body:                           "",
+			initialLabels:                  []string{},
+			IssueLabelsAdded:               []string{labels.ReleaseNoteLabelNeeded},
+			expectedGuidelinesURLInComment: "https://example.com/release-notes",
 		},
 	}
 	for _, test := range tests {
@@ -504,28 +504,31 @@ func TestReleaseNotePR(t *testing.T) {
 		fc, pr := newFakeClient(test.body, test.branch, test.initialLabels, test.issueComments, test.parentPRs)
 		pr.PullRequest.Merged = test.merged
 
-		releaseNoteURL := "https://git.k8s.io/community/contributors/guide/release-notes.md"
-		if test.expectedURLInComment != "" {
-			releaseNoteURL = test.expectedURLInComment
+		releaseNoteGuidelinesURL := "https://git.k8s.io/community/contributors/guide/release-notes.md"
+		if test.expectedGuidelinesURLInComment != "" {
+			releaseNoteGuidelinesURL = test.expectedGuidelinesURLInComment
 		}
 
-		err := handlePR(fc, logrus.WithField("plugin", PluginName), releaseNoteURL, pr)
+		err := handlePR(fc, logrus.WithField("plugin", PluginName), releaseNoteGuidelinesURL, pr)
 		if err != nil {
 			t.Fatalf("Unexpected error from handlePR: %v", err)
 		}
 
-		// Verify expected URL appears in bot comment
-		if test.expectedURLInComment != "" {
+		// Verify the guidelines URL appears in bot comments when release-note-label-needed was added.
+		// Skip when deprecation label is present as it uses a different comment without the guidelines URL.
+		initialLabelSet := sets.New[string](test.initialLabels...)
+		addedLabelSet := sets.New[string](test.IssueLabelsAdded...)
+		if !initialLabelSet.Has(labels.DeprecationLabel) && addedLabelSet.Has(labels.ReleaseNoteLabelNeeded) {
 			found := false
 			for _, comment := range fc.IssueCommentsAdded {
-				if strings.Contains(comment, test.expectedURLInComment) {
+				if strings.Contains(comment, releaseNoteGuidelinesURL) {
 					found = true
 					break
 				}
 			}
 			if !found {
 				t.Errorf("(%s): Expected bot comment to contain URL %q, but it was not found in: %v",
-					test.name, test.expectedURLInComment, fc.IssueCommentsAdded)
+					test.name, releaseNoteGuidelinesURL, fc.IssueCommentsAdded)
 			}
 		}
 


### PR DESCRIPTION
Allow projects to configure a custom release note guide URL instead of the hardcoded Kubernetes community docs link.

- Add ReleaseNote.URL config field with default to existing K8s URL
- Use configured URL in bot comments directing users to a release note process
- Add test for custom URL in bot comments

Related [kubevirt/project-infra#4189](https://github.com/kubevirt/project-infra/issues/4189)

Fixes #634