### PR TITLE
tide: remove per-presubmit debug log that dominates log output

### DIFF
--- a/pkg/tide/tide.go
+++ b/pkg/tide/tide.go
@@ -1711,7 +1711,6 @@ func (c *syncController) presubmitsByPull(sp *subpool) (map[int][]config.Presubm
 				return nil, err
 			}
 			if !shouldRun {
-				log.WithField("context", ps.Context).Debug("Presubmit excluded by ps.ShouldRun")
 				continue
 			}
 
@@ -1766,7 +1765,6 @@ func (c *syncController) presubmitsForBatch(prs []CodeReviewCommon, org, repo, b
 			return nil, err
 		}
 		if !shouldRun {
-			log.WithField("context", ps.Context).Debug("Presubmit excluded by ps.ShouldRun")
 			continue
 		}
 


### PR DESCRIPTION
## Summary

- Remove two `"Presubmit excluded by ps.ShouldRun"` debug log lines that fire for every non-matching presubmit × PR combination each sync cycle
- In large deployments, this single message generates ~87% of all Tide log output (~30,000 lines per cycle), causing container log buffers to rotate every ~5 minutes and making Tide effectively unobservable

## Context

Analysis of OpenShift instance Tide log showed:

| Message | Count per ~5min | % of total |
|---------|----------------|------------|
| `Presubmit excluded by ps.ShouldRun` | 30,306 | **87%** |
| `Blocking merges to branch via issue.` | 986 | 3% |
| `Sending query` / `Finished query` | 945 | 3% |

The log volume causes container log buffer to rotate every ~5 minutes, meaning incident logs are lost almost immediately. Info-level entries that would diagnose issues (like `"Subpool synced."` with action and targets) are evicted before they can be retrieved.

After this change, the existing summary debug logs remain:
- `"Found possible presubmits"` with `num_possible_presubmit` field (before filtering)
- `"Determined required presubmits for PR."` with `required-presubmit-count` field (after filtering)
- `"After filtering, N presubmits remained for batch"` (batch equivalent)

Assisted by Claude Code