### PR TITLE
deps(go): bump go from 1.25.5 -> 1.25.8

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/prow
 
-go 1.25.7
+go 1.25.8
 
 require (
 	cloud.google.com/go/cloudbuild v1.22.0


### PR DESCRIPTION

Latest go version had some security patches

- 1.25.8 https://groups.google.com/g/golang-nuts/c/NgsVkcokGF4
- 1.25.7 https://groups.google.com/g/golang-nuts/c/05wEerWuZVU