### PR TITLE
invalidcommitmsg: check added to detect fixup! amend! commits

### DIFF
--- a/pkg/plugins/invalidcommitmsg/invalidcommitmsg.go
+++ b/pkg/plugins/invalidcommitmsg/invalidcommitmsg.go
@@ -35,7 +35,7 @@ import (
 
 const (
 	pluginName                    = "invalidcommitmsg"
-	invalidCommitMsgCommentMarker = "invalid-commit-message"
+	invalidCommitMsgCommentMarker = "<!-- [prow:invalid-commit-message] -->"
 	invalidCommitMsgLabel         = "do-not-merge/invalid-commit-message"
 )
 
@@ -138,7 +138,10 @@ func handle(gc githubClient, log *logrus.Entry, pr github.PullRequestEvent, cp c
 
 	// unified comment handling
 	cp.PruneComments(func(comment github.IssueComment) bool {
-		return strings.Contains(comment.Body, invalidCommitMsgCommentMarker)
+		return strings.Contains(comment.Body, invalidCommitMsgCommentMarker) ||
+			// TODO: legacy markers, remove after August 2026
+			strings.Contains(comment.Body, "**The list of commits with invalid commit messages**:") ||
+			strings.Contains(comment.Body, "not allowed in the title of a Pull Request")
 	})
 
 	if hasIssues {
@@ -155,19 +158,20 @@ func handle(gc githubClient, log *logrus.Entry, pr github.PullRequestEvent, cp c
 		if checkFixup && len(fixupCommits) != 0 {
 			sections = append(sections,
 				fmt.Sprintf(
-					"### Fixup/amend/squash commits\n\nTemporary commits like fixup!, amend!, or squash! are not allowed.\n\nUse git rebase --autosquash to fix them.\n\n%s",
+					"### Fixup/amend/squash commits\n\nTemporary commits like fixup!, amend!, or squash! are not allowed.\n\nUse [git rebase --autosquash](https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash) to fix them.\n\n%s",
 					dco.MarkdownSHAList(org, repo, fixupCommits),
 				))
 		}
 
 		if invalidPRTitle {
 			sections = append(sections,
-				"### Invalid PR title\n\n[Keywords](https://help.github.com/articles/closing-issues-using-keywords) are not allowed in PR titles.\n\nUse /retitle <new-title> to fix it.",
+				"### Invalid PR title\n\n[Keywords](https://help.github.com/articles/closing-issues-using-keywords) are not allowed in PR titles.\n\nUse `/retitle <new-title>` to fix it.",
 			)
 		}
 
 		commentBody := fmt.Sprintf(
-			"[invalid-commit-message]\n\nInvalid commit message issues detected\n\n%s\n\n%s",
+			"%s\n\nInvalid commit message issues detected\n\n%s\n\n%s",
+			invalidCommitMsgCommentMarker,
 			strings.Join(sections, "\n\n"),
 			plugins.AboutThisBot,
 		)

--- a/pkg/plugins/invalidcommitmsg/invalidcommitmsg_test.go
+++ b/pkg/plugins/invalidcommitmsg/invalidcommitmsg_test.go
@@ -292,7 +292,7 @@ func TestHandlePullRequest(t *testing.T) {
 
 				comment := comments[0]
 
-				if !strings.Contains(comment, "[invalid-commit-message]") {
+				if !strings.Contains(comment, invalidCommitMsgCommentMarker) {
 					t.Errorf("Missing marker in comment")
 				}
 


### PR DESCRIPTION
Fixes #617

This change extends the `invalidcommitmsg` plugin to detect temporary commits such as `fixup!` and `amend!` in pull request history.

When such commits are present, the plugin:
- Applies the `do-not-merge/fixup-commits` label
- Posts a comment advising contributors to squash or rebase these commits before merging

The existing validation for issue-closing keywords in commit messages and PR titles remains unchanged.

The fixup/amend commit check is **disabled by default** and can be enabled by setting the following environment variable:

```bash
ENABLE_FIXUP_CHECK=true