### PR TITLE
fix(deck): show tide history records without tenant IDs

### DIFF
--- a/cmd/deck/tide.go
+++ b/cmd/deck/tide.go
@@ -210,11 +210,18 @@ func (ta *tideAgent) filterHistory(hist map[string][]history.Record) map[string]
 }
 
 func (ta *tideAgent) filter(orgRepoID string, curIDs sets.Set[string], needsHide bool) bool {
-	// If the orgrepo is associated with no tenantID OR the default tenantID we ignore it here.
-	// This prevents already IDd History from getting the default ID assigned to them when their orgrepo is not associated with an OrgRepo.
-	// History with no tenantID and with default tenantID behave the same, so adding the default ID just causes issues
+	// Only add a non-default orgRepoID to curIDs. Adding DefaultTenantID here
+	// would poison curIDs for pools that already have non-default IDs from their
+	// records, because matchingIDs uses HasAll: a pool with {"t", DefaultTenantID}
+	// would fail to match a Deck configured with just {"t"}.
 	if orgRepoID != "" && orgRepoID != config.DefaultTenantID {
 		curIDs.Insert(orgRepoID)
+	}
+	// When curIDs is still empty (e.g. repos with no Prow jobs produce history
+	// records with no tenant IDs, and orgRepoID was empty or default), treat the
+	// pool as belonging to the default tenant so it can be matched.
+	if len(curIDs) == 0 {
+		curIDs.Insert(config.DefaultTenantID)
 	}
 	if len(ta.tenantIDs) > 0 {
 		if ta.matchingIDs(sets.List(curIDs)) {

--- a/cmd/deck/tide_test.go
+++ b/cmd/deck/tide_test.go
@@ -711,6 +711,28 @@ func TestFilter(t *testing.T) {
 				"kubernetes/kubernetes:master": {{Action: "TRIGGER_BATCH", TenantIDs: []string{config.DefaultTenantID}}, {Action: "MERGE_BATCH"}},
 			},
 		},
+		{
+			name: "default-tenanted Deck shows pools and history with no tenant IDs",
+
+			tenantIDs: []string{config.DefaultTenantID},
+			pools: []tide.Pool{
+				{Org: "kubernetes", Repo: "test-infra", TenantIDs: []string{config.DefaultTenantID}},
+				{Org: "upstream", Repo: "no-prow-jobs"},
+			},
+			hist: map[string][]history.Record{
+				"kubernetes/test-infra:master": {{Action: "MERGE", TenantIDs: []string{config.DefaultTenantID}}},
+				"upstream/no-prow-jobs:main":   {{Action: "MERGE"}},
+			},
+
+			expectedPools: []tide.Pool{
+				{Org: "kubernetes", Repo: "test-infra", TenantIDs: []string{config.DefaultTenantID}},
+				{Org: "upstream", Repo: "no-prow-jobs"},
+			},
+			expectedHist: map[string][]history.Record{
+				"kubernetes/test-infra:master": {{Action: "MERGE", TenantIDs: []string{config.DefaultTenantID}}},
+				"upstream/no-prow-jobs:main":   {{Action: "MERGE"}},
+			},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Pools from repos without Prow jobs have no tenant IDs on their history records. The Deck filter treated these as not belonging to any tenant, making them invisible to Decks configured with DefaultTenantID. Normalize empty tenant ID sets to DefaultTenantID so these pools are displayed.

Assisted-By: Claude Opus 4.6 <noreply@anthropic.com>