### PR TITLE
tide: skip unmergeable PRs instead of retrying indefinitely

### DIFF
--- a/pkg/tide/tide.go
+++ b/pkg/tide/tide.go
@@ -95,6 +95,14 @@ type syncController struct {
 
 	// Shared fields with status controller
 	statusUpdate *statusUpdate
+
+	// mergeExclusions tracks PRs that recently failed to merge with
+	// UnmergablePRError (e.g. due to branch protection requiring more
+	// reviews). These PRs are temporarily skipped so Tide can advance
+	// to the next mergeable PR instead of retrying the same one.
+	// Key: "org/repo#number@sha", Value: time of failure.
+	mergeExclusions   map[string]time.Time
+	mergeExclusionsMu sync.Mutex
 }
 
 // Action represents what actions the controller can take. It will take
@@ -488,8 +496,9 @@ func newSyncController(
 			provider:        provider,
 			nextChangeCache: make(map[changeCacheKey][]string),
 		},
-		History:      hist,
-		statusUpdate: statusUpdate,
+		History:         hist,
+		statusUpdate:    statusUpdate,
+		mergeExclusions: make(map[string]time.Time),
 	}, nil
 }
 
@@ -501,6 +510,79 @@ func setupSyncControllerIndexes(ctx context.Context, indexer ctrlruntimeclient.F
 		return fmt.Errorf("failed to add index for non failed batches: %w", err)
 	}
 	return nil
