### PR TITLE
Add support for git cherry-pick -x style commit messages

### DIFF
--- a/cmd/external-plugins/cherrypicker/main.go
+++ b/cmd/external-plugins/cherrypicker/main.go
@@ -44,12 +44,12 @@ type options struct {
 	instrumentationOptions prowflagutil.InstrumentationOptions
 	logLevel               string
 
-	webhookSecretFile string
-	prowAssignments   bool
-	allowAll          bool
-	issueOnConflict   bool
-        addOriginalCommitID bool
-	labelPrefix       string
+	webhookSecretFile   string
+	prowAssignments     bool
+	allowAll            bool
+	issueOnConflict     bool
+	addOriginalCommitID bool
+	labelPrefix         string
 }
 
 func (o *options) Validate() error {
@@ -73,7 +73,7 @@ func gatherOptions() options {
 	fs.BoolVar(&o.prowAssignments, "use-prow-assignments", true, "Use prow commands to assign cherrypicked PRs.")
 	fs.BoolVar(&o.allowAll, "allow-all", false, "Allow anybody to use automated cherrypicks by skipping GitHub organization membership checks.")
 	fs.BoolVar(&o.issueOnConflict, "create-issue-on-conflict", false, "Create a GitHub issue and assign it to the requestor on cherrypick conflict.")
-        fs.BoolVar(&o.addOriginalCommitID, "add-original-commit-id", true, "Add original commit ID to cherry-picked commit messages (similar to git cherry-pick -x).")
+	fs.BoolVar(&o.addOriginalCommitID, "add-original-commit-id", true, "Add original commit ID to cherry-picked commit messages (similar to git cherry-pick -x).")
 	fs.StringVar(&o.labelPrefix, "label-prefix", defaultLabelPrefix, "Set a custom label prefix.")
 	for _, group := range []flagutil.OptionGroup{&o.github, &o.instrumentationOptions} {
 		group.AddFlags(fs)
@@ -133,12 +133,12 @@ func main() {
 		ghc: githubClient,
 		log: log,
 
-		labels:          o.labels.Strings(),
-		prowAssignments: o.prowAssignments,
-		allowAll:        o.allowAll,
-		issueOnConflict: o.issueOnConflict,
-                addOriginalCommitID: o.addOriginalCommitID,
-		labelPrefix:     o.labelPrefix,
+		labels:              o.labels.Strings(),
+		prowAssignments:     o.prowAssignments,
+		allowAll:            o.allowAll,
+		issueOnConflict:     o.issueOnConflict,
+		addOriginalCommitID: o.addOriginalCommitID,
+		labelPrefix:         o.labelPrefix,
 
 		bare:     &http.Client{},
 		patchURL: "https://patch-diff.githubusercontent.com",

--- a/cmd/external-plugins/cherrypicker/main.go
+++ b/cmd/external-plugins/cherrypicker/main.go
@@ -48,6 +48,7 @@ type options struct {
 	prowAssignments   bool
 	allowAll          bool
 	issueOnConflict   bool
+        addOriginalCommitID bool
 	labelPrefix       string
 }
 
@@ -72,6 +73,7 @@ func gatherOptions() options {
 	fs.BoolVar(&o.prowAssignments, "use-prow-assignments", true, "Use prow commands to assign cherrypicked PRs.")
 	fs.BoolVar(&o.allowAll, "allow-all", false, "Allow anybody to use automated cherrypicks by skipping GitHub organization membership checks.")
 	fs.BoolVar(&o.issueOnConflict, "create-issue-on-conflict", false, "Create a GitHub issue and assign it to the requestor on cherrypick conflict.")
+        fs.BoolVar(&o.addOriginalCommitID, "add-original-commit-id", true, "Add original commit ID to cherry-picked commit messages (similar to git cherry-pick -x).")
 	fs.StringVar(&o.labelPrefix, "label-prefix", defaultLabelPrefix, "Set a custom label prefix.")
 	for _, group := range []flagutil.OptionGroup{&o.github, &o.instrumentationOptions} {
 		group.AddFlags(fs)
@@ -135,6 +137,7 @@ func main() {
 		prowAssignments: o.prowAssignments,
 		allowAll:        o.allowAll,
 		issueOnConflict: o.issueOnConflict,
+                addOriginalCommitID: o.addOriginalCommitID,
 		labelPrefix:     o.labelPrefix,
 
 		bare:     &http.Client{},

--- a/cmd/external-plugins/cherrypicker/server.go
+++ b/cmd/external-plugins/cherrypicker/server.go
@@ -641,7 +641,7 @@ func (s *Server) handle(logger logrus.FieldLogger, requester string, comment *gi
 		originalSHAs, err := extractOriginalSHAs(localPath)
 		if err != nil {
 			logger.WithError(err).Warn("Failed to extract original SHAs from patch")
-		} else if len(originalSHAs) > 0 {
+		} else {
 			// Append cherry-pick messages to all commits created by git am
 			if err := appendCherryPickMessages(r.Directory(), originalSHAs); err != nil {
 				logger.WithError(err).Warn("Failed to append cherry-pick messages")
@@ -652,6 +652,7 @@ func (s *Server) handle(logger logrus.FieldLogger, requester string, comment *gi
 		}
 	}
 
+        // Push the new branch
 	if err := p.Push(r, newBranch, true); err != nil {
 		logger.WithError(err).Warn("failed to push chery-picked changes to GitHub")
 		resp := fmt.Sprintf("failed to push cherry-picked changes in GitHub: %v", err)

--- a/cmd/external-plugins/cherrypicker/server.go
+++ b/cmd/external-plugins/cherrypicker/server.go
@@ -800,101 +800,91 @@ func releaseNoteFromParentPR(body string) string {
 // extractOriginalSHAs extracts all original commit SHAs from a patch file.
 // Each commit in a patch starts with: "From <SHA> Mon Sep 17 00:00:00 2001"
 func extractOriginalSHAs(patchPath string) ([]string, error) {
-	file, err := os.Open(patchPath)
-	if err != nil {
-		return nil, fmt.Errorf("failed to open patch file: %w", err)
-	}
-	defer file.Close()
+        file, err := os.Open(patchPath)
+        if err != nil {
+                return nil, fmt.Errorf("failed to open patch file: %w", err)
+        }
+        defer file.Close()
 
-	var shas []string
-	scanner := bufio.NewScanner(file)
-	for scanner.Scan() {
-		line := scanner.Text()
-		if strings.HasPrefix(line, "From ") {
-			parts := strings.Split(line, " ")
-			if len(parts) > 1 {
-				shas = append(shas, strings.TrimSpace(parts[1]))
-			}
-		}
-	}
+        var shas []string
+        scanner := bufio.NewScanner(file)
+        fromPattern := regexp.MustCompile(`^From ([0-9a-f]{40}) `)
+        for scanner.Scan() {
+                line := scanner.Text()
+                if matches := fromPattern.FindStringSubmatch(line); matches != nil {
+                    shas = append(shas, matches[1])
+                }
+        }
 
-	if err := scanner.Err(); err != nil {
-		return nil, fmt.Errorf("error reading patch file: %w", err)
-	}
+        if err := scanner.Err(); err != nil {
+                return nil, fmt.Errorf("error reading patch file: %w", err)
+        }
 
-	if len(shas) == 0 {
-		return nil, fmt.Errorf("no original SHAs found in patch file")
-	}
+        if len(shas) == 0 {
+                return nil, fmt.Errorf("no original SHAs found in patch file")
+        }
 
-	return shas, nil
+        return shas, nil
 }
 
 // appendCherryPickMessages appends "(cherry picked from commit <sha>)"
 // to all commits created by git am (supports single and multi-commit PRs).
 func appendCherryPickMessages(repoPath string, originalSHAs []string) error {
-	numCommits := len(originalSHAs)
+    numCommits := len(originalSHAs)
+    if numCommits == 0 {
+        return nil
+    }
+    if len(originalSHAs) != numCommits {
+        return fmt.Errorf("internal: originalSHAs length mismatch")
+    }
 
-	// Get commits created by git am (oldest → newest)
-	cmd := exec.Command("git", "-C", repoPath,
-		"rev-list", "--reverse",
-		fmt.Sprintf("HEAD~%d..HEAD", numCommits),
-	)
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("failed to list commits: %w, output: %s", err, string(out))
-	}
+    // Resolve absolute base SHA for stability
+    baseCmd := exec.Command("git", "-C", repoPath, "rev-parse", fmt.Sprintf("HEAD~%d", numCommits))
+    baseSHABytes, err := baseCmd.Output()
+    if err != nil {
+        return fmt.Errorf("failed to resolve base SHA: %w", err)
+    }
+    baseSHA := strings.TrimSpace(string(baseSHABytes))
 
-	commits := strings.Split(strings.TrimSpace(string(out)), "\n")
-	if len(commits) != numCommits {
-		return fmt.Errorf("commit count mismatch: expected %d, got %d", numCommits, len(commits))
-	}
+    // Helper script run after each commit during rebase
+    script := fmt.Sprintf(`#!/bin/sh
+set -e
+COMMIT_NUM=$(git rev-list --count %s..HEAD)
+ORIGINAL_SHA=$(echo "$ORIGINAL_SHAS" | cut -d',' -f$COMMIT_NUM)
+if [ -n "$ORIGINAL_SHA" ]; then
+    CURRENT_MSG=$(git log -1 --pretty=%%B)
+    git commit --amend -m "$CURRENT_MSG
 
-	// Build msg-filter script
-	scriptContent := "#!/bin/sh\n"
-	scriptContent += "MSG=$(cat)\n"
-	scriptContent += "case \"$GIT_COMMIT\" in\n"
+(cherry picked from commit $ORIGINAL_SHA)"
+fi
+`, baseSHA)
 
-	for i, commitSHA := range commits {
-		originalSHA := originalSHAs[i]
-		scriptContent += fmt.Sprintf("  %s)\n", commitSHA)
-		scriptContent += fmt.Sprintf(
-			"    printf '%%s\\n\\n(cherry picked from commit %s)' \"$MSG\"\n",
-			originalSHA,
-		)
-		scriptContent += "    ;;\n"
-	}
+    tmpfile, err := os.CreateTemp("", "cherry-pick-exec-*.sh")
+    if err != nil {
+        return fmt.Errorf("failed to create tmp script: %w", err)
+    }
+    tmpPath := tmpfile.Name()
+    defer os.Remove(tmpPath)
 
-	scriptContent += "  *)\n"
-	scriptContent += "    printf '%s\n' \"$MSG\"\n"
-	scriptContent += "    ;;\n"
-	scriptContent += "esac\n"
+    if _, err := tmpfile.WriteString(script); err != nil {
+        tmpfile.Close()
+        return fmt.Errorf("failed to write tmp script: %w", err)
+    }
+    tmpfile.Close()
 
-	// Write script to temp file
-	tmpfile, err := os.CreateTemp("", "cherrypick-msg-filter-*.sh")
-	if err != nil {
-		return fmt.Errorf("failed to create temp script: %w", err)
-	}
-	defer os.Remove(tmpfile.Name())
+    if err := os.Chmod(tmpPath, 0755); err != nil {
+        return fmt.Errorf("failed to chmod tmp script: %w", err)
+    }
 
-	if err := os.WriteFile(tmpfile.Name(), []byte(scriptContent), 0755); err != nil {
-		return fmt.Errorf("failed to write script: %w", err)
-	}
+    // Prepare and run the rebase. Export ORIGINAL_SHAS and prevent editor.
+    origEnv := fmt.Sprintf("ORIGINAL_SHAS=%s", strings.Join(originalSHAs, ","))
+    cmd := exec.Command("git", "-C", repoPath, "rebase", "-i", baseSHA, "--exec", tmpPath)
+    cmd.Env = append(os.Environ(), origEnv, "GIT_SEQUENCE_EDITOR=true", "GIT_CONFIG_NOSYSTEM=1")
 
-	// Ensure executable
-	if err := os.Chmod(tmpfile.Name(), 0755); err != nil {
-		return fmt.Errorf("failed to chmod script: %w", err)
-	}
+    out, err := cmd.CombinedOutput()
+    if err != nil {
+        return fmt.Errorf("git rebase --exec failed: %w, output: %s", err, string(out))
+    }
 
-	// Rewrite only last N commits
-	filterCmd := exec.Command("git", "-C", repoPath,
-		"filter-branch", "-f",
-		"--msg-filter", tmpfile.Name(),
-		fmt.Sprintf("HEAD~%d..HEAD", numCommits),
-	)
-
-	if out, err := filterCmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("failed to rewrite commits: %w, output: %s", err, string(out))
-	}
-
-	return nil
+    return nil
 }

--- a/cmd/external-plugins/cherrypicker/server.go
+++ b/cmd/external-plugins/cherrypicker/server.go
@@ -652,7 +652,7 @@ func (s *Server) handle(logger logrus.FieldLogger, requester string, comment *gi
 		}
 	}
 
-        // Push the new branch
+	// Push the new branch
 	if err := p.Push(r, newBranch, true); err != nil {
 		logger.WithError(err).Warn("failed to push chery-picked changes to GitHub")
 		resp := fmt.Sprintf("failed to push cherry-picked changes in GitHub: %v", err)
@@ -800,54 +800,54 @@ func releaseNoteFromParentPR(body string) string {
 // extractOriginalSHAs extracts all original commit SHAs from a patch file.
 // Each commit in a patch starts with: "From <SHA> Mon Sep 17 00:00:00 2001"
 func extractOriginalSHAs(patchPath string) ([]string, error) {
-        file, err := os.Open(patchPath)
-        if err != nil {
-                return nil, fmt.Errorf("failed to open patch file: %w", err)
-        }
-        defer file.Close()
+	file, err := os.Open(patchPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open patch file: %w", err)
+	}
+	defer file.Close()
 
-        var shas []string
-        scanner := bufio.NewScanner(file)
-        fromPattern := regexp.MustCompile(`^From ([0-9a-f]{40}) `)
-        for scanner.Scan() {
-                line := scanner.Text()
-                if matches := fromPattern.FindStringSubmatch(line); matches != nil {
-                    shas = append(shas, matches[1])
-                }
-        }
+	var shas []string
+	scanner := bufio.NewScanner(file)
+	fromPattern := regexp.MustCompile(`^From ([0-9a-f]{40}) `)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if matches := fromPattern.FindStringSubmatch(line); matches != nil {
+			shas = append(shas, matches[1])
+		}
+	}
 
-        if err := scanner.Err(); err != nil {
-                return nil, fmt.Errorf("error reading patch file: %w", err)
-        }
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("error reading patch file: %w", err)
+	}
 
-        if len(shas) == 0 {
-                return nil, fmt.Errorf("no original SHAs found in patch file")
-        }
+	if len(shas) == 0 {
+		return nil, fmt.Errorf("no original SHAs found in patch file")
+	}
 
-        return shas, nil
+	return shas, nil
 }
 
 // appendCherryPickMessages appends "(cherry picked from commit <sha>)"
 // to all commits created by git am (supports single and multi-commit PRs).
 func appendCherryPickMessages(repoPath string, originalSHAs []string) error {
-    numCommits := len(originalSHAs)
-    if numCommits == 0 {
-        return nil
-    }
-    if len(originalSHAs) != numCommits {
-        return fmt.Errorf("internal: originalSHAs length mismatch")
-    }
+	numCommits := len(originalSHAs)
+	if numCommits == 0 {
+		return nil
+	}
+	if len(originalSHAs) != numCommits {
+		return fmt.Errorf("internal: originalSHAs length mismatch")
+	}
 
-    // Resolve absolute base SHA for stability
-    baseCmd := exec.Command("git", "-C", repoPath, "rev-parse", fmt.Sprintf("HEAD~%d", numCommits))
-    baseSHABytes, err := baseCmd.Output()
-    if err != nil {
-        return fmt.Errorf("failed to resolve base SHA: %w", err)
-    }
-    baseSHA := strings.TrimSpace(string(baseSHABytes))
+	// Resolve absolute base SHA for stability
+	baseCmd := exec.Command("git", "-C", repoPath, "rev-parse", fmt.Sprintf("HEAD~%d", numCommits))
+	baseSHABytes, err := baseCmd.Output()
+	if err != nil {
+		return fmt.Errorf("failed to resolve base SHA: %w", err)
+	}
+	baseSHA := strings.TrimSpace(string(baseSHABytes))
 
-    // Helper script run after each commit during rebase
-    script := fmt.Sprintf(`#!/bin/sh
+	// Helper script run after each commit during rebase
+	script := fmt.Sprintf(`#!/bin/sh
 set -e
 COMMIT_NUM=$(git rev-list --count %s..HEAD)
 ORIGINAL_SHA=$(echo "$ORIGINAL_SHAS" | cut -d',' -f$COMMIT_NUM)
@@ -859,32 +859,32 @@ if [ -n "$ORIGINAL_SHA" ]; then
 fi
 `, baseSHA)
 
-    tmpfile, err := os.CreateTemp("", "cherry-pick-exec-*.sh")
-    if err != nil {
-        return fmt.Errorf("failed to create tmp script: %w", err)
-    }
-    tmpPath := tmpfile.Name()
-    defer os.Remove(tmpPath)
+	tmpfile, err := os.CreateTemp("", "cherry-pick-exec-*.sh")
+	if err != nil {
+		return fmt.Errorf("failed to create tmp script: %w", err)
+	}
+	tmpPath := tmpfile.Name()
+	defer os.Remove(tmpPath)
 
-    if _, err := tmpfile.WriteString(script); err != nil {
-        tmpfile.Close()
-        return fmt.Errorf("failed to write tmp script: %w", err)
-    }
-    tmpfile.Close()
+	if _, err := tmpfile.WriteString(script); err != nil {
+		tmpfile.Close()
+		return fmt.Errorf("failed to write tmp script: %w", err)
+	}
+	tmpfile.Close()
 
-    if err := os.Chmod(tmpPath, 0755); err != nil {
-        return fmt.Errorf("failed to chmod tmp script: %w", err)
-    }
+	if err := os.Chmod(tmpPath, 0755); err != nil {
+		return fmt.Errorf("failed to chmod tmp script: %w", err)
+	}
 
-    // Prepare and run the rebase. Export ORIGINAL_SHAS and prevent editor.
-    origEnv := fmt.Sprintf("ORIGINAL_SHAS=%s", strings.Join(originalSHAs, ","))
-    cmd := exec.Command("git", "-C", repoPath, "rebase", "-i", baseSHA, "--exec", tmpPath)
-    cmd.Env = append(os.Environ(), origEnv, "GIT_SEQUENCE_EDITOR=true", "GIT_CONFIG_NOSYSTEM=1")
+	// Prepare and run the rebase. Export ORIGINAL_SHAS and prevent editor.
+	origEnv := fmt.Sprintf("ORIGINAL_SHAS=%s", strings.Join(originalSHAs, ","))
+	cmd := exec.Command("git", "-C", repoPath, "rebase", "-i", baseSHA, "--exec", tmpPath)
+	cmd.Env = append(os.Environ(), origEnv, "GIT_SEQUENCE_EDITOR=true", "GIT_CONFIG_NOSYSTEM=1")
 
-    out, err := cmd.CombinedOutput()
-    if err != nil {
-        return fmt.Errorf("git rebase --exec failed: %w, output: %s", err, string(out))
-    }
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("git rebase --exec failed: %w, output: %s", err, string(out))
+	}
 
-    return nil
+	return nil
 }

--- a/cmd/external-plugins/cherrypicker/server.go
+++ b/cmd/external-plugins/cherrypicker/server.go
@@ -834,9 +834,6 @@ func appendCherryPickMessages(repoPath string, originalSHAs []string) error {
 	if numCommits == 0 {
 		return nil
 	}
-	if len(originalSHAs) != numCommits {
-		return fmt.Errorf("internal: originalSHAs length mismatch")
-	}
 
 	// Resolve absolute base SHA for stability
 	baseCmd := exec.Command("git", "-C", repoPath, "rev-parse", fmt.Sprintf("HEAD~%d", numCommits))

--- a/cmd/external-plugins/cherrypicker/server.go
+++ b/cmd/external-plugins/cherrypicker/server.go
@@ -635,18 +635,19 @@ func (s *Server) handle(logger logrus.FieldLogger, requester string, comment *gi
 		return utilerrors.NewAggregate(errs)
 	}
 
-	// Add original commit ID if flag is enabled
+	// Add original commit IDs if flag is enabled
 	if s.addOriginalCommitID {
-		// Extract original commit SHA from patch
-		originalSHA, err := extractOriginalSHA(localPath)
+		// Extract all original commit SHAs from patch
+		originalSHAs, err := extractOriginalSHAs(localPath)
 		if err != nil {
-			logger.WithError(err).Warn("Failed to extract original SHA from patch")
-		} else {
-			// Append cherry-pick message
-			if err := appendCherryPickMessage(r.Directory(), originalSHA); err != nil {
-				logger.WithError(err).Warn("Failed to append cherry-pick message")
+			logger.WithError(err).Warn("Failed to extract original SHAs from patch")
+		} else if len(originalSHAs) > 0 {
+			// Append cherry-pick messages to all commits created by git am
+			if err := appendCherryPickMessages(r.Directory(), originalSHAs); err != nil {
+				logger.WithError(err).Warn("Failed to append cherry-pick messages")
 			} else {
-				logger.WithField("original_sha", originalSHA).Info("Successfully added original commit ID to cherry-picked commit")
+				logger.WithField("commit_count", len(originalSHAs)).
+					Info("Successfully added original commit IDs to cherry-picked commits")
 			}
 		}
 	}
@@ -795,51 +796,103 @@ func releaseNoteFromParentPR(body string) string {
 	return fmt.Sprintf("```release-note\n%s\n```", strings.TrimSpace(potentialMatch[1]))
 }
 
-// extractOriginalSHA extracts the original commit SHA from a patch file.
-// Patch files contain lines like "From <SHA> Mon Sep 17 00:00:00 2001" at the start.
-func extractOriginalSHA(patchPath string) (string, error) {
+// extractOriginalSHAs extracts all original commit SHAs from a patch file.
+// Each commit in a patch starts with: "From <SHA> Mon Sep 17 00:00:00 2001"
+func extractOriginalSHAs(patchPath string) ([]string, error) {
 	file, err := os.Open(patchPath)
 	if err != nil {
-		return "", fmt.Errorf("failed to open patch file: %w", err)
+		return nil, fmt.Errorf("failed to open patch file: %w", err)
 	}
 	defer file.Close()
 
+	var shas []string
 	scanner := bufio.NewScanner(file)
 	for scanner.Scan() {
 		line := scanner.Text()
 		if strings.HasPrefix(line, "From ") {
 			parts := strings.Split(line, " ")
 			if len(parts) > 1 {
-				return strings.TrimSpace(parts[1]), nil
+				shas = append(shas, strings.TrimSpace(parts[1]))
 			}
 		}
 	}
 
 	if err := scanner.Err(); err != nil {
-		return "", fmt.Errorf("error reading patch file: %w", err)
+		return nil, fmt.Errorf("error reading patch file: %w", err)
 	}
 
-	return "", fmt.Errorf("no original SHA found in patch file")
+	if len(shas) == 0 {
+		return nil, fmt.Errorf("no original SHAs found in patch file")
+	}
+
+	return shas, nil
 }
 
-// appendCherryPickMessage amends the most recent commit with a cherry-pick message.
-func appendCherryPickMessage(repoPath string, originalSHA string) error {
-	// Get current commit message using git log with proper format
-	cmd := exec.Command("git", "-C", repoPath, "log", "-1", "--pretty=%B")
-	output, err := cmd.Output()
+// appendCherryPickMessages appends "(cherry picked from commit <sha>)"
+// to all commits created by git am (supports single and multi-commit PRs).
+func appendCherryPickMessages(repoPath string, originalSHAs []string) error {
+	numCommits := len(originalSHAs)
+
+	// Get commits created by git am (oldest → newest)
+	cmd := exec.Command("git", "-C", repoPath,
+		"rev-list", "--reverse",
+		fmt.Sprintf("HEAD~%d..HEAD", numCommits),
+	)
+	out, err := cmd.CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("failed to get commit message: %w", err)
+		return fmt.Errorf("failed to list commits: %w, output: %s", err, string(out))
 	}
 
-	currentMessage := strings.TrimSpace(string(output))
+	commits := strings.Split(strings.TrimSpace(string(out)), "\n")
+	if len(commits) != numCommits {
+		return fmt.Errorf("commit count mismatch: expected %d, got %d", numCommits, len(commits))
+	}
 
-	// Construct new message with cherry-pick line
-	newMessage := fmt.Sprintf("%s\n\n(cherry picked from commit %s)", currentMessage, originalSHA)
+	// Build msg-filter script
+	scriptContent := "#!/bin/sh\n"
+	scriptContent += "MSG=$(cat)\n"
+	scriptContent += "case \"$GIT_COMMIT\" in\n"
 
-	// Amend commit with new message
-	amendCmd := exec.Command("git", "-C", repoPath, "commit", "--amend", "-m", newMessage)
-	if err := amendCmd.Run(); err != nil {
-		return fmt.Errorf("failed to amend commit: %w", err)
+	for i, commitSHA := range commits {
+		originalSHA := originalSHAs[i]
+		scriptContent += fmt.Sprintf("  %s)\n", commitSHA)
+		scriptContent += fmt.Sprintf(
+			"    printf '%%s\\n\\n(cherry picked from commit %s)' \"$MSG\"\n",
+			originalSHA,
+		)
+		scriptContent += "    ;;\n"
+	}
+
+	scriptContent += "  *)\n"
+	scriptContent += "    printf '%s\n' \"$MSG\"\n"
+	scriptContent += "    ;;\n"
+	scriptContent += "esac\n"
+
+	// Write script to temp file
+	tmpfile, err := os.CreateTemp("", "cherrypick-msg-filter-*.sh")
+	if err != nil {
+		return fmt.Errorf("failed to create temp script: %w", err)
+	}
+	defer os.Remove(tmpfile.Name())
+
+	if err := os.WriteFile(tmpfile.Name(), []byte(scriptContent), 0755); err != nil {
+		return fmt.Errorf("failed to write script: %w", err)
+	}
+
+	// Ensure executable
+	if err := os.Chmod(tmpfile.Name(), 0755); err != nil {
+		return fmt.Errorf("failed to chmod script: %w", err)
+	}
+
+	// Rewrite only last N commits
+	filterCmd := exec.Command("git", "-C", repoPath,
+		"filter-branch", "-f",
+		"--msg-filter", tmpfile.Name(),
+		fmt.Sprintf("HEAD~%d..HEAD", numCommits),
+	)
+
+	if out, err := filterCmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("failed to rewrite commits: %w, output: %s", err, string(out))
 	}
 
 	return nil

--- a/cmd/external-plugins/cherrypicker/server.go
+++ b/cmd/external-plugins/cherrypicker/server.go
@@ -17,10 +17,12 @@ limitations under the License.
 package main
 
 import (
+	"bufio"
 	"encoding/json"
 	"fmt"
 	"net/http"
 	"os"
+	"os/exec"
 	"regexp"
 	"slices"
 	"strings"
@@ -103,6 +105,8 @@ type Server struct {
 	allowAll bool
 	// Create an issue on cherrypick conflict.
 	issueOnConflict bool
+	// Add original commit ID to cherry-picked commit messages.
+	addOriginalCommitID bool
 	// Set a custom label prefix.
 	labelPrefix string
 
@@ -631,7 +635,22 @@ func (s *Server) handle(logger logrus.FieldLogger, requester string, comment *gi
 		return utilerrors.NewAggregate(errs)
 	}
 
-	// Push the new branch
+	// Add original commit ID if flag is enabled
+	if s.addOriginalCommitID {
+		// Extract original commit SHA from patch
+		originalSHA, err := extractOriginalSHA(localPath)
+		if err != nil {
+			logger.WithError(err).Warn("Failed to extract original SHA from patch")
+		} else {
+			// Append cherry-pick message
+			if err := appendCherryPickMessage(r.Directory(), originalSHA); err != nil {
+				logger.WithError(err).Warn("Failed to append cherry-pick message")
+			} else {
+				logger.WithField("original_sha", originalSHA).Info("Successfully added original commit ID to cherry-picked commit")
+			}
+		}
+	}
+
 	if err := p.Push(r, newBranch, true); err != nil {
 		logger.WithError(err).Warn("failed to push chery-picked changes to GitHub")
 		resp := fmt.Sprintf("failed to push cherry-picked changes in GitHub: %v", err)
@@ -774,4 +793,54 @@ func releaseNoteFromParentPR(body string) string {
 		return ""
 	}
 	return fmt.Sprintf("```release-note\n%s\n```", strings.TrimSpace(potentialMatch[1]))
+}
+
+// extractOriginalSHA extracts the original commit SHA from a patch file.
+// Patch files contain lines like "From <SHA> Mon Sep 17 00:00:00 2001" at the start.
+func extractOriginalSHA(patchPath string) (string, error) {
+	file, err := os.Open(patchPath)
+	if err != nil {
+		return "", fmt.Errorf("failed to open patch file: %w", err)
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.HasPrefix(line, "From ") {
+			parts := strings.Split(line, " ")
+			if len(parts) > 1 {
+				return strings.TrimSpace(parts[1]), nil
+			}
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return "", fmt.Errorf("error reading patch file: %w", err)
+	}
+
+	return "", fmt.Errorf("no original SHA found in patch file")
+}
+
+// appendCherryPickMessage amends the most recent commit with a cherry-pick message.
+func appendCherryPickMessage(repoPath string, originalSHA string) error {
+	// Get current commit message using git log with proper format
+	cmd := exec.Command("git", "-C", repoPath, "log", "-1", "--pretty=%B")
+	output, err := cmd.Output()
+	if err != nil {
+		return fmt.Errorf("failed to get commit message: %w", err)
+	}
+
+	currentMessage := strings.TrimSpace(string(output))
+
+	// Construct new message with cherry-pick line
+	newMessage := fmt.Sprintf("%s\n\n(cherry picked from commit %s)", currentMessage, originalSHA)
+
+	// Amend commit with new message
+	amendCmd := exec.Command("git", "-C", repoPath, "commit", "--amend", "-m", newMessage)
+	if err := amendCmd.Run(); err != nil {
+		return fmt.Errorf("failed to amend commit: %w", err)
+	}
+
+	return nil
 }

--- a/cmd/external-plugins/cherrypicker/server_test.go
+++ b/cmd/external-plugins/cherrypicker/server_test.go
@@ -19,6 +19,9 @@ package main
 import (
 	"errors"
 	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"sync"
@@ -27,6 +30,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	"sigs.k8s.io/prow/pkg/git/localgit"
@@ -1458,4 +1462,235 @@ func (p *prNumberGenerator) GetPRNumber() int {
 	defer p.Unlock()
 	p.prNumber = p.prNumber + 10
 	return p.prNumber
+}
+
+func TestExtractOriginalSHAs(t *testing.T) {
+	tests := []struct {
+		name        string
+		patch       string
+		expected    []string
+		expectError bool
+	}{
+		{
+			name: "single commit",
+			patch: `From 1111111111111111111111111111111111111111 Mon Sep 17 00:00:00 2001
+diff --git a/file b/file`,
+			expected: []string{
+				"1111111111111111111111111111111111111111",
+			},
+		},
+		{
+			name: "multiple commits",
+			patch: `From 1111111111111111111111111111111111111111 Mon Sep 17 00:00:00 2001
+diff --git a/file1 b/file1
+From 2222222222222222222222222222222222222222 Mon Sep 17 00:00:00 2001
+diff --git a/file2 b/file2`,
+			expected: []string{
+				"1111111111111111111111111111111111111111",
+				"2222222222222222222222222222222222222222",
+			},
+		},
+		{
+			name: "ignore invalid From lines",
+			patch: `From invalid-sha
+From 3333333333333333333333333333333333333333 Mon Sep 17 00:00:00 2001`,
+			expected: []string{
+				"3333333333333333333333333333333333333333",
+			},
+		},
+		{
+			name:        "no commits",
+			patch:       `random content`,
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			tmp, err := os.CreateTemp("", "patch-*.patch")
+			require.NoError(t, err)
+			defer os.Remove(tmp.Name())
+
+			_, err = tmp.WriteString(tt.patch)
+			require.NoError(t, err)
+
+			require.NoError(t, tmp.Close())
+
+			shas, err := extractOriginalSHAs(tmp.Name())
+
+			if tt.expectError {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "no original SHAs found")
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, shas)
+		})
+	}
+}
+
+func TestAppendCherryPickMessages_Empty(t *testing.T) {
+	t.Parallel()
+
+	err := appendCherryPickMessages(t.TempDir(), []string{})
+	require.NoError(t, err)
+}
+
+func TestAppendCherryPickMessages_NoGitRepo(t *testing.T) {
+	t.Parallel()
+
+	err := appendCherryPickMessages(t.TempDir(), []string{
+		"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+	})
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to resolve base SHA")
+}
+
+func TestAppendCherryPickMessages_SingleCommit(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+
+	run := func(args ...string) {
+		t.Helper()
+
+		cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+		cmd.Env = append(os.Environ(),
+			"GIT_SEQUENCE_EDITOR=true",
+			"GIT_EDITOR=true",
+		)
+
+		out, err := cmd.CombinedOutput()
+		require.NoError(t, err, string(out))
+	}
+
+	run("init")
+	run("config", "user.email", "test@test.com")
+	run("config", "user.name", "test")
+
+	require.NoError(t,
+		os.WriteFile(filepath.Join(dir, "file.txt"), []byte("base"), 0644),
+	)
+
+	run("add", ".")
+	run("commit", "-m", "base")
+
+	require.NoError(t,
+		os.WriteFile(filepath.Join(dir, "file.txt"), []byte("change-1"), 0644),
+	)
+
+	run("add", ".")
+	run("commit", "-m", "commit1")
+
+	err := appendCherryPickMessages(dir, []string{
+		"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+	})
+	require.NoError(t, err)
+
+	cmd := exec.Command("git", "-C", dir, "log", "-1", "--pretty=%B")
+
+	out, err := cmd.Output()
+	require.NoError(t, err)
+
+	require.Contains(
+		t,
+		string(out),
+		"(cherry picked from commit aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa)",
+	)
+}
+
+func TestAppendCherryPickMessages_MultiCommit(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+
+	run := func(args ...string) {
+		t.Helper()
+
+		cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+		cmd.Env = append(os.Environ(),
+			"GIT_SEQUENCE_EDITOR=true",
+			"GIT_EDITOR=true",
+		)
+
+		out, err := cmd.CombinedOutput()
+		require.NoError(t, err, string(out))
+	}
+
+	run("init")
+	run("config", "user.email", "test@test.com")
+	run("config", "user.name", "test")
+
+	require.NoError(t,
+		os.WriteFile(filepath.Join(dir, "file.txt"), []byte("base"), 0644),
+	)
+
+	run("add", ".")
+	run("commit", "-m", "base")
+
+	require.NoError(t,
+		os.WriteFile(filepath.Join(dir, "file.txt"), []byte("one"), 0644),
+	)
+
+	run("add", ".")
+	run("commit", "-m", "commit1")
+
+	require.NoError(t,
+		os.WriteFile(filepath.Join(dir, "file.txt"), []byte("two"), 0644),
+	)
+
+	run("add", ".")
+	run("commit", "-m", "commit2")
+
+	err := appendCherryPickMessages(dir, []string{
+		"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+	})
+	require.NoError(t, err)
+
+	cmd := exec.Command(
+		"git",
+		"-C",
+		dir,
+		"log",
+		"-2",
+		"--format=%B%x00",
+	)
+
+	out, err := cmd.Output()
+	require.NoError(t, err)
+
+	messages := strings.Split(string(out), "\x00")
+
+	var got []string
+	for _, msg := range messages {
+		msg = strings.TrimSpace(msg)
+		if msg != "" {
+			got = append(got, msg)
+		}
+	}
+
+	require.Len(t, got, 2)
+
+	require.Contains(
+		t,
+		got[0],
+		"(cherry picked from commit bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb)",
+	)
+
+	require.Contains(
+		t,
+		got[1],
+		"(cherry picked from commit aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa)",
+	)
+
+	// Ensure original messages are preserved
+	require.Contains(t, got[0], "commit2")
+	require.Contains(t, got[1], "commit1")
 }

--- a/cmd/external-plugins/cherrypicker/server_test.go
+++ b/cmd/external-plugins/cherrypicker/server_test.go
@@ -1506,7 +1506,6 @@ From 3333333333333333333333333333333333333333 Mon Sep 17 00:00:00 2001`,
 	}
 
 	for _, tt := range tests {
-		tt := tt
 
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()


### PR DESCRIPTION
This PR adds support for git cherry-pick -x style commit messages in the cherrypicker plugin, addressing issue #500 . When enabled, cherry-picked commits will automatically include a reference to their original commit SHA in the format (cherry picked from commit <sha>), making it easier to track which changes have been backported to release branches.