### PR TITLE
Fix per-record tenant ID filtering for tide history in Deck

### DIFF
--- a/cmd/deck/main.go
+++ b/cmd/deck/main.go
@@ -1367,10 +1367,12 @@ func handleTideHistory(ta *tideAgent, log *logrus.Entry) http.HandlerFunc {
 
 		ta.Lock()
 		history := ta.history
+		hiddenRecords := ta.hiddenRecords
 		ta.Unlock()
 
 		payload := tideHistory{
-			History: history,
+			History:       history,
+			HiddenRecords: hiddenRecords,
 		}
 		pd, err := json.Marshal(payload)
 		if err != nil {

--- a/cmd/deck/static/api/tide-history.ts
+++ b/cmd/deck/static/api/tide-history.ts
@@ -2,6 +2,7 @@ import {Pull} from "../api/prow";
 
 export interface HistoryData {
   History: {[key: string]: Record[]};
+  HiddenRecords?: {[key: string]: number};
 }
 
 export interface Record {

--- a/cmd/deck/static/tide-history/tide-history.ts
+++ b/cmd/deck/static/tide-history/tide-history.ts
@@ -233,10 +233,27 @@ function redraw(): void {
   }
   // Sort by descending time.
   filteredRecs = filteredRecs.sort((a, b) => a.time > b.time ? -1 : (a.time < b.time ? 1 : 0));
-  redrawRecords(filteredRecs);
+
+  // Compute hidden record count for pools visible in the current view
+  const hiddenMap: {[key: string]: number} = typeof tideHistory !== 'undefined' && tideHistory.HiddenRecords ? tideHistory.HiddenRecords : {};
+  let totalHidden = 0;
+  for (const poolKey of poolKeys) {
+    const [repo, branch] = repoBranchFromPoolKey(poolKey);
+    if (repo === "") {
+      continue;
+    }
+    if (!equalSelected(repoSel, repo) || !equalSelected(branchSel, branch)) {
+      continue;
+    }
+    if (hiddenMap[poolKey]) {
+      totalHidden += hiddenMap[poolKey];
+    }
+  }
+
+  redrawRecords(filteredRecs, totalHidden);
 }
 
-function redrawRecords(recs: FilteredRecord[]): void {
+function redrawRecords(recs: FilteredRecord[], totalHidden: number): void {
   const records = document.getElementById("records")!.getElementsByTagName(
     "tbody")[0];
   while (records.firstChild) {
@@ -280,7 +297,11 @@ function redrawRecords(recs: FilteredRecord[]): void {
     records.appendChild(r);
   }
   const recCount = document.getElementById("record-count")!;
-  recCount.textContent = `Showing ${displayCount}/${recs.length} records`;
+  let countText = `Showing ${displayCount}/${recs.length} records`;
+  if (totalHidden > 0) {
+    countText += ` (${totalHidden} hidden by tenant filter)`;
+  }
+  recCount.textContent = countText;
 }
 
 function targetCell(rec: FilteredRecord): HTMLTableDataCellElement {

--- a/cmd/deck/tide.go
+++ b/cmd/deck/tide.go
@@ -187,23 +187,55 @@ func noTenantIDOrDefaultTenantID(ids []string) bool {
 	return true
 }
 
-func recordIDs(records []history.Record) sets.Set[string] {
-	res := sets.Set[string]{}
-	for _, record := range records {
-		res.Insert(record.TenantIDs...)
+func (ta *tideAgent) matchRecordIDs(rec history.Record, orgRepoID string) bool {
+	effectiveIDs := sets.New[string](rec.TenantIDs...)
+	if orgRepoID != "" && orgRepoID != config.DefaultTenantID {
+		effectiveIDs.Insert(orgRepoID)
 	}
-	return res
+	if len(ta.tenantIDs) > 0 {
+		return effectiveIDs.Len() > 0 && ta.tenantIDs.HasAll(sets.List(effectiveIDs)...)
+	}
+	return noTenantIDOrDefaultTenantID(sets.List(effectiveIDs))
 }
 
 func (ta *tideAgent) filterHistory(hist map[string][]history.Record) map[string][]history.Record {
 	filtered := make(map[string][]history.Record, len(hist))
 	for pool, records := range hist {
 		orgRepo := strings.Split(pool, ":")[0]
-		curIDs := recordIDs(records).Insert()
 		orgRepoID := ta.cfg().GetProwJobDefault(orgRepo, "*").TenantID
 		needsHide := matches(orgRepo, ta.hiddenRepos())
-		if match := ta.filter(orgRepoID, curIDs, needsHide); match {
-			filtered[pool] = records
+
+		// When Deck has no tenantIDs, use pool-level hidden/default logic (unchanged)
+		if len(ta.tenantIDs) == 0 {
+			if needsHide {
+				if ta.showHidden || ta.hiddenOnly {
+					filtered[pool] = records
+				}
+			} else if !ta.hiddenOnly {
+				// Compute pool-level IDs for the default-tenant check
+				poolIDs := sets.New[string]()
+				for _, rec := range records {
+					poolIDs.Insert(rec.TenantIDs...)
+				}
+				if orgRepoID != "" && orgRepoID != config.DefaultTenantID {
+					poolIDs.Insert(orgRepoID)
+				}
+				if noTenantIDOrDefaultTenantID(sets.List(poolIDs)) {
+					filtered[pool] = records
+				}
+			}
+			continue
+		}
+
+		// When Deck has tenantIDs, filter per-record
+		var kept []history.Record
+		for _, rec := range records {
+			if ta.matchRecordIDs(rec, orgRepoID) {
+				kept = append(kept, rec)
+			}
+		}
+		if len(kept) > 0 {
+			filtered[pool] = kept
 		}
 	}
 	return filtered

--- a/cmd/deck/tide.go
+++ b/cmd/deck/tide.go
@@ -40,7 +40,8 @@ type tidePools struct {
 }
 
 type tideHistory struct {
-	History map[string][]history.Record
+	History       map[string][]history.Record
+	HiddenRecords map[string]int `json:"HiddenRecords,omitempty"`
 }
 
 type tideAgent struct {
@@ -57,8 +58,9 @@ type tideAgent struct {
 	cfg       func() *config.Config
 
 	sync.Mutex
-	pools   []tide.Pool
-	history map[string][]history.Record
+	pools         []tide.Pool
+	history       map[string][]history.Record
+	hiddenRecords map[string]int
 }
 
 func (ta *tideAgent) start() {
@@ -151,11 +153,12 @@ func (ta *tideAgent) updateHistory() error {
 	if err := fetchTideData(ta.log, path, &history); err != nil {
 		return err
 	}
-	history = ta.filterHistory(history)
+	history, hiddenRecords := ta.filterHistory(history)
 
 	ta.Lock()
 	defer ta.Unlock()
 	ta.history = history
+	ta.hiddenRecords = hiddenRecords
 	return nil
 }
 
@@ -198,8 +201,9 @@ func (ta *tideAgent) matchRecordIDs(rec history.Record, orgRepoID string) bool {
 	return noTenantIDOrDefaultTenantID(sets.List(effectiveIDs))
 }
 
-func (ta *tideAgent) filterHistory(hist map[string][]history.Record) map[string][]history.Record {
+func (ta *tideAgent) filterHistory(hist map[string][]history.Record) (map[string][]history.Record, map[string]int) {
 	filtered := make(map[string][]history.Record, len(hist))
+	hidden := make(map[string]int)
 	for pool, records := range hist {
 		orgRepo := strings.Split(pool, ":")[0]
 		orgRepoID := ta.cfg().GetProwJobDefault(orgRepo, "*").TenantID
@@ -236,9 +240,12 @@ func (ta *tideAgent) filterHistory(hist map[string][]history.Record) map[string]
 		}
 		if len(kept) > 0 {
 			filtered[pool] = kept
+			if dropped := len(records) - len(kept); dropped > 0 {
+				hidden[pool] = dropped
+			}
 		}
 	}
-	return filtered
+	return filtered, hidden
 }
 
 func (ta *tideAgent) filter(orgRepoID string, curIDs sets.Set[string], needsHide bool) bool {

--- a/cmd/deck/tide.go
+++ b/cmd/deck/tide.go
@@ -196,7 +196,11 @@ func (ta *tideAgent) matchRecordIDs(rec history.Record, orgRepoID string) bool {
 		effectiveIDs.Insert(orgRepoID)
 	}
 	if len(ta.tenantIDs) > 0 {
-		return effectiveIDs.Len() > 0 && ta.tenantIDs.HasAll(sets.List(effectiveIDs)...)
+		// Records with no tenant IDs are treated as belonging to the default tenant
+		if effectiveIDs.Len() == 0 {
+			return ta.tenantIDs.Has(config.DefaultTenantID)
+		}
+		return ta.tenantIDs.HasAll(sets.List(effectiveIDs)...)
 	}
 	return noTenantIDOrDefaultTenantID(sets.List(effectiveIDs))
 }

--- a/cmd/deck/tide_test.go
+++ b/cmd/deck/tide_test.go
@@ -777,6 +777,50 @@ func TestFilter(t *testing.T) {
 			expectedHist:    map[string][]history.Record{},
 		},
 		{
+			name:      "per-record filtering: empty TenantIDs treated as default tenant",
+			cfg:       exampleConfigNoDefaults,
+			tenantIDs: []string{config.DefaultTenantID},
+			hist: map[string][]history.Record{
+				"unconfigured/repo:master": {
+					{Action: "TRIGGER", TenantIDs: []string{config.DefaultTenantID}},
+					{Action: "MERGE"},
+					{Action: "TRIGGER_BATCH", TenantIDs: []string{"qe-private"}},
+				},
+			},
+			expectedQueries: []config.TideQuery{},
+			expectedPools:   []tide.Pool{},
+			expectedHist: map[string][]history.Record{
+				"unconfigured/repo:master": {
+					{Action: "TRIGGER", TenantIDs: []string{config.DefaultTenantID}},
+					{Action: "MERGE"},
+				},
+			},
+			expectedHiddenRecords: map[string]int{
+				"unconfigured/repo:master": 1,
+			},
+		},
+		{
+			name:      "per-record filtering: empty TenantIDs hidden for non-default tenant",
+			cfg:       exampleConfigNoDefaults,
+			tenantIDs: []string{"t"},
+			hist: map[string][]history.Record{
+				"unconfigured/repo:master": {
+					{Action: "TRIGGER", TenantIDs: []string{"t"}},
+					{Action: "MERGE"},
+				},
+			},
+			expectedQueries: []config.TideQuery{},
+			expectedPools:   []tide.Pool{},
+			expectedHist: map[string][]history.Record{
+				"unconfigured/repo:master": {
+					{Action: "TRIGGER", TenantIDs: []string{"t"}},
+				},
+			},
+			expectedHiddenRecords: map[string]int{
+				"unconfigured/repo:master": 1,
+			},
+		},
+		{
 			name:      "per-record filtering: pool excluded when all records have non-matching IDs",
 			cfg:       exampleConfigNoDefaults,
 			tenantIDs: []string{"t"},

--- a/cmd/deck/tide_test.go
+++ b/cmd/deck/tide_test.go
@@ -535,7 +535,7 @@ func TestFilter(t *testing.T) {
 			},
 			expectedHist: map[string][]history.Record{
 				"tenanted/test:master":         {{Action: "TRIGGER_BATCH"}, {Action: "MERGE_BATCH"}},
-				"clustered-tenant/test:master": {{Action: "TRIGGER_BATCH", TenantIDs: []string{"t"}}, {Action: "MERGE_BATCH"}},
+				"clustered-tenant/test:master": {{Action: "TRIGGER_BATCH", TenantIDs: []string{"t"}}},
 			},
 		},
 		{
@@ -589,7 +589,7 @@ func TestFilter(t *testing.T) {
 			},
 			expectedHist: map[string][]history.Record{
 				"tenanted/test:master":         {{Action: "TRIGGER_BATCH"}, {Action: "MERGE_BATCH"}},
-				"clustered-tenant/test:master": {{Action: "TRIGGER_BATCH", TenantIDs: []string{"t"}}, {Action: "MERGE_BATCH"}},
+				"clustered-tenant/test:master": {{Action: "TRIGGER_BATCH", TenantIDs: []string{"t"}}},
 			},
 		},
 		{
@@ -732,6 +732,53 @@ func TestFilter(t *testing.T) {
 				"kubernetes/test-infra:master": {{Action: "MERGE", TenantIDs: []string{config.DefaultTenantID}}},
 				"upstream/no-prow-jobs:main":   {{Action: "MERGE"}},
 			},
+		},
+		{
+			name:      "per-record filtering: mixed tenant IDs keep only matching records",
+			cfg:       exampleConfigNoDefaults,
+			tenantIDs: []string{"t"},
+			hist: map[string][]history.Record{
+				"unconfigured/repo:master": {
+					{Action: "TRIGGER", TenantIDs: []string{"t"}},
+					{Action: "MERGE", TenantIDs: []string{config.DefaultTenantID, "qe-private"}},
+					{Action: "TRIGGER_BATCH", TenantIDs: []string{"t"}},
+				},
+			},
+			expectedQueries: []config.TideQuery{},
+			expectedPools:   []tide.Pool{},
+			expectedHist: map[string][]history.Record{
+				"unconfigured/repo:master": {
+					{Action: "TRIGGER", TenantIDs: []string{"t"}},
+					{Action: "TRIGGER_BATCH", TenantIDs: []string{"t"}},
+				},
+			},
+		},
+		{
+			name:      "per-record filtering: HasAll semantics - record excluded if Deck lacks any of its IDs",
+			cfg:       exampleConfigNoDefaults,
+			tenantIDs: []string{"t"},
+			hist: map[string][]history.Record{
+				"unconfigured/repo:master": {
+					{Action: "MERGE", TenantIDs: []string{"t", "other"}},
+				},
+			},
+			expectedQueries: []config.TideQuery{},
+			expectedPools:   []tide.Pool{},
+			expectedHist:    map[string][]history.Record{},
+		},
+		{
+			name:      "per-record filtering: pool excluded when all records have non-matching IDs",
+			cfg:       exampleConfigNoDefaults,
+			tenantIDs: []string{"t"},
+			hist: map[string][]history.Record{
+				"other/repo:master": {
+					{Action: "TRIGGER", TenantIDs: []string{"qe-private"}},
+					{Action: "MERGE", TenantIDs: []string{"something-else"}},
+				},
+			},
+			expectedQueries: []config.TideQuery{},
+			expectedPools:   []tide.Pool{},
+			expectedHist:    map[string][]history.Record{},
 		},
 	}
 

--- a/cmd/deck/tide_test.go
+++ b/cmd/deck/tide_test.go
@@ -106,9 +106,10 @@ func TestFilter(t *testing.T) {
 		hist        map[string][]history.Record
 		cfg         config.Config
 
-		expectedQueries []config.TideQuery
-		expectedPools   []tide.Pool
-		expectedHist    map[string][]history.Record
+		expectedQueries       []config.TideQuery
+		expectedPools         []tide.Pool
+		expectedHist          map[string][]history.Record
+		expectedHiddenRecords map[string]int
 	}{
 		{
 			name: "public frontend",
@@ -537,6 +538,9 @@ func TestFilter(t *testing.T) {
 				"tenanted/test:master":         {{Action: "TRIGGER_BATCH"}, {Action: "MERGE_BATCH"}},
 				"clustered-tenant/test:master": {{Action: "TRIGGER_BATCH", TenantIDs: []string{"t"}}},
 			},
+			expectedHiddenRecords: map[string]int{
+				"clustered-tenant/test:master": 1,
+			},
 		},
 		{
 			name: "tenantID on Deck ignores hidden repos",
@@ -590,6 +594,9 @@ func TestFilter(t *testing.T) {
 			expectedHist: map[string][]history.Record{
 				"tenanted/test:master":         {{Action: "TRIGGER_BATCH"}, {Action: "MERGE_BATCH"}},
 				"clustered-tenant/test:master": {{Action: "TRIGGER_BATCH", TenantIDs: []string{"t"}}},
+			},
+			expectedHiddenRecords: map[string]int{
+				"clustered-tenant/test:master": 1,
 			},
 		},
 		{
@@ -752,6 +759,9 @@ func TestFilter(t *testing.T) {
 					{Action: "TRIGGER_BATCH", TenantIDs: []string{"t"}},
 				},
 			},
+			expectedHiddenRecords: map[string]int{
+				"unconfigured/repo:master": 1,
+			},
 		},
 		{
 			name:      "per-record filtering: HasAll semantics - record excluded if Deck lacks any of its IDs",
@@ -798,7 +808,7 @@ func TestFilter(t *testing.T) {
 
 		gotQueries := ta.filterQueries(test.queries)
 		gotPools := ta.filterPools(test.pools)
-		gotHist := ta.filterHistory(test.hist)
+		gotHist, gotHiddenRecords := ta.filterHistory(test.hist)
 		if !equality.Semantic.DeepEqual(gotQueries, test.expectedQueries) {
 			t.Errorf("expected queries:\n%v\ngot queries:\n%v\n", test.expectedQueries, gotQueries)
 		}
@@ -809,6 +819,13 @@ func TestFilter(t *testing.T) {
 		// We don't care about that for this test.
 		if !reflect.DeepEqual(gotHist, test.expectedHist) {
 			t.Errorf("expected history:\n%v\ngot history:\n%v\n", test.expectedHist, gotHist)
+		}
+		// Normalize nil to empty map for comparison
+		if test.expectedHiddenRecords == nil {
+			test.expectedHiddenRecords = map[string]int{}
+		}
+		if !reflect.DeepEqual(gotHiddenRecords, test.expectedHiddenRecords) {
+			t.Errorf("expected hiddenRecords:\n%v\ngot hiddenRecords:\n%v\n", test.expectedHiddenRecords, gotHiddenRecords)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- **Fix per-record tenant filtering**: `filterHistory()` previously aggregated tenant IDs from all records in a pool and required all IDs to match Deck's configured set. A single record with a non-matching tenant ID caused the entire pool to be hidden. Now each record is checked independently: a pool appears if it has at least one matching record.
- **Add "records hidden" indicator**: When per-record filtering drops some records from a pool, the frontend now shows a count like `Showing 42/42 records (3 hidden by tenant filter)` so users know some records were filtered out.

## Test plan

- [x] `go test ./cmd/deck/ -run TestFilter -v` — all scenarios pass
- [x] `go build ./cmd/deck/` — compiles cleanly
- [ ] Manual verification on a Deck instance with tenant filtering configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)