+}
+
+// mergeExclusionTTL is how long a PR stays excluded after a merge failure
+// before Tide retries it.
+const mergeExclusionTTL = 5 * time.Minute
+
+// mergeExclusionKey returns a unique key for tracking merge exclusions.
+// The key includes the head SHA so that when an author pushes new commits,
+// the exclusion is automatically invalidated without waiting for the TTL.
+func mergeExclusionKey(org, repo string, number int, sha string) string {
+	return fmt.Sprintf("%s/%s#%d@%s", org, repo, number, sha)
+}
+
+// mergeExclusionPrefix returns the prefix shared by all exclusion keys for
+// a given PR, regardless of head SHA. Used to clean up stale entries when
+// a PR's head SHA changes.
+func mergeExclusionPrefix(org, repo string, number int) string {
+	return fmt.Sprintf("%s/%s#%d@", org, repo, number)
+}
+
+// excludeFromMerge records that a PR at a specific head SHA should be
+// temporarily skipped for merging. It also removes any prior exclusion
+// entries for the same PR at a different SHA to prevent unbounded map growth.
+func (c *syncController) excludeFromMerge(org, repo string, number int, sha string) {
+	c.mergeExclusionsMu.Lock()
+	defer c.mergeExclusionsMu.Unlock()
+	// Remove any prior exclusion for this PR (different SHA) to avoid leaking entries.
+	prefix := mergeExclusionPrefix(org, repo, number)
+	for key := range c.mergeExclusions {
+		if strings.HasPrefix(key, prefix) {
+			delete(c.mergeExclusions, key)
+		}
+	}
+	c.mergeExclusions[mergeExclusionKey(org, repo, number, sha)] = time.Now()
+}
+
+// isExcludedFromMerge returns true if a PR at its current head SHA is
+// temporarily excluded from merging. If the PR's head SHA has changed
+// since the exclusion was recorded, the PR is no longer excluded.
+func (c *syncController) isExcludedFromMerge(org, repo string, number int, sha string) bool {
+	c.mergeExclusionsMu.Lock()
+	defer c.mergeExclusionsMu.Unlock()
+	key := mergeExclusionKey(org, repo, number, sha)
+	failedAt, ok := c.mergeExclusions[key]
+	if !ok {
+		return false
+	}
+	if time.Since(failedAt) >= mergeExclusionTTL {
+		delete(c.mergeExclusions, key)
+		return false
+	}
+	return true
+}
+
+// isUnmergableError checks whether an error from mergePRs wraps an
+// UnmergablePRError, indicating GitHub rejected the merge (e.g. due to
+// branch protection settings like required review count).
+func isUnmergableError(err error) bool {
+	if err == nil {
+		return false
+	}
+	// The error may be wrapped in a mergeFailure. Check the underlying errors.
+	if mf, ok := err.(*mergeFailure); ok {
+		for _, me := range mf.errs {
+			if isUnmergableError(me.err) {
+				return true
+			}
+		}
+		return false
+	}
+	// Check for the UnmergablePRError type, possibly wrapped by fmt.Errorf.
+	var unmergable github.UnmergablePRError
+	return errors.As(err, &unmergable)
 }
 
 func prKey(pr *CodeReviewCommon) string {
@@ -1556,8 +1638,31 @@ func (c *syncController) takeAction(sp subpool, batchPending, successes, pending
 	// Do not merge PRs while waiting for a batch to complete. We don't want to
 	// invalidate the old batch result.
 	if len(successes) > 0 && len(batchPending) == 0 {
-		if ok, pr := pickHighestPriorityPR(sp.log, successes, sp.cc, c.isPassingTests, c.config().Tide.Priority); ok {
+		// Filter out PRs that recently failed to merge (e.g. due to branch
+		// protection rejecting the merge). This prevents Tide from getting
+		// stuck retrying the same unmergeable PR every sync cycle while
+		// other mergeable PRs wait behind it.
+		// See https://github.com/kubernetes-sigs/prow/issues/673
+		eligible := make([]CodeReviewCommon, 0, len(successes))
+		for _, pr := range successes {
+			if c.isExcludedFromMerge(sp.org, sp.repo, pr.Number, pr.HeadRefOID) {
+				sp.log.WithFields(pr.logFields()).Debug("Skipping PR temporarily excluded from merging due to recent merge failure.")
+				continue
+			}
+			eligible = append(eligible, pr)
+		}
+		if ok, pr := pickHighestPriorityPR(sp.log, eligible, sp.cc, c.isPassingTests, c.config().Tide.Priority); ok {
 			merged, err = c.provider.mergePRs(sp, []CodeReviewCommon{pr}, c.statusUpdate.dontUpdateStatus)
+			if err != nil {
+				// If the merge failed with an unmergeable error, exclude this PR
+				// at its current head SHA temporarily so Tide advances to the
+				// next candidate on the next sync cycle. If the author pushes
+				// new commits, the SHA changes and the exclusion no longer applies.
+				if isUnmergableError(err) {
+					c.excludeFromMerge(sp.org, sp.repo, pr.Number, pr.HeadRefOID)
+					sp.log.WithFields(pr.logFields()).WithError(err).Warning("PR merge rejected by GitHub, temporarily excluding from merge queue.")
+				}
+			}
 			return Merge, []CodeReviewCommon{pr}, err
 		}
 	}

--- a/pkg/tide/tide.go
+++ b/pkg/tide/tide.go
@@ -100,8 +100,8 @@ type syncController struct {
 	// UnmergablePRError (e.g. due to branch protection requiring more
 	// reviews). These PRs are temporarily skipped so Tide can advance
 	// to the next mergeable PR instead of retrying the same one.
-	// Key: "org/repo#number@sha", Value: time of failure.
-	mergeExclusions   map[string]time.Time
+	// Key: "org/repo#number@sha", Value: remaining sync cycles to skip.
+	mergeExclusions   map[string]int
 	mergeExclusionsMu sync.Mutex
 }
 
@@ -498,7 +498,7 @@ func newSyncController(
 		},
 		History:         hist,
 		statusUpdate:    statusUpdate,
-		mergeExclusions: make(map[string]time.Time),
+		mergeExclusions: make(map[string]int),
 	}, nil
 }
 
@@ -512,9 +512,11 @@ func setupSyncControllerIndexes(ctx context.Context, indexer ctrlruntimeclient.F
 	return nil
 }
 
-// mergeExclusionTTL is how long a PR stays excluded after a merge failure
-// before Tide retries it.
-const mergeExclusionTTL = 5 * time.Minute
+// mergeExclusionSyncs is how many additional sync cycles a PR stays
+// excluded after a merge failure, before Tide retries it. Counting sync
+// cycles rather than wall-clock time means the exclusion behaves the same
+// regardless of how frequently Tide is configured to sync.
+const mergeExclusionSyncs = 3
 
 // mergeExclusionKey returns a unique key for tracking merge exclusions.
 // The key includes the head SHA so that when an author pushes new commits,
@@ -543,7 +545,7 @@ func (c *syncController) excludeFromMerge(org, repo string, number int, sha stri
 			delete(c.mergeExclusions, key)
 		}
 	}
-	c.mergeExclusions[mergeExclusionKey(org, repo, number, sha)] = time.Now()
+	c.mergeExclusions[mergeExclusionKey(org, repo, number, sha)] = mergeExclusionSyncs
 }
 
 // isExcludedFromMerge returns true if a PR at its current head SHA is
