### PR TITLE
Add "ok-to-test cancel" command

### DIFF
--- a/pkg/pjutil/filter.go
+++ b/pkg/pjutil/filter.go
@@ -37,6 +37,9 @@ var RetestRequiredRe = regexp.MustCompile(`(?m)^/retest-required\s*$`)
 
 var OkToTestRe = regexp.MustCompile(`(?m)^/ok-to-test\s*$`)
 
+// OkToTestCancelRe checks for cancellation of the `/ok-to-test` approval
+var OkToTestCancelRe = regexp.MustCompile(`(?m)^/ok-to-test\s+cancel\s*$`)
+
 // AvailablePresubmits returns 3 sets of presubmits:
 // 1. presubmits that can be run with '/test all' command.
 // 2. optional presubmits commands that can be run with their trigger, e.g. '/test job'

--- a/pkg/plugins/trigger/generic-comment.go
+++ b/pkg/plugins/trigger/generic-comment.go
@@ -63,22 +63,9 @@ func handleGenericComment(c Client, cp commentPruner, trigger plugins.Trigger, g
 
 	// Skip comments not germane to this plugin
 	textToCheck := markdown.DropCodeBlock(gc.Body)
-	if !pjutil.RetestRe.MatchString(textToCheck) &&
-		!pjutil.RetestRequiredRe.MatchString(textToCheck) &&
-		!pjutil.OkToTestRe.MatchString(textToCheck) &&
-		!pjutil.TestAllRe.MatchString(textToCheck) &&
-		!pjutil.MayNeedHelpComment(textToCheck) {
-		matched := false
-		for _, presubmit := range presubmits {
-			matched = matched || presubmit.TriggerMatches(textToCheck)
-			if matched {
-				break
-			}
-		}
-		if !matched {
-			c.Logger.Debug("Comment doesn't match any triggering regex, skipping.")
-			return nil
-		}
+	if !commentMatchesTrigger(textToCheck, presubmits) {
+		c.Logger.Debug("Comment doesn't match any triggering regex, skipping.")
+		return nil
 	}
 
 	// Skip untrusted users comments.
@@ -126,6 +113,25 @@ func handleGenericComment(c Client, cp commentPruner, trigger plugins.Trigger, g
 		if err := c.GitHubClient.RemoveLabel(org, repo, number, labels.NeedsOkToTest); err != nil {
 			return err
 		}
+	}
+
+	isOkToTestCancel := HonorOkToTest(trigger) && pjutil.OkToTestCancelRe.MatchString(textToCheck)
+	if isOkToTestCancel {
+		if !trustedResponse.IsTrusted {
+			resp := "Only trusted users can revoke `/ok-to-test`."
+			return c.GitHubClient.CreateComment(org, repo, number, plugins.FormatResponseRaw(gc.Body, gc.HTMLURL, gc.User.Login, resp))
+		}
+		if github.HasLabel(labels.OkToTest, l) {
+			if err := c.GitHubClient.RemoveLabel(org, repo, number, labels.OkToTest); err != nil {
+				return err
+			}
+		}
+		if !github.HasLabel(labels.NeedsOkToTest, l) {
+			if err := c.GitHubClient.AddLabel(org, repo, number, labels.NeedsOkToTest); err != nil {
+				return err
+			}
+		}
+		return nil
 	}
 
 	pr, err := refGetter.PullRequest()
@@ -202,6 +208,26 @@ func handleGenericComment(c Client, cp commentPruner, trigger plugins.Trigger, g
 
 func HonorOkToTest(trigger plugins.Trigger) bool {
 	return !trigger.IgnoreOkToTest
+}
+
+// commentMatchesTrigger reports whether the comment text is relevant to the
+// trigger plugin - i.e. it contains a known trigger command or matches a
+// presubmit trigger pattern.
+func commentMatchesTrigger(text string, presubmits []config.Presubmit) bool {
+	if pjutil.RetestRe.MatchString(text) ||
+		pjutil.RetestRequiredRe.MatchString(text) ||
+		pjutil.OkToTestRe.MatchString(text) ||
+		pjutil.OkToTestCancelRe.MatchString(text) ||
+		pjutil.TestAllRe.MatchString(text) ||
+		pjutil.MayNeedHelpComment(text) {
+		return true
+	}
+	for _, presubmit := range presubmits {
+		if presubmit.TriggerMatches(text) {
+			return true
+		}
+	}
+	return false
 }
 
 type GitHubClient interface {

--- a/pkg/plugins/trigger/trigger.go
+++ b/pkg/plugins/trigger/trigger.go
@@ -107,6 +107,7 @@ func helpProvider(config *plugins.Configuration, enabledRepos []config.OrgRepo) 
 		Description: `The trigger plugin starts jobs in reaction to various events.
 <br>Presubmit jobs are run automatically on pull requests that are trusted and not in a draft state with file changes matching the file filters and targeting a branch matching the branch filters.
 <br>A pull request is considered trusted if the author is a member of the 'trusted organization' for the repository or if such a member has left an '/ok-to-test' command on the PR.
+<br>Trusted status granted by '/ok-to-test' can be revoked by a trusted user with '/ok-to-test cancel', which restores the 'needs-ok-to-test' label.
 <br>Trigger will not automatically start jobs for a PR in draft state, and if a PR is changed to draft it cancels pending jobs.
 <br>If jobs are not run automatically for a PR because it is not trusted or is in draft state, a trusted user can still start jobs manually via the '/test' command.
 <br>The '/retest' command can be used to rerun jobs that have reported failure.
@@ -120,6 +121,13 @@ func helpProvider(config *plugins.Configuration, enabledRepos []config.OrgRepo) 
 		Featured:    false,
 		WhoCanUse:   "Members of the trusted organization for the repo.",
 		Examples:    []string{"/ok-to-test"},
+	})
+	pluginHelp.AddCommand(pluginhelp.Command{
+		Usage:       "/ok-to-test cancel",
+		Description: "Revokes trusted status previously granted by '/ok-to-test', removing the 'ok-to-test' label and restoring 'needs-ok-to-test'.",
+		Featured:    false,
+		WhoCanUse:   "Members of the trusted organization for the repo.",
+		Examples:    []string{"/ok-to-test cancel"},
 	})
 	pluginHelp.AddCommand(pluginhelp.Command{
 		Usage:       "/test [<job name>|all]",


### PR DESCRIPTION
Once "/ok-to-test" has been granted on a PR, and subsequent updates to that PR will trigger jobs to run again. Particularly with the increase of fully AI agent driven PRs, this could mean the agent can very quickly iterate on a PR and cause massive CI overhead.

It can also be a security issue that someone can start with a small, innocuous change, then once approved to run tests push changes they shouldn't be.

In either case, we want the ability to revoke the ok-to-test after it's been granted. There currently isn't any way exposed to do that. This adds a "cancel" command to match the existing pattern used for other commands ("lgtm cancel", "hold cancel", etc).

Closes: #652