### PR TITLE
Automate adding kind/* labels to cherry-pick PRs

### DIFF
--- a/cmd/external-plugins/cherrypicker/lib/lib.go
+++ b/cmd/external-plugins/cherrypicker/lib/lib.go
@@ -18,11 +18,12 @@ package cherrypicker
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 )
 
 // CreateCherrypickBody creates the body of a cherrypick PR
-func CreateCherrypickBody(num int, requestor, note string, chainBranches []string) string {
+func CreateCherrypickBody(num int, requestor, note string, chainBranches []string, kindLabels []string) string {
 	cherryPickBody := fmt.Sprintf("This is an automated cherry-pick of #%d", num)
 	if len(requestor) != 0 {
 		cherryPickBody = fmt.Sprintf("%s\n\n/assign %s", cherryPickBody, requestor)
@@ -32,6 +33,17 @@ func CreateCherrypickBody(num int, requestor, note string, chainBranches []strin
 	}
 	if len(chainBranches) != 0 {
 		cherryPickBody = fmt.Sprintf("%s\n\n/cherrypick %s", cherryPickBody, strings.Join(chainBranches, " "))
+	}
+	if len(kindLabels) > 0 {
+		// Sort for deterministic output
+		sorted := make([]string, len(kindLabels))
+		copy(sorted, kindLabels)
+		sort.Strings(sorted)
+		var kindLines []string
+		for _, name := range sorted {
+			kindLines = append(kindLines, fmt.Sprintf("/kind %s", name))
+		}
+		cherryPickBody = fmt.Sprintf("%s\n\n%s", cherryPickBody, strings.Join(kindLines, "\n"))
 	}
 	return cherryPickBody
 }

--- a/cmd/external-plugins/cherrypicker/server.go
+++ b/cmd/external-plugins/cherrypicker/server.go
@@ -69,7 +69,7 @@ type githubClient interface {
 // HelpProvider construct the pluginhelp.PluginHelp for this plugin.
 func HelpProvider(_ []config.OrgRepo) (*pluginhelp.PluginHelp, error) {
 	pluginHelp := &pluginhelp.PluginHelp{
-		Description: `The cherrypick plugin is used for cherrypicking PRs across branches. For every successful cherrypick invocation a new PR is opened against the target branch and assigned to the requester. If the parent PR contains a release note, it is copied to the cherrypick PR.`,
+		Description: `The cherrypick plugin is used for cherrypicking PRs across branches. For every successful cherrypick invocation a new PR is opened against the target branch and assigned to the requester. If the parent PR contains a release note, it is copied to the cherrypick PR. Kind labels (e.g. kind/bug, kind/cleanup) from the original PR are copied into the cherry-pick PR description as /kind commands so the bot can re-apply them.`,
 	}
 	pluginHelp.AddCommand(pluginhelp.Command{
 		Usage:       "/cherrypick [branch]",
@@ -582,11 +582,17 @@ func (s *Server) handle(logger logrus.FieldLogger, requester string, comment *gi
 	}
 
 	// Open a PR in GitHub.
+	var kindLabels []string
+	if labels, err := s.ghc.GetIssueLabels(org, repo, num); err != nil {
+		logger.WithError(err).Debug("Failed to get issue labels, omitting kind commands from cherry-pick PR body.")
+	} else {
+		kindLabels = kindLabelsFromIssueLabels(labels)
+	}
 	var cherryPickBody string
 	if s.prowAssignments {
-		cherryPickBody = cherrypicker.CreateCherrypickBody(num, requester, releaseNoteFromParentPR(body), chainBranches)
+		cherryPickBody = cherrypicker.CreateCherrypickBody(num, requester, releaseNoteFromParentPR(body), chainBranches, kindLabels)
 	} else {
-		cherryPickBody = cherrypicker.CreateCherrypickBody(num, "", releaseNoteFromParentPR(body), chainBranches)
+		cherryPickBody = cherrypicker.CreateCherrypickBody(num, "", releaseNoteFromParentPR(body), chainBranches, kindLabels)
 	}
 
 	head := fmt.Sprintf("%s:%s", pushOrg, newBranch)
@@ -717,4 +723,23 @@ func releaseNoteFromParentPR(body string) string {
 		return ""
 	}
 	return fmt.Sprintf("```release-note\n%s\n```", strings.TrimSpace(potentialMatch[1]))
+}
+
+const kindLabelPrefix = "kind/"
+
+// kindLabelsFromIssueLabels returns the kind names (without "kind/" prefix) from
+// the given labels, deduplicated and sorted. Labels that are not kind/* or have
+// an empty name after stripping the prefix are skipped.
+func kindLabelsFromIssueLabels(labels []github.Label) []string {
+	kindSet := sets.New[string]()
+	for _, label := range labels {
+		if !strings.HasPrefix(label.Name, kindLabelPrefix) {
+			continue
+		}
+		name := strings.TrimPrefix(label.Name, kindLabelPrefix)
+		if name != "" {
+			kindSet.Insert(name)
+		}
+	}
+	return sets.List(kindSet)
 }

--- a/cmd/external-plugins/cherrypicker/server_test.go
+++ b/cmd/external-plugins/cherrypicker/server_test.go
@@ -319,6 +319,10 @@ func testCherryPickIC(clients localgit.Clients, t *testing.T) {
 				Title:  "This is a fix for X",
 				Body:   body,
 			},
+			prLabels: []github.Label{
+				{Name: "kind/cleanup"},
+				{Name: "kind/bug"},
+			},
 			isMember: true,
 			patch:    patch,
 		}
@@ -345,7 +349,7 @@ func testCherryPickIC(clients localgit.Clients, t *testing.T) {
 			},
 		}
 		expectedTitle := "[stage] This is a fix for X"
-		expectedBody := fmt.Sprintf("This is an automated cherry-pick of #%d\n\n/assign wiseguy\n\n```release-note\nUpdate the magic number from 42 to 49\n```", iNumber)
+		expectedBody := fmt.Sprintf("This is an automated cherry-pick of #%d\n\n/assign wiseguy\n\n```release-note\nUpdate the magic number from 42 to 49\n```\n\n/kind bug\n/kind cleanup", iNumber)
 		expectedBase := "stage"
 		expectedHead := fmt.Sprintf(botUser.Login+":"+cherryPickBranchFmt, iNumber, expectedBase)
 		expectedLabels := []string{}

--- a/pkg/plugins/bugzilla/bugzilla_test.go
+++ b/pkg/plugins/bugzilla/bugzilla_test.go
@@ -2244,7 +2244,7 @@ func TestGetCherrypickPRMatch(t *testing.T) {
 	}
 	for _, testCase := range testCases {
 		testPR := *pr
-		testPR.PullRequest.Body = cherrypicker.CreateCherrypickBody(prNum, testCase.requestor, testCase.note, []string{})
+		testPR.PullRequest.Body = cherrypicker.CreateCherrypickBody(prNum, testCase.requestor, testCase.note, []string{}, nil)
 		cherrypick, cherrypickOfPRNum, cherrypickTo, err := getCherryPickMatch(testPR)
 		if err != nil {
 			t.Fatalf("%s: Got error but did not expect one: %v", testCase.name, err)


### PR DESCRIPTION
**What type of PR is this?**
/kind feature
**What this PR does / why we need it:**
When the cherrypicker plugin creates a cherry-pick PR, it now copies kind/* labels from the original PR into the new PR’s body as /kind commands (e.g. /kind cleanup, /kind bug). The repo’s bot can then apply the same kind/* labels on the cherry-pick PR, so maintainers don’t have to add them manually.
This matches the behavior introduced for the manual cherry-pick flow in kubernetes/kubernetes (e.g. kubernetes/kubernetes#137051).