@@ -553,15 +555,42 @@ func (c *syncController) isExcludedFromMerge(org, repo string, number int, sha s
 	c.mergeExclusionsMu.Lock()
 	defer c.mergeExclusionsMu.Unlock()
 	key := mergeExclusionKey(org, repo, number, sha)
-	failedAt, ok := c.mergeExclusions[key]
-	if !ok {
-		return false
+	remaining, ok := c.mergeExclusions[key]
+	return ok && remaining > 0
+}
+
+// ageMergeExclusions decrements the remaining sync count for every merge
+// exclusion by one and removes entries that have run out. It must be
+// called exactly once per Sync() cycle, before subpools are synced, so a
+// PR excluded after a merge failure is skipped for a bounded number of
+// subsequent syncs.
+func (c *syncController) ageMergeExclusions() {
+	c.mergeExclusionsMu.Lock()
+	defer c.mergeExclusionsMu.Unlock()
+	for key, remaining := range c.mergeExclusions {
+		remaining--
+		if remaining <= 0 {
+			delete(c.mergeExclusions, key)
+		} else {
+			c.mergeExclusions[key] = remaining
+		}
 	}
-	if time.Since(failedAt) >= mergeExclusionTTL {
-		delete(c.mergeExclusions, key)
-		return false
+}
+
+// filterExcludedFromMerge removes PRs that are temporarily excluded from
+// merging (e.g. due to a recent UnmergablePRError) so they are not
+// considered as merge candidates, whether for a direct merge or as part of
+// a new batch.
+func (c *syncController) filterExcludedFromMerge(log *logrus.Entry, org, repo string, prs []CodeReviewCommon) []CodeReviewCommon {
+	eligible := make([]CodeReviewCommon, 0, len(prs))
+	for _, pr := range prs {
+		if c.isExcludedFromMerge(org, repo, pr.Number, pr.HeadRefOID) {
+			log.WithFields(pr.logFields()).Debug("Skipping PR temporarily excluded from merging due to recent merge failure.")
+			continue
+		}
+		eligible = append(eligible, pr)
 	}
-	return true
+	return eligible
 }
 
 // isUnmergableError checks whether an error from mergePRs wraps an
@@ -583,6 +612,33 @@ func isUnmergableError(err error) bool {
 	// Check for the UnmergablePRError type, possibly wrapped by fmt.Errorf.
 	var unmergable github.UnmergablePRError
 	return errors.As(err, &unmergable)
+}
+
+// excludeUnmergablePRsFromBatch inspects a batch merge error and excludes
+// any individual PR that failed with an UnmergablePRError from future merge
+// attempts at its current head SHA. This keeps a single unmergeable PR in a
+// batch from blocking that PR's fellow PRs on every sync cycle, whether the
+// batch is retried whole or the PR resurfaces in a later batch.
+func (c *syncController) excludeUnmergablePRsFromBatch(sp subpool, batch []CodeReviewCommon, err error) {
+	mf, ok := err.(*mergeFailure)
+	if !ok {
+		return
+	}
+	shaByNumber := make(map[int]string, len(batch))
+	for _, pr := range batch {
+		shaByNumber[pr.Number] = pr.HeadRefOID
+	}
+	for _, me := range mf.errs {
+		if !isUnmergableError(me.err) {
+			continue
+		}
+		sha, ok := shaByNumber[me.pr]
+		if !ok {
+			continue
+		}
+		c.excludeFromMerge(sp.org, sp.repo, me.pr, sha)
+		sp.log.WithField("pr", me.pr).WithError(me.err).Warning("PR merge rejected by GitHub in batch, temporarily excluding from merge queue.")
+	}
 }
 
 func prKey(pr *CodeReviewCommon) string {
@@ -611,6 +667,7 @@ func contextsToStrings(contexts []Context) []string {
 
 // Sync runs one sync iteration.
 func (c *syncController) Sync() error {
+	c.ageMergeExclusions()
 	start := time.Now()
 	defer func() {
 		duration := time.Since(start)
@@ -1298,6 +1355,10 @@ func (c *syncController) pickBatch(sp subpool, cc map[int]contextChecker, newBat
 	}
 
 	log := sp.log.WithField("subpool_pr_count", len(sp.prs))
+	// Exclude PRs that recently failed to merge so a single unmergeable PR
+	// cannot keep re-entering (and blocking) a batch every sync cycle.
+	// See https://github.com/kubernetes-sigs/prow/issues/673
+	candidates = c.filterExcludedFromMerge(sp.log, sp.org, sp.repo, candidates)
 	if len(candidates) == 0 {
 		log.Debug("None of the prs in the subpool was passing tests, no batch will be created")
 		return nil, nil, nil
@@ -1633,6 +1694,9 @@ func (c *syncController) takeAction(sp subpool, batchPending, successes, pending
 	// Merge the batch!
 	if len(batchMerges) > 0 {
 		merged, err = c.provider.mergePRs(sp, batchMerges, c.statusUpdate.dontUpdateStatus)
+		if err != nil {
+			c.excludeUnmergablePRsFromBatch(sp, batchMerges, err)
+		}
 		return MergeBatch, batchMerges, err
 	}
 	// Do not merge PRs while waiting for a batch to complete. We don't want to
@@ -1643,14 +1707,7 @@ func (c *syncController) takeAction(sp subpool, batchPending, successes, pending
 		// stuck retrying the same unmergeable PR every sync cycle while
 		// other mergeable PRs wait behind it.
 		// See https://github.com/kubernetes-sigs/prow/issues/673
-		eligible := make([]CodeReviewCommon, 0, len(successes))
-		for _, pr := range successes {
-			if c.isExcludedFromMerge(sp.org, sp.repo, pr.Number, pr.HeadRefOID) {
-				sp.log.WithFields(pr.logFields()).Debug("Skipping PR temporarily excluded from merging due to recent merge failure.")
-				continue
-			}
-			eligible = append(eligible, pr)
-		}
+		eligible := c.filterExcludedFromMerge(sp.log, sp.org, sp.repo, successes)
 		if ok, pr := pickHighestPriorityPR(sp.log, eligible, sp.cc, c.isPassingTests, c.config().Tide.Priority); ok {
 			merged, err = c.provider.mergePRs(sp, []CodeReviewCommon{pr}, c.statusUpdate.dontUpdateStatus)
 			if err != nil {

--- a/pkg/tide/tide_test.go
+++ b/pkg/tide/tide_test.go
@@ -2197,6 +2197,216 @@ func testTakeAction(clients localgit.Clients, t *testing.T) {
 	}
 }
 
+func TestTakeActionSkipsExcludedPRs(t *testing.T) {
+	// This test verifies that when a PR fails to merge with UnmergablePRError
+	// (e.g. due to branch protection requiring more reviews), Tide excludes it
+	// on the next sync cycle and advances to the next mergeable PR.
+	// See https://github.com/kubernetes-sigs/prow/issues/673
+	sleep = func(time.Duration) {}
+	defer func() { sleep = time.Sleep }()
+
+	lg, gc, err := localgit.NewV2()
+	if err != nil {
+		t.Fatalf("Error making local git: %v", err)
+	}
+	defer gc.Clean()
+	defer lg.Clean()
+	if err := lg.MakeFakeRepo("o", "r"); err != nil {
+		t.Fatalf("Error making fake repo: %v", err)
+	}
+	if err := lg.AddCommit("o", "r", map[string][]byte{"foo": []byte("foo")}); err != nil {
+		t.Fatalf("Adding initial commit: %v", err)
+	}
+
+	// Create two PRs: #1 (unmergeable) and #2 (mergeable).
+	// pickHighestPriorityPR picks lowest-numbered first, so #1 will always
+	// be picked before #2 unless excluded.
+	sp := subpool{
+		log:        logrus.WithField("component", "tide"),
+		presubmits: map[int][]config.Presubmit{},
+		cc: map[int]contextChecker{
+			1: &config.TideContextPolicy{},
+			2: &config.TideContextPolicy{},
+		},
+		org:    "o",
+		repo:   "r",
+		branch: defaultBranch,
+		sha:    defaultBranch,
+	}
+
+	var successes []CodeReviewCommon
+	for _, i := range []int{1, 2} {
+		if err := lg.CheckoutNewBranch("o", "r", fmt.Sprintf("pr-%d", i)); err != nil {
+			t.Fatalf("Error checking out new branch: %v", err)
+		}
+		if err := lg.AddCommit("o", "r", map[string][]byte{fmt.Sprintf("%d", i): []byte("WOW")}); err != nil {
+			t.Fatalf("Error adding commit: %v", err)
+		}
+		if err := lg.Checkout("o", "r", defaultBranch); err != nil {
+			t.Fatalf("Error checking out master: %v", err)
+		}
+		oid := githubql.String(fmt.Sprintf("origin/pr-%d", i))
+		var pr PullRequest
+		pr.Number = githubql.Int(i)
+		pr.HeadRefOID = oid
+		pr.Commits.Nodes = []struct {
+			Commit Commit
+		}{{Commit: Commit{OID: oid}}}
+		sp.prs = append(sp.prs, *CodeReviewCommonFromPullRequest(&pr))
+		successes = append(successes, *CodeReviewCommonFromPullRequest(&pr))
+	}
+
+	ca := &config.Agent{}
+	cfg := &config.Config{
+		ProwConfig: config.ProwConfig{
+			ProwJobNamespace: "pj-ns",
+		},
+	}
+	ca.Set(cfg)
+
+	log := logrus.WithField("controller", "tide")
+	ctx := context.Background()
+
+	// --- Sync cycle 1: PR #1 fails with UnmergablePRError ---
+	fgc1 := fgc{mergeErrs: map[int]error{1: github.UnmergablePRError("required review count not met")}}
+	ghProvider1 := newGitHubProvider(log, &fgc1, gc, ca.Config, nil, false)
+	mgr1 := newFakeManager(t, ctx)
+	c, err := newSyncController(ctx, log, mgr1, ghProvider1, ca.Config, gc, nil, false, &statusUpdate{
+		dontUpdateStatus: &threadSafePRSet{},
+		newPoolPending:   make(chan bool),
+	})
+	if err != nil {
+		t.Fatalf("failed to construct sync controller: %v", err)
+	}
+	c.changedFiles = &changedFilesAgent{
+		provider:        ghProvider1,
+		nextChangeCache: make(map[changeCacheKey][]string),
+	}
+
+	act, targets, err := c.takeAction(sp, nil, successes, nil, nil, nil, nil)
+	if act != Merge {
+		t.Errorf("Sync 1: expected Merge action, got %v", act)
+	}
+	if err == nil {
+		t.Fatal("Sync 1: expected error from takeAction, got nil")
+	}
+	// Should have tried to merge PR #1 (lowest number)
+	if len(targets) != 1 || targets[0].Number != 1 {
+		t.Errorf("Sync 1: expected target PR #1, got %v", targets)
+	}
+	if fgc1.merged != 0 {
+		t.Errorf("Sync 1: expected 0 merges (PR #1 should fail), got %d", fgc1.merged)
+	}
+
+	// Verify PR #1 is now excluded at its current SHA
+	pr1SHA := successes[0].HeadRefOID
+	if !c.isExcludedFromMerge("o", "r", 1, pr1SHA) {
+		t.Error("Sync 1: PR #1 should be excluded from merging after UnmergablePRError")
+	}
+
+	// --- Sync cycle 2: same controller, PR #1 excluded, PR #2 should be picked ---
+	fgc2 := fgc{mergeErrs: map[int]error{1: github.UnmergablePRError("required review count not met")}}
+	ghProvider2 := newGitHubProvider(log, &fgc2, gc, ca.Config, nil, false)
+	c.provider = ghProvider2
+
+	act, targets, err = c.takeAction(sp, nil, successes, nil, nil, nil, nil)
+	if act != Merge {
+		t.Errorf("Sync 2: expected Merge action, got %v", act)
+	}
+	if err != nil {
+		t.Errorf("Sync 2: expected no error (PR #2 should merge), got: %v", err)
+	}
+	// Should have tried to merge PR #2 since PR #1 is excluded
+	if len(targets) != 1 || targets[0].Number != 2 {
+		t.Errorf("Sync 2: expected target PR #2, got %v", targets)
+	}
+	if fgc2.merged != 1 {
+		t.Errorf("Sync 2: expected 1 merge (PR #2), got %d", fgc2.merged)
+	}
+}
+
+func TestIsUnmergableError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "nil error",
+			err:      nil,
+			expected: false,
+		},
+		{
+			name:     "direct UnmergablePRError",
+			err:      github.UnmergablePRError("test"),
+			expected: true,
+		},
+		{
+			name:     "wrapped UnmergablePRError",
+			err:      fmt.Errorf("PR is unmergable: %w", github.UnmergablePRError("test")),
+			expected: true,
+		},
+		{
+			name: "mergeFailure containing UnmergablePRError",
+			err: &mergeFailure{errs: []mergeErr{
+				{err: fmt.Errorf("PR is unmergable: %w", github.UnmergablePRError("test")), pr: 1},
+			}},
+			expected: true,
+		},
+		{
+			name:     "unrelated error",
+			err:      errors.New("something else"),
+			expected: false,
+		},
+		{
+			name:     "UnauthorizedToPushError",
+			err:      github.UnauthorizedToPushError("no push"),
+			expected: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isUnmergableError(tc.err); got != tc.expected {
+				t.Errorf("isUnmergableError(%v) = %v, want %v", tc.err, got, tc.expected)
+			}
+		})
+	}
+}
+
+func TestMergeExclusionExpiry(t *testing.T) {
+	c := &syncController{
+		mergeExclusions: make(map[string]time.Time),
+	}
+
+	// Exclude PR #1 at sha "abc123"
+	c.excludeFromMerge("o", "r", 1, "abc123")
+	if !c.isExcludedFromMerge("o", "r", 1, "abc123") {
+		t.Error("PR should be excluded immediately after exclusion")
+	}
+
+	// A new push (different SHA) should not be excluded
+	if c.isExcludedFromMerge("o", "r", 1, "def456") {
+		t.Error("PR with a new head SHA should not be excluded")
+	}
+
+	// Manually set the exclusion time to the past (beyond TTL)
+	c.mergeExclusionsMu.Lock()
+	c.mergeExclusions[mergeExclusionKey("o", "r", 1, "abc123")] = time.Now().Add(-mergeExclusionTTL - time.Second)
+	c.mergeExclusionsMu.Unlock()
+
+	if c.isExcludedFromMerge("o", "r", 1, "abc123") {
+		t.Error("PR should no longer be excluded after TTL expires")
+	}
+
+	// Verify the expired entry was cleaned up
+	c.mergeExclusionsMu.Lock()
+	if _, ok := c.mergeExclusions[mergeExclusionKey("o", "r", 1, "abc123")]; ok {
+		t.Error("Expired exclusion entry should be cleaned up")
+	}
+	c.mergeExclusionsMu.Unlock()
+}
+
 func TestServeHTTP(t *testing.T) {
 	pr1 := PullRequest{}
 	pr1.Commits.Nodes = append(pr1.Commits.Nodes, struct{ Commit Commit }{})

--- a/pkg/tide/tide_test.go
+++ b/pkg/tide/tide_test.go
@@ -2374,9 +2374,9 @@ func TestIsUnmergableError(t *testing.T) {
 	}
 }
 
-func TestMergeExclusionExpiry(t *testing.T) {
+func TestMergeExclusionAging(t *testing.T) {
 	c := &syncController{
-		mergeExclusions: make(map[string]time.Time),
+		mergeExclusions: make(map[string]int),
 	}
 
 	// Exclude PR #1 at sha "abc123"
@@ -2390,21 +2390,230 @@ func TestMergeExclusionExpiry(t *testing.T) {
 		t.Error("PR with a new head SHA should not be excluded")
 	}
 
-	// Manually set the exclusion time to the past (beyond TTL)
-	c.mergeExclusionsMu.Lock()
-	c.mergeExclusions[mergeExclusionKey("o", "r", 1, "abc123")] = time.Now().Add(-mergeExclusionTTL - time.Second)
-	c.mergeExclusionsMu.Unlock()
-
-	if c.isExcludedFromMerge("o", "r", 1, "abc123") {
-		t.Error("PR should no longer be excluded after TTL expires")
+	// The exclusion should survive all but the last of the sync cycles it
+	// was granted.
+	for i := range mergeExclusionSyncs - 1 {
+		c.ageMergeExclusions()
+		if !c.isExcludedFromMerge("o", "r", 1, "abc123") {
+			t.Fatalf("PR should still be excluded after %d of %d sync cycles", i+1, mergeExclusionSyncs)
+		}
 	}
 
-	// Verify the expired entry was cleaned up
+	// One more sync cycle should expire the exclusion.
+	c.ageMergeExclusions()
+	if c.isExcludedFromMerge("o", "r", 1, "abc123") {
+		t.Error("PR should no longer be excluded after mergeExclusionSyncs cycles")
+	}
+
+	// Verify the expired entry was cleaned up.
 	c.mergeExclusionsMu.Lock()
 	if _, ok := c.mergeExclusions[mergeExclusionKey("o", "r", 1, "abc123")]; ok {
 		t.Error("Expired exclusion entry should be cleaned up")
 	}
 	c.mergeExclusionsMu.Unlock()
+}
+
+func TestExcludeFromMergeReplacesPriorSHA(t *testing.T) {
+	c := &syncController{
+		mergeExclusions: make(map[string]int),
+	}
+
+	c.excludeFromMerge("o", "r", 1, "abc123")
+	c.ageMergeExclusions() // remaining goes from mergeExclusionSyncs to mergeExclusionSyncs-1
+
+	// A new push (new SHA) resets the exclusion.
+	c.excludeFromMerge("o", "r", 1, "def456")
+
+	c.mergeExclusionsMu.Lock()
+	if _, ok := c.mergeExclusions[mergeExclusionKey("o", "r", 1, "abc123")]; ok {
+		t.Error("stale entry for old SHA should have been removed")
+	}
+	if got := c.mergeExclusions[mergeExclusionKey("o", "r", 1, "def456")]; got != mergeExclusionSyncs {
+		t.Errorf("new SHA should start with a fresh count of %d, got %d", mergeExclusionSyncs, got)
+	}
+	c.mergeExclusionsMu.Unlock()
+}
+
+func TestTakeActionExcludesPRThatFailsInBatch(t *testing.T) {
+	// This test verifies that when an individual PR within a MERGE_BATCH
+	// fails to merge with UnmergablePRError, only that PR is excluded from
+	// future merge attempts -- its batch-mates, which merged fine, are not.
+	// See https://github.com/kubernetes-sigs/prow/pull/674#issuecomment-4187300292
+	sleep = func(time.Duration) {}
+	defer func() { sleep = time.Sleep }()
+
+	lg, gc, err := localgit.NewV2()
+	if err != nil {
+		t.Fatalf("Error making local git: %v", err)
+	}
+	defer gc.Clean()
+	defer lg.Clean()
+	if err := lg.MakeFakeRepo("o", "r"); err != nil {
+		t.Fatalf("Error making fake repo: %v", err)
+	}
+	if err := lg.AddCommit("o", "r", map[string][]byte{"foo": []byte("foo")}); err != nil {
+		t.Fatalf("Adding initial commit: %v", err)
+	}
+
+	sp := subpool{
+		log:    logrus.WithField("component", "tide"),
+		org:    "o",
+		repo:   "r",
+		branch: defaultBranch,
+		sha:    defaultBranch,
+	}
+	var batch []CodeReviewCommon
+	for _, number := range []int{1, 2, 3} {
+		if err := lg.CheckoutNewBranch("o", "r", fmt.Sprintf("pr-%d", number)); err != nil {
+			t.Fatalf("Error checking out new branch: %v", err)
+		}
+		if err := lg.AddCommit("o", "r", map[string][]byte{fmt.Sprintf("%d", number): []byte("WOW")}); err != nil {
+			t.Fatalf("Error adding commit: %v", err)
+		}
+		if err := lg.Checkout("o", "r", defaultBranch); err != nil {
+			t.Fatalf("Error checking out master: %v", err)
+		}
+		oid := githubql.String(fmt.Sprintf("origin/pr-%d", number))
+		var pr PullRequest
+		pr.Number = githubql.Int(number)
+		pr.HeadRefOID = oid
+		pr.Commits.Nodes = []struct {
+			Commit Commit
+		}{{Commit: Commit{OID: oid}}}
+		sp.prs = append(sp.prs, *CodeReviewCommonFromPullRequest(&pr))
+		batch = append(batch, *CodeReviewCommonFromPullRequest(&pr))
+	}
+
+	ca := &config.Agent{}
+	ca.Set(&config.Config{ProwConfig: config.ProwConfig{ProwJobNamespace: "pj-ns"}})
+	log := logrus.WithField("controller", "tide")
+	ctx := context.Background()
+	fgc := fgc{mergeErrs: map[int]error{2: github.UnmergablePRError("required review count not met")}}
+	ghProvider := newGitHubProvider(log, &fgc, gc, ca.Config, nil, false)
+	mgr := newFakeManager(t, ctx)
+	c, err := newSyncController(ctx, log, mgr, ghProvider, ca.Config, gc, nil, false, &statusUpdate{
+		dontUpdateStatus: &threadSafePRSet{},
+		newPoolPending:   make(chan bool),
+	})
+	if err != nil {
+		t.Fatalf("failed to construct sync controller: %v", err)
+	}
+	c.changedFiles = &changedFilesAgent{
+		provider:        ghProvider,
+		nextChangeCache: make(map[changeCacheKey][]string),
+	}
+
+	act, _, err := c.takeAction(sp, nil, nil, nil, nil, batch, nil)
+	if act != MergeBatch {
+		t.Fatalf("expected MergeBatch action, got %v", act)
+	}
+	if err == nil {
+		t.Fatal("expected an error from the batch merge (PR #2 unmergeable), got nil")
+	}
+
+	if c.isExcludedFromMerge("o", "r", 1, batch[0].HeadRefOID) {
+		t.Error("PR #1 merged fine and should not be excluded")
+	}
+	if !c.isExcludedFromMerge("o", "r", 2, batch[1].HeadRefOID) {
+		t.Error("PR #2 failed with UnmergablePRError and should be excluded")
+	}
+	if c.isExcludedFromMerge("o", "r", 3, batch[2].HeadRefOID) {
+		t.Error("PR #3 merged fine and should not be excluded")
+	}
+}
+
+func TestPickBatchExcludesMergeExcludedPR(t *testing.T) {
+	// This test verifies that a PR temporarily excluded from merging (e.g.
+	// after a recent UnmergablePRError) is not picked as a batch candidate,
+	// so it cannot keep re-entering (and blocking) a batch every sync cycle.
+	// See https://github.com/kubernetes-sigs/prow/issues/673
+	lg, gc, err := localgit.NewV2()
+	if err != nil {
+		t.Fatalf("Error making local git: %v", err)
+	}
+	defer gc.Clean()
+	defer lg.Clean()
+	if err := lg.MakeFakeRepo("o", "r"); err != nil {
+		t.Fatalf("Error making fake repo: %v", err)
+	}
+	if err := lg.AddCommit("o", "r", map[string][]byte{"foo": []byte("foo")}); err != nil {
+		t.Fatalf("Adding initial commit: %v", err)
+	}
+
+	sp := subpool{
+		log:    logrus.WithField("component", "tide"),
+		org:    "o",
+		repo:   "r",
+		branch: defaultBranch,
+		sha:    defaultBranch,
+	}
+	for _, number := range []int{1, 2} {
+		if err := lg.CheckoutNewBranch("o", "r", fmt.Sprintf("pr-%d", number)); err != nil {
+			t.Fatalf("Error checking out new branch: %v", err)
+		}
+		if err := lg.AddCommit("o", "r", map[string][]byte{fmt.Sprintf("%d", number): []byte("ok")}); err != nil {
+			t.Fatalf("Error adding commit: %v", err)
+		}
+		if err := lg.Checkout("o", "r", defaultBranch); err != nil {
+			t.Fatalf("Error checking out master: %v", err)
+		}
+		oid := githubql.String(fmt.Sprintf("origin/pr-%d", number))
+		var pr PullRequest
+		pr.Number = githubql.Int(number)
+		pr.HeadRefOID = oid
+		pr.Commits.Nodes = []struct {
+			Commit Commit
+		}{{Commit: Commit{OID: oid}}}
+		pr.Commits.Nodes[0].Commit.Status.Contexts = []Context{{State: githubql.StatusStateSuccess}}
+		sp.prs = append(sp.prs, *CodeReviewCommonFromPullRequest(&pr))
+	}
+
+	ca := &config.Agent{}
+	ca.Set(&config.Config{
+		ProwConfig: config.ProwConfig{
+			Tide: config.Tide{BatchSizeLimitMap: map[string]int{"*": 5}},
+		},
+		JobConfig: config.JobConfig{
+			PresubmitsStatic: map[string][]config.Presubmit{
+				"o/r": {{AlwaysRun: true, JobBase: config.JobBase{Name: "my-presubmit"}}},
+			},
+		},
+	})
+	logger := logrus.WithField("component", "tide")
+	ghProvider := &GitHubProvider{cfg: ca.Config, gc: gc, mergeChecker: newMergeChecker(ca.Config, &fgc{}), logger: logger}
+	c := &syncController{
+		logger:          logger,
+		provider:        ghProvider,
+		config:          ca.Config,
+		pickNewBatch:    pickNewBatch(gc, ca.Config, ghProvider),
+		mergeExclusions: make(map[string]int),
+	}
+
+	// PR #1 recently failed to merge; it should not re-enter a batch.
+	c.excludeFromMerge("o", "r", 1, sp.prs[0].HeadRefOID)
+
+	prs, _, err := c.pickBatch(sp, map[int]contextChecker{
+		1: &config.TideContextPolicy{},
+		2: &config.TideContextPolicy{},
+	}, c.pickNewBatch)
+	if err != nil {
+		t.Fatalf("Error from pickBatch: %v", err)
+	}
+	var found1, found2 bool
+	for _, pr := range prs {
+		if int(pr.Number) == 1 {
+			found1 = true
+		}
+		if int(pr.Number) == 2 {
+			found2 = true
+		}
+	}
+	if found1 {
+		t.Error("PR #1 is temporarily excluded from merging and should not be picked for a batch")
+	}
+	if !found2 {
+		t.Error("PR #2 should still be picked for a batch")
+	}
 }
 
 func TestServeHTTP(t *testing.T) {


### PR DESCRIPTION
## Summary

- When a PR fails to merge with `UnmergablePRError` (e.g. branch protection requires more reviews than the PR has), Tide now temporarily excludes that PR from the merge queue for 5 minutes
- This allows other mergeable PRs to proceed instead of the entire queue being blocked by a single unmergeable PR retried every sync cycle
- The exclusion key includes the PR's head SHA, so pushing new commits automatically clears the exclusion

Fixes https://github.com/kubernetes-sigs/prow/issues/673
Related: https://github.com/kubernetes-sigs/prow/issues/134

### Root cause

In [`takeAction()`](https://github.com/kubernetes-sigs/prow/blob/d01b8af18f00474804250403f9bc3d8e45852190/pkg/tide/tide.go#L1434-L1437), `pickHighestPriorityPR()` deterministically picks the lowest-numbered PR from `successes`. When that PR fails to merge (GitHub returns HTTP 405), [`accumulate()`](https://github.com/kubernetes-sigs/prow/blob/d01b8af18f00474804250403f9bc3d8e45852190/pkg/tide/tide.go#L1061-L1062) puts it right back into `successes` on the next sync cycle (since CI status is fine), and the same PR gets picked again indefinitely.

### Changes

**`pkg/tide/tide.go`:**
- Add `mergeExclusions` map to `syncController` — tracks `org/repo#number@SHA` → failure timestamp
- `excludeFromMerge()` / `isExcludedFromMerge()` — thread-safe helpers with 5-minute TTL and lazy cleanup
- `isUnmergableError()` — unwraps `*mergeFailure` and `fmt.Errorf`-wrapped errors to detect `UnmergablePRError`
- `takeAction()` — filters excluded PRs from `successes` before calling `pickHighestPriorityPR()`, records new exclusions on `UnmergablePRError`

**`pkg/tide/tide_test.go`:**
- `TestTakeActionSkipsExcludedPRs` — end-to-end: PR #1 fails cycle 1, PR #2 merges cycle 2
- `TestIsUnmergableError` — table-driven: direct, wrapped, nested in `mergeFailure`, negative cases
- `TestMergeExclusionExpiry` — TTL expiry, SHA-scoped invalidation, cleanup

## Test plan

- [x] `TestTakeActionSkipsExcludedPRs` — verifies PR #1 excluded after `UnmergablePRError`, PR #2 picked on next sync
- [x] `TestIsUnmergableError` — verifies error detection for all error wrapping scenarios
- [x] `TestMergeExclusionExpiry` — verifies TTL expiry, new-SHA invalidation, and map cleanup
- [x] `TestTakeActionV2` — all existing takeAction tests still pass
- [x] Full `go test ./pkg/tide/` passes