### PR TITLE
tide: surface all merge errors in history dashboard

### DIFF
--- a/pkg/tide/github.go
+++ b/pkg/tide/github.go
@@ -242,8 +242,7 @@ func (gi *GitHubProvider) prepareMergeDetails(commitTemplates config.TideMergeCo
 
 func (gi *GitHubProvider) mergePRs(sp subpool, prs []CodeReviewCommon, dontUpdateStatus *threadSafePRSet) ([]CodeReviewCommon, error) {
 	var merged []CodeReviewCommon
-	var failed []int
-	var errs []error
+	var errs []mergeErr
 	log := sp.log.WithField("merge-targets", prNumbers(prs))
 	tideConfig := gi.cfg().Tide
 	tideContextPolicy := config.ParseTideContextPolicyOptions(sp.org, sp.repo, sp.branch, tideConfig.ContextOptions)
@@ -255,8 +254,7 @@ func (gi *GitHubProvider) mergePRs(sp subpool, prs []CodeReviewCommon, dontUpdat
 		if mergeMethod == nil {
 			err := fmt.Errorf("multiple merge method labels found for %s/%s#%d", sp.org, sp.repo, pr.Number)
 			log.WithError(err).Error("Multiple merge method labels are not supported.")
-			errs = append(errs, err)
-			failed = append(failed, pr.Number)
+			errs = append(errs, mergeErr{err: err, pr: pr.Number, userFacing: true, operatorFacing: true})
 			continue
 		}
 
@@ -265,8 +263,7 @@ func (gi *GitHubProvider) mergePRs(sp subpool, prs []CodeReviewCommon, dontUpdat
 		dontUpdateStatus.insert(sp.org, sp.repo, pr.Number)
 		if err := setTideStatusSuccess(pr, gi.ghc, gi.cfg(), log); err != nil {
 			log.WithError(err).Error("Unable to set tide context to SUCCESS.")
-			errs = append(errs, err)
-			failed = append(failed, pr.Number)
+			errs = append(errs, mergeErr{err: err, pr: pr.Number, operatorFacing: true})
 			continue
 		}
 
@@ -275,8 +272,7 @@ func (gi *GitHubProvider) mergePRs(sp subpool, prs []CodeReviewCommon, dontUpdat
 			log.Infof("%d Contexts of pending presubmit jobs will be overwritten", i)
 			if err := gi.overwriteProwJobContextsWithStatusSuccess(pr, prowJobsForPRs[pr.Number], log); err != nil {
 				log.WithError(err).Error("Unable to set contexts of pending presubmit jobs to SUCCESS.")
-				errs = append(errs, err)
-				failed = append(failed, pr.Number)
+				errs = append(errs, mergeErr{err: err, pr: pr.Number, operatorFacing: true})
 				continue
 			}
 		}
@@ -287,8 +283,8 @@ func (gi *GitHubProvider) mergePRs(sp subpool, prs []CodeReviewCommon, dontUpdat
 			return gi.ghc.Merge(sp.org, sp.repo, pr.Number, ghMergeDetails)
 		})
 		if err != nil {
-			// These are user errors, shouldn't be printed as tide errors
 			log.WithError(err).Debug("Merge failed.")
+			errs = append(errs, mergeErr{err: err, pr: pr.Number, userFacing: true})
 		} else {
 			log.Info("Merged.")
 			merged = append(merged, pr)
@@ -307,7 +303,6 @@ func (gi *GitHubProvider) mergePRs(sp subpool, prs []CodeReviewCommon, dontUpdat
 		return merged, nil
 	}
 
-	// Construct a more informative error.
 	var batch string
 	if len(prs) > 1 {
 		batch = fmt.Sprintf(" from batch %v", prNumbers(prs))
@@ -315,7 +310,7 @@ func (gi *GitHubProvider) mergePRs(sp subpool, prs []CodeReviewCommon, dontUpdat
 			batch = fmt.Sprintf("%s, partial merge %v", batch, prNumbers(merged))
 		}
 	}
-	return merged, fmt.Errorf("failed merging %v%s: %w", failed, batch, utilerrors.NewAggregate(errs))
+	return merged, &mergeFailure{errs: errs, batch: batch}
 }
 
 // headContexts gets the status contexts for the commit with OID == pr.HeadRefOID

--- a/pkg/tide/tide.go
+++ b/pkg/tide/tide.go
@@ -1358,6 +1358,65 @@ func prHasSuccessfulTideStatusContext(pr CodeReviewCommon) bool {
 	return false
 }
 
+// mergeErr represents a single categorized merge error for a specific PR.
+// Every error must be at least one of userFacing or operatorFacing.
+type mergeErr struct {
+	err            error
+	pr             int
+	userFacing     bool // include message in Tide history for PR authors
+	operatorFacing bool // surface through error-level logs and poolErrors metric
+}
+
+// mergeFailure aggregates categorized merge errors with audience-aware
+// reporting. Error() returns the full message. historyMessage() returns
+// user-appropriate text (with placeholders for operator-only errors).
+// operatorError() returns only operator-facing errors for metrics and logs.
+type mergeFailure struct {
+	errs  []mergeErr
+	batch string // batch context (e.g. " from batch [1 2 3], partial merge [1]")
+}
+
+func (mf *mergeFailure) failedPRs() []int {
+	prs := make([]int, 0, len(mf.errs))
+	for _, me := range mf.errs {
+		prs = append(prs, me.pr)
+	}
+	return prs
+}
+
+func (mf *mergeFailure) Error() string {
+	msgs := make([]string, 0, len(mf.errs))
+	for _, me := range mf.errs {
+		msgs = append(msgs, fmt.Sprintf("#%d: %v", me.pr, me.err))
+	}
+	return fmt.Sprintf("failed merging %v%s: %s", mf.failedPRs(), mf.batch, strings.Join(msgs, "; "))
+}
+
+func (mf *mergeFailure) historyMessage() string {
+	msgs := make([]string, 0, len(mf.errs))
+	for _, me := range mf.errs {
+		if me.userFacing {
+			msgs = append(msgs, fmt.Sprintf("#%d: %v", me.pr, me.err))
+		} else {
+			msgs = append(msgs, fmt.Sprintf("#%d: merge error (contact Prow admin)", me.pr))
+		}
+	}
+	return fmt.Sprintf("failed merging %v%s: %s", mf.failedPRs(), mf.batch, strings.Join(msgs, "; "))
+}
+
+func (mf *mergeFailure) operatorError() error {
+	var msgs []string
+	for _, me := range mf.errs {
+		if me.operatorFacing {
+			msgs = append(msgs, fmt.Sprintf("#%d: %v", me.pr, me.err))
+		}
+	}
+	if len(msgs) == 0 {
+		return nil
+	}
+	return fmt.Errorf("failed merging %v%s: %s", mf.failedPRs(), mf.batch, strings.Join(msgs, "; "))
+}
+
 // tryMerge attempts 1 merge and returns a bool indicating if we should try
 // to merge the remaining PRs and possibly an error.
 //
@@ -1740,7 +1799,11 @@ func (c *syncController) syncSubpool(sp subpool, blocks []blockers.Blocker) (Poo
 	} else {
 		act, targets, err = c.takeAction(sp, batchPending, successes, pendings, missings, batchMerge, missingSerialTests)
 		if err != nil {
-			errorString = err.Error()
+			if mf, ok := err.(*mergeFailure); ok {
+				errorString = mf.historyMessage()
+			} else {
+				errorString = err.Error()
+			}
 		}
 		if recordableActions[act] {
 			c.History.Record(
@@ -1752,6 +1815,16 @@ func (c *syncController) syncSubpool(sp subpool, blocks []blockers.Blocker) (Poo
 				tenantIDs,
 			)
 		}
+	}
+
+	// Extract only operator-facing errors for metrics and logs.
+	// All errors (including user-facing) are already recorded in Tide
+	// history above via errorString.
+	var operatorErr error
+	if mf, ok := err.(*mergeFailure); ok {
+		operatorErr = mf.operatorError()
+	} else {
+		operatorErr = err
 	}
 
 	sp.log.WithFields(logrus.Fields{
@@ -1786,7 +1859,7 @@ func (c *syncController) syncSubpool(sp subpool, blocks []blockers.Blocker) (Poo
 
 			TenantIDs: tenantIDs,
 		},
-		err
+		operatorErr
 }
 
 func prMeta(prs ...CodeReviewCommon) []prowapi.Pull {

--- a/pkg/tide/tide_test.go
+++ b/pkg/tide/tide_test.go
@@ -1549,6 +1549,7 @@ func testTakeAction(clients localgit.Clients, t *testing.T) {
 		triggered        int
 		triggeredBatches int
 		action           Action
+		expectErr        bool
 	}{
 		{
 			name: "no prs to test, should do nothing",
@@ -1903,6 +1904,7 @@ func testTakeAction(clients localgit.Clients, t *testing.T) {
 			merged:      2,
 			triggered:   0,
 			action:      MergeBatch,
+			expectErr:   true,
 		},
 		{
 			name: "batch merge errors but continues if a PR has changed",
@@ -1912,6 +1914,7 @@ func testTakeAction(clients localgit.Clients, t *testing.T) {
 			merged:      2,
 			triggered:   0,
 			action:      MergeBatch,
+			expectErr:   true,
 		},
 		{
 			name: "batch merge errors but continues on unknown error",
@@ -1921,6 +1924,7 @@ func testTakeAction(clients localgit.Clients, t *testing.T) {
 			merged:      2,
 			triggered:   0,
 			action:      MergeBatch,
+			expectErr:   true,
 		},
 		{
 			name: "batch merge stops on auth error",
@@ -1930,6 +1934,7 @@ func testTakeAction(clients localgit.Clients, t *testing.T) {
 			merged:      1,
 			triggered:   0,
 			action:      MergeBatch,
+			expectErr:   true,
 		},
 		{
 			name: "batch merge stops on invalid merge method error",
@@ -1939,6 +1944,7 @@ func testTakeAction(clients localgit.Clients, t *testing.T) {
 			merged:      1,
 			triggered:   0,
 			action:      MergeBatch,
+			expectErr:   true,
 		},
 		{
 			name: "pending batch, should trigger serial in scheduling state",
@@ -2103,8 +2109,32 @@ func testTakeAction(clients localgit.Clients, t *testing.T) {
 			if tc.batchPending {
 				batchPending = []CodeReviewCommon{{}}
 			}
-			if act, _, _ := c.takeAction(sp, batchPending, genPulls(tc.successes), genPulls(tc.pendings), genPulls(tc.nones), genPulls(tc.batchMerges), sp.presubmits); act != tc.action {
+			act, _, err := c.takeAction(sp, batchPending, genPulls(tc.successes), genPulls(tc.pendings), genPulls(tc.nones), genPulls(tc.batchMerges), sp.presubmits)
+			if act != tc.action {
 				t.Errorf("Wrong action. Got %v, wanted %v.", act, tc.action)
+			}
+			if tc.expectErr && err == nil {
+				t.Error("Expected an error from takeAction, got nil.")
+			} else if !tc.expectErr && err != nil {
+				t.Errorf("Unexpected error from takeAction: %v", err)
+			}
+			if tc.expectErr && err != nil {
+				mf, ok := err.(*mergeFailure)
+				if !ok {
+					t.Errorf("Expected error to be *mergeFailure, got %T", err)
+				} else {
+					if mf.operatorError() != nil {
+						t.Errorf("Expected no operator errors for user merge errors, got: %v", mf.operatorError())
+					}
+					if mf.historyMessage() == "" {
+						t.Error("Expected non-empty history message")
+					}
+					for _, me := range mf.errs {
+						if !me.userFacing {
+							t.Errorf("Expected all merge errors to be user-facing, PR #%d is not", me.pr)
+						}
+					}
+				}
 			}
 
 			prowJobs := &prowapi.ProwJobList{}


### PR DESCRIPTION
Various Tide failures are hard to troubleshoot because many are not surfaced anywhere; they are treated as "user errors" and only logged at debug:

https://github.com/kubernetes-sigs/prow/blob/af120b0c1a42eaae8f57a5376079801d2470fd77/pkg/tide/github.go#L290-L291

```go
keepTrying, err := tryMerge(...)
if err != nil {
	// These are user errors, shouldn't be printed as tide errors
	log.WithError(err).Debug("Merge failed.")
} else ...
```

This felt weird to me so I was digging in the history and discovered these were intentionally suppressed long time ago by this pair of PRs:

https://github.com/kubernetes/test-infra/pull/19437
https://github.com/kubernetes/test-infra/pull/19478

There is not much context in the PRs but apparently the problems was that failed merges caused by repository misconfiguration (like strict branch protection config not allowing PRs to merge) were causing noise for Tide
admins by propagating them into error logs and metrics. The PRs suggest the failures "should be surfaced somewhere on users side".

They actually were: in Tide history dashboard - notice the `Error` column. This column would get populated from `takeAction` error that was actually `nil` in most cases - even if merge actually failed.

This PR addresses this by providing an error type that carries metadata about whether a merge error is user-facing or admin-facing (it can be both). All errors that previously propagated to error logs/metrics are now admin-facing, and some are user-facing too. All errors that werepreviously swallowed are now user-facing.

All admin-facing errors propagate to error metrics and logs, like before. All user-facing errors propagate to merge history. Errors that are admin facing but not user-facing will still propagate to merge history as failures, but with a placeholder message instead of the original one.

Error classifications:
- tryMerge errors (conflicts, modified head, unmergeable): user-facing
- Multiple merge method labels: both user and operator-facing
- Status context / prow job context API failures: operator-facing only

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
