### PR TITLE
jira remove QA Contact and Target Version getters and flags

### DIFF
--- a/pkg/jira/fakejira/fake.go
+++ b/pkg/jira/fakejira/fake.go
@@ -302,14 +302,6 @@ func (f *FakeClient) GetIssueSecurityLevel(issue *jira.Issue) (*jiraclient.Secur
 	return jiraclient.GetIssueSecurityLevel(issue)
 }
 
-func (f *FakeClient) GetIssueQaContact(issue *jira.Issue) (*jira.User, error) {
-	return jiraclient.GetIssueQaContact(issue)
-}
-
-func (f *FakeClient) GetIssueTargetVersion(issue *jira.Issue) (*[]*jira.Version, error) {
-	return jiraclient.GetIssueTargetVersion(issue)
-}
-
 func (f *FakeClient) UpdateIssue(issue *jira.Issue) (*jira.Issue, error) {
 	if f.UpdateIssueError != nil {
 		if err, ok := f.UpdateIssueError[issue.Key]; ok {

--- a/pkg/jira/jira.go
+++ b/pkg/jira/jira.go
@@ -73,10 +73,6 @@ type Client interface {
 	// is set for the issue, the returned SecurityLevel and error will both be nil and
 	// the issue will follow the default project security level.
 	GetIssueSecurityLevel(*jira.Issue) (*SecurityLevel, error)
-	// GetIssueQaContact get the user details for the QA contact. The QA contact is a custom field in Jira
-	GetIssueQaContact(*jira.Issue) (*jira.User, error)
-	// GetIssueTargetVersion get the issue Target Release. The target release is a custom field in Jira
-	GetIssueTargetVersion(issue *jira.Issue) (*[]*jira.Version, error)
 	// FindUser returns all users with a field matching the queryParam (ex: email, display name, etc.)
 	FindUser(queryParam string) ([]*jira.User, error)
 	GetRemoteLinks(id string) ([]jira.RemoteLink, error)
@@ -875,32 +871,6 @@ func GetIssueSecurityLevel(issue *jira.Issue) (*SecurityLevel, error) {
 
 func (jc *client) GetIssueSecurityLevel(issue *jira.Issue) (*SecurityLevel, error) {
 	return GetIssueSecurityLevel(issue)
-}
-
-func GetIssueQaContact(issue *jira.Issue) (*jira.User, error) {
-	var obj *jira.User
-	err := GetUnknownField("customfield_12316243", issue, func() any {
-		obj = &jira.User{}
-		return obj
-	})
-	return obj, err
-}
-
-func (jc *client) GetIssueQaContact(issue *jira.Issue) (*jira.User, error) {
-	return GetIssueQaContact(issue)
-}
-
-func GetIssueTargetVersion(issue *jira.Issue) (*[]*jira.Version, error) {
-	var obj *[]*jira.Version
-	err := GetUnknownField("customfield_12319940", issue, func() any {
-		obj = &[]*jira.Version{{}}
-		return obj
-	})
-	return obj, err
-}
-
-func (jc *client) GetIssueTargetVersion(issue *jira.Issue) (*[]*jira.Version, error) {
-	return GetIssueTargetVersion(issue)
 }
 
 // GetProjectVersions returns the list of all the Versions defined in a Project


### PR DESCRIPTION
This PR removes the QA Contact and Target Version custom field logic from the Jira client. The diff is deletions only relative to the current branch.

## Changes

**pkg/jira/jira.go**
- Remove from `Client` interface: `GetIssueQaContact`, `GetIssueTargetVersion` and their comments.
- Remove package-level `GetIssueQaContact` and `GetIssueTargetVersion` that used hardcoded `customfield_12316243` (QA Contact) and `customfield_12319940` (Target Version).
- Remove the client methods that delegated to those package-level getters.

**pkg/jira/fakejira/fake.go**
- Remove `FakeClient.GetIssueQaContact` and `FakeClient.GetIssueTargetVersion`.

**pkg/flagutil/jira.go**
- Struct field alignment only (no behavioral change).

## Rationale

Those custom field IDs are instance-specific. Removing this API avoids tying Prow to a single Jira instance. Callers that need QA Contact or Target Version should resolve fields by name (e.g. via `GET /rest/api/2/field`) and read from the issue’s field map; downstream can provide helpers and cache IDs.

**Breaking change:** Any caller using `Client.GetIssueQaContact` or `Client.GetIssueTargetVersion` must switch to name-based resolution or a custom helper.