### PR TITLE
feat(decoration): add SparseCheckoutFiles to DecorationConfig

### DIFF
--- a/config/prow/cluster/prowjob-crd/prowjob_customresourcedefinition.yaml
+++ b/config/prow/cluster/prowjob-crd/prowjob_customresourcedefinition.yaml
@@ -1559,6 +1559,16 @@ spec:
                       SkipCloning determines if we should clone source code in the
                       initcontainers for jobs that specify refs
                     type: boolean
+                  sparse_checkout_files:
+                    description: |-
+                      SparseCheckoutFiles limits the working tree to only the listed paths.
+                      Accepts the same patterns as git sparse-checkout set (file names,
+                      directory names, gitignore-style globs). When set, clonerefs performs a
+                      sparse checkout instead of a full clone. Applied to the primary ref for
+                      presubmit/postsubmit jobs. Not applied to extra refs.
+                    items:
+                      type: string
+                    type: array
                   ssh_host_fingerprints:
                     description: |-
                       SSHHostFingerprints are the fingerprints of known SSH hosts

--- a/pkg/apis/prowjobs/v1/types.go
+++ b/pkg/apis/prowjobs/v1/types.go
@@ -502,6 +502,12 @@ type DecorationConfig struct {
 	// BloblessFetch tells Prow to avoid fetching objects when cloning using
 	// the --filter=blob:none flag.
 	BloblessFetch *bool `json:"blobless_fetch,omitempty"`
+	// SparseCheckoutFiles limits the working tree to only the listed paths.
+	// Accepts the same patterns as git sparse-checkout set (file names,
+	// directory names, gitignore-style globs). When set, clonerefs performs a
+	// sparse checkout instead of a full clone. Applied to the primary ref for
+	// presubmit/postsubmit jobs. Not applied to extra refs.
+	SparseCheckoutFiles []string `json:"sparse_checkout_files,omitempty"`
 	// SkipCloning determines if we should clone source code in the
 	// initcontainers for jobs that specify refs
 	SkipCloning *bool `json:"skip_cloning,omitempty"`
@@ -852,6 +858,9 @@ func (d *DecorationConfig) ApplyDefault(def *DecorationConfig) *DecorationConfig
 
 	if merged.BloblessFetch == nil {
 		merged.BloblessFetch = def.BloblessFetch
+	}
+	if len(merged.SparseCheckoutFiles) == 0 {
+		merged.SparseCheckoutFiles = def.SparseCheckoutFiles
 	}
 	if merged.SchedulingOptions == nil {
 		merged.SchedulingOptions = def.SchedulingOptions

--- a/pkg/apis/prowjobs/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/prowjobs/v1/zz_generated.deepcopy.go
@@ -129,6 +129,11 @@ func (in *DecorationConfig) DeepCopyInto(out *DecorationConfig) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.SparseCheckoutFiles != nil {
+		in, out := &in.SparseCheckoutFiles, &out.SparseCheckoutFiles
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.SkipCloning != nil {
 		in, out := &in.SkipCloning, &out.SkipCloning
 		*out = new(bool)

--- a/pkg/config/prow-config-documented.yaml
+++ b/pkg/config/prow-config-documented.yaml
@@ -921,6 +921,13 @@ plank:
             # SkipCloning determines if we should clone source code in the
             # initcontainers for jobs that specify refs
             skip_cloning: false
+            # SparseCheckoutFiles limits the working tree to only the listed paths.
+            # Accepts the same patterns as git sparse-checkout set (file names,
+            # directory names, gitignore-style globs). When set, clonerefs performs a
+            # sparse checkout instead of a full clone. Applied to the primary ref for
+            # presubmit/postsubmit jobs. Not applied to extra refs.
+            sparse_checkout_files:
+                - ""
             # SSHHostFingerprints are the fingerprints of known SSH hosts
             # that the cloning process can trust.
             # Create with ssh-keyscan [-t rsa] host
@@ -1282,6 +1289,13 @@ plank:
             # SkipCloning determines if we should clone source code in the
             # initcontainers for jobs that specify refs
             skip_cloning: false
+            # SparseCheckoutFiles limits the working tree to only the listed paths.
+            # Accepts the same patterns as git sparse-checkout set (file names,
+            # directory names, gitignore-style globs). When set, clonerefs performs a
+            # sparse checkout instead of a full clone. Applied to the primary ref for
+            # presubmit/postsubmit jobs. Not applied to extra refs.
+            sparse_checkout_files:
+                - ""
             # SSHHostFingerprints are the fingerprints of known SSH hosts
             # that the cloning process can trust.
             # Create with ssh-keyscan [-t rsa] host

--- a/pkg/pjutil/pjutil.go
+++ b/pkg/pjutil/pjutil.go
@@ -288,7 +288,11 @@ func CompletePrimaryRefs(refs prowapi.Refs, jb config.JobBase) *prowapi.Refs {
 	if jb.SkipFetchHead {
 		refs.SkipFetchHead = jb.SkipFetchHead
 	}
-	return DecorateRefs(refs, jb)
+	drefs := DecorateRefs(refs, jb)
+	if dc := jb.DecorationConfig; dc != nil && len(dc.SparseCheckoutFiles) > 0 {
+		drefs.SparseCheckoutFiles = dc.SparseCheckoutFiles
+	}
+	return drefs
 }
 
 // PartitionActive separates the provided prowjobs into pending and triggered

--- a/pkg/pjutil/pjutil_test.go
+++ b/pkg/pjutil/pjutil_test.go
@@ -349,6 +349,27 @@ func TestCompletePrimaryRefs(t *testing.T) {
 				CloneDepth: 2,
 			},
 		},
+		{
+			name: "sparse checkout files from decoration config are applied to ref",
+			refs: prowapi.Refs{
+				Org:     "org",
+				Repo:    "repo",
+				BaseRef: "main",
+			},
+			jobBase: config.JobBase{
+				UtilityConfig: config.UtilityConfig{
+					DecorationConfig: &prowapi.DecorationConfig{
+						SparseCheckoutFiles: []string{"Dockerfile"},
+					},
+				},
+			},
+			expected: prowapi.Refs{
+				Org:                 "org",
+				Repo:                "repo",
+				BaseRef:             "main",
+				SparseCheckoutFiles: []string{"Dockerfile"},
+			},
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
Add `SparseCheckoutFiles` field to `DecorationConfig` to allow jobs to set/limit the working tree to only the paths needed. The field is propagated only to the primary ref (presubmit/postsubmit) via `CompletePrimaryRefs` and is not applied to extra refs. 

Follow up of: https://github.com/kubernetes-sigs/prow/pull/626