### PR TITLE
trigger: add hierarchical `trusted_apps` config with global/org/repo levels

### DIFF
--- a/cmd/checkconfig/main.go
+++ b/cmd/checkconfig/main.go
@@ -125,6 +125,7 @@ const (
 	requiredJobAnnotationsWarning                  = "required-job-annotations"
 	periodicDefaultCloneWarning                    = "periodic-default-clone-config"
 	validateConfigUpdaterACLsWarning               = "validate-config-updater-acls"
+	validateLockedTrustedAppsWarning                = "validate-locked-trusted-apps"
 
 	defaultHourlyTokens = 3000
 	defaultAllowedBurst = 100
@@ -163,6 +164,7 @@ var optionalWarnings = []string{
 	// https://github.com/kubernetes/test-infra/pull/21075#issuecomment-862550510
 	unknownFieldsAllWarning,
 	validateGitHubAppInstallationWarning,
+	validateLockedTrustedAppsWarning,
 }
 
 var throttlerDefaults = flagutil.ThrottlerDefaults(defaultHourlyTokens, defaultAllowedBurst)
@@ -442,6 +444,11 @@ func validate(o options) error {
 
 	if pcfg != nil && o.warningEnabled(validateConfigUpdaterACLsWarning) {
 		if err := validateConfigUpdaterACLs(pcfg); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	if pcfg != nil && o.warningEnabled(validateLockedTrustedAppsWarning) {
+		if err := pcfg.ValidateLockedTrustedApps(); err != nil {
 			errs = append(errs, err)
 		}
 	}

--- a/pkg/plugins/config.go
+++ b/pkg/plugins/config.go
@@ -33,6 +33,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 
@@ -548,16 +549,59 @@ type OrgInviteConfig struct {
 	Prominent ProminentOrgInviteConfig `json:"prominent,omitzero"`
 }
 
+// TrustedApp represents a single app entry in the trusted_apps configuration.
+type TrustedApp struct {
+	// Name is the GitHub App username without the [bot] suffix.
+	Name string `json:"name"`
+	// Untrusted, if true, means this app is explicitly NOT trusted at this level.
+	// When absent or false, the app is trusted.
+	Untrusted bool `json:"untrusted,omitempty"`
+	// Locked, if true, means lower configuration levels cannot override this app's trust setting.
+	// Only meaningful at global and org levels.
+	Locked bool `json:"locked,omitempty"`
+}
+
+// TrustedApps is a list of TrustedApp entries. It supports unmarshaling from both
+// the legacy format (a list of plain strings) and the new format (a list of objects),
+// as well as mixed arrays containing both.
+type TrustedApps []TrustedApp
+
+// UnmarshalJSON implements custom JSON unmarshaling for backward compatibility.
+// Each array element can be either a bare string ("app-name") or an object ({"name": "app-name", ...}).
+func (ta *TrustedApps) UnmarshalJSON(data []byte) error {
+	var raw []json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	result := make([]TrustedApp, len(raw))
+	for i, elem := range raw {
+		// Try as string first (legacy format)
+		var name string
+		if err := json.Unmarshal(elem, &name); err == nil {
+			result[i] = TrustedApp{Name: name}
+			continue
+		}
+		// Try as object (new format)
+		if err := json.Unmarshal(elem, &result[i]); err != nil {
+			return fmt.Errorf("trusted_apps element %d: must be a string or an object with name, untrusted, and locked fields: %w", i, err)
+		}
+	}
+	*ta = result
+	return nil
+}
+
 // Trigger specifies a configuration for a single trigger.
 //
 // The configuration for the trigger plugin is defined as a list of these structures.
 type Trigger struct {
 	// Repos is either of the form org/repos or just org.
+	// Use `*` to define a global trigger whose trusted_apps apply to all repos.
 	Repos []string `json:"repos,omitempty"`
-	// TrustedApps is the explicit list of GitHub apps whose PRs will be automatically
+	// TrustedApps is the list of GitHub apps whose PRs will be automatically
 	// considered as trusted. The list should contain usernames of each GitHub App without [bot] suffix.
+	// Each entry can specify untrusted and locked fields for hierarchical configuration.
 	// By default, trigger will ignore this list.
-	TrustedApps []string `json:"trusted_apps,omitempty"`
+	TrustedApps TrustedApps `json:"trusted_apps,omitempty"`
 	// TrustedOrg is the org whose members' PRs will be automatically built for
 	// PRs to the above repos. The default is the PR's org.
 	//
@@ -579,6 +623,17 @@ type Trigger struct {
 	// OrgInvite holds configuration for the org invite message
 	// shown to non-org members when they open a PR.
 	OrgInvite OrgInviteConfig `json:"org_invite,omitzero"`
+
+	// resolvedTrustedApps is populated by TriggerFor with the final flat list of
+	// trusted app names after hierarchical resolution across global, org, and repo levels.
+	resolvedTrustedApps []string
+}
+
+// GetTrustedApps returns the resolved list of trusted app names.
+// The Trigger should be obtained via TriggerFor, which populates the resolved list
+// through hierarchical resolution. If resolution did not happen, no apps are trusted.
+func (t *Trigger) GetTrustedApps() []string {
+	return t.resolvedTrustedApps
 }
 
 // Heart contains the configuration for the heart plugin.
@@ -1079,29 +1134,95 @@ func (c *Configuration) LgtmFor(org, repo string) *Lgtm {
 	return &Lgtm{}
 }
 
-// TriggerFor finds the Trigger for a repo, if one exists
-// a trigger can be listed for the repo itself or for the
-// owning organization
+// TriggerFor finds the Trigger for a repo, if one exists.
+// A trigger can be listed for the repo itself or for the owning organization.
+// The returned Trigger has its trusted apps resolved across global, org, and repo levels.
 func (c *Configuration) TriggerFor(org, repo string) Trigger {
 	fullName := fmt.Sprintf("%s/%s", org, repo)
-	// Prioritize repo level triggers over org level triggers.
+	var repoMatch, orgMatch Trigger
+	var foundRepo, foundOrg bool
+	var globalApps, orgApps, repoApps TrustedApps
 	for _, trigger := range c.Triggers {
-		if !sets.NewString(trigger.Repos...).Has(fullName) {
-			continue
+		repos := sets.New[string](trigger.Repos...)
+		switch {
+		case repos.Has("*"):
+			globalApps = append(globalApps, trigger.TrustedApps...)
+		case repos.Has(fullName):
+			repoApps = append(repoApps, trigger.TrustedApps...)
+			if !foundRepo {
+				repoMatch = trigger
+				foundRepo = true
+			}
+		case repos.Has(org):
+			orgApps = append(orgApps, trigger.TrustedApps...)
+			if !foundOrg {
+				orgMatch = trigger
+				foundOrg = true
+			}
 		}
-		return trigger
-	}
-	// If you don't find anything, loop again looking for an org config
-	for _, trigger := range c.Triggers {
-		if !sets.NewString(trigger.Repos...).Has(org) {
-			continue
-		}
-		return trigger
 	}
 
-	var tr Trigger
-	tr.SetDefaults()
-	return tr
+	var result Trigger
+	switch {
+	case foundRepo:
+		result = repoMatch
+	case foundOrg:
+		result = orgMatch
+	default:
+		result.SetDefaults()
+	}
+
+	result.resolvedTrustedApps = resolveTrustedApps(globalApps, orgApps, repoApps)
+	return result
+}
+
+// trustedAppState tracks the trust status and lock state of an app during hierarchical resolution.
+type trustedAppState struct {
+	trusted bool
+	locked  bool
+}
+
+// resolveTrustedApps merges trusted app configurations across global, org, and repo levels.
+// It returns the final flat list of trusted app names after applying inheritance,
+// untrusted exclusions, and locked overrides.
+func resolveTrustedApps(globalApps, orgApps, repoApps TrustedApps) []string {
+	state := map[string]*trustedAppState{}
+	for _, app := range globalApps {
+		if s, exists := state[app.Name]; exists && s.locked {
+			continue
+		}
+		state[app.Name] = &trustedAppState{
+			trusted: !app.Untrusted,
+			locked:  app.Locked,
+		}
+	}
+	for _, app := range orgApps {
+		if s, exists := state[app.Name]; exists && s.locked {
+			continue
+		}
+		state[app.Name] = &trustedAppState{
+			trusted: !app.Untrusted,
+			locked:  app.Locked,
+		}
+	}
+	for _, app := range repoApps {
+		if s, exists := state[app.Name]; exists && s.locked {
+			continue
+		}
+		// locked is not set here: repo is the lowest level, so there is nothing to lock against.
+		state[app.Name] = &trustedAppState{
+			trusted: !app.Untrusted,
+		}
+	}
+
+	var result []string
+	for name, s := range state {
+		if s.trusted {
+			result = append(result, name)
+		}
+	}
+	sort.Strings(result)
+	return result
 }
 
 func (t *Trigger) SetDefaults() {
@@ -1522,6 +1643,26 @@ func validateTrigger(triggers []Trigger) error {
 		if trigger.TrustedOrg != "" {
 			logrusutil.ThrottledWarnf(&warnTriggerTrustedOrg, 5*time.Minute, "trusted_org functionality is deprecated. Please ensure your configuration is updated before the end of December 2019.")
 		}
+		if err := validateTrustedApps(trigger.TrustedApps); err != nil {
+			if sets.New[string](trigger.Repos...).Has("*") {
+				return fmt.Errorf("global trigger: %w", err)
+			}
+			return fmt.Errorf("trigger for %v: %w", trigger.Repos, err)
+		}
+	}
+	return nil
+}
+
+func validateTrustedApps(apps TrustedApps) error {
+	seen := map[string]bool{}
+	for _, app := range apps {
+		if app.Name == "" {
+			return errors.New("trusted_apps entry has empty app name")
+		}
+		if seen[app.Name] {
+			return fmt.Errorf("duplicate trusted_apps entry for app %q", app.Name)
+		}
+		seen[app.Name] = true
 	}
 	return nil
 }
@@ -2256,10 +2397,13 @@ type Override struct {
 func (c *Configuration) mergeFrom(other *Configuration) error {
 	var errs []error
 
+	// Trigger has unexported fields, so we need to extend DefaultDiffOpts here
+	// (adding it there would create a circular import between config and plugins).
+	diffOpts := append(config.DefaultDiffOpts, cmpopts.IgnoreUnexported(Trigger{}))
 	diff := cmp.Diff(other, &Configuration{Approve: other.Approve, Bugzilla: other.Bugzilla,
 		ExternalPlugins: other.ExternalPlugins, Label: Label{RestrictedLabels: other.Label.RestrictedLabels},
 		Lgtm: other.Lgtm, Plugins: other.Plugins, Triggers: other.Triggers, Welcome: other.Welcome},
-		config.DefaultDiffOpts...)
+		diffOpts...)
 
 	if diff != "" {
 		errs = append(errs, fmt.Errorf("supplemental plugin configuration has config that doesn't support merging: %s", diff))

--- a/pkg/plugins/config.go
+++ b/pkg/plugins/config.go
@@ -1692,6 +1692,68 @@ func validateInvalidCommitMsg(cfgs []InvalidCommitMsg) error {
 	return utilerrors.NewAggregate(errs)
 }
 
+// ValidateLockedTrustedApps checks whether any lower-level trigger entries attempt to
+// configure trusted apps that are locked at a higher level. This is not an error (the
+// locked setting simply takes precedence), but it may indicate a misconfiguration.
+func (c *Configuration) ValidateLockedTrustedApps() error {
+	globalLocked := map[string]bool{}
+	orgLocked := map[string]map[string]bool{}
+	for _, trigger := range c.Triggers {
+		for _, r := range trigger.Repos {
+			if r == "*" {
+				for _, app := range trigger.TrustedApps {
+					if app.Locked {
+						globalLocked[app.Name] = true
+					}
+				}
+				continue
+			}
+			if strings.Contains(r, "/") {
+				continue
+			}
+			for _, app := range trigger.TrustedApps {
+				if app.Locked {
+					if orgLocked[r] == nil {
+						orgLocked[r] = map[string]bool{}
+					}
+					orgLocked[r][app.Name] = true
+				}
+			}
+		}
+	}
+
+	var errs []error
+
+	for _, trigger := range c.Triggers {
+		for _, r := range trigger.Repos {
+			if r == "*" {
+				continue
+			}
+			if strings.Contains(r, "/") {
+				// Repo-level entry: check against both global and org locks
+				parts := strings.SplitN(r, "/", 2)
+				org := parts[0]
+				for _, app := range trigger.TrustedApps {
+					if globalLocked[app.Name] {
+						errs = append(errs, fmt.Errorf("trigger for %q configures trusted app %q which is locked at global level", r, app.Name))
+					} else if orgLocked[org] != nil && orgLocked[org][app.Name] {
+						errs = append(errs, fmt.Errorf("trigger for %q configures trusted app %q which is locked at org level (%s)", r, app.Name, org))
+					}
+				}
+			} else {
+				// Org-level entry: check against global locks
+				for _, app := range trigger.TrustedApps {
+					if globalLocked[app.Name] {
+						errs = append(errs, fmt.Errorf("trigger for org %q configures trusted app %q which is locked at global level", r, app.Name))
+					}
+				}
+			}
+		}
+	}
+
+	return utilerrors.NewAggregate(errs)
+}
+
 var warnRepoMilestone time.Time
 
 func validateRepoMilestone(milestones map[string]Milestone) {

--- a/pkg/plugins/config_test.go
+++ b/pkg/plugins/config_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package plugins
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"reflect"
@@ -2350,7 +2351,7 @@ func TestMergeFrom(t *testing.T) {
 			}
 		}
 
-		if diff := cmp.Diff(tc.expected, tc.in); !tc.errorExpected && diff != "" {
+		if diff := cmp.Diff(tc.expected, tc.in, cmpopts.IgnoreUnexported(Trigger{})); !tc.errorExpected && diff != "" {
 			t.Errorf("expected config differs from expected: %s", diff)
 		}
 	}
@@ -2929,5 +2930,534 @@ func TestInvalidCommitMsgFor(t *testing.T) {
 				t.Errorf("expected %+v, got %+v", test.expected, *result)
 			}
 		})
+	}
+}
+
+func TestTrustedAppsUnmarshalJSON(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    string
+		expected TrustedApps
+		wantErr  bool
+	}{
+		{
+			name:  "legacy format: list of strings",
+			input: `["app1", "app2"]`,
+			expected: TrustedApps{
+				{Name: "app1"},
+				{Name: "app2"},
+			},
+		},
+		{
+			name:  "new format: list of objects",
+			input: `[{"name": "app1"}, {"name": "app2", "untrusted": true, "locked": true}]`,
+			expected: TrustedApps{
+				{Name: "app1"},
+				{Name: "app2", Untrusted: true, Locked: true},
+			},
+		},
+		{
+			name:  "mixed format: strings and objects",
+			input: `["app1", {"name": "app2", "untrusted": true}]`,
+			expected: TrustedApps{
+				{Name: "app1"},
+				{Name: "app2", Untrusted: true},
+			},
+		},
+		{
+			name:     "empty array",
+			input:    `[]`,
+			expected: TrustedApps{},
+		},
+		{
+			name:    "invalid: not an array",
+			input:   `"not-an-array"`,
+			wantErr: true,
+		},
+		{
+			name:    "invalid: array with invalid element",
+			input:   `[123]`,
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var got TrustedApps
+			err := json.Unmarshal([]byte(tc.input), &got)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if diff := cmp.Diff(tc.expected, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestTrustedAppsUnmarshalYAML(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    string
+		expected TrustedApps
+	}{
+		{
+			name: "legacy YAML format",
+			input: `
+- app1
+- app2
+`,
+			expected: TrustedApps{
+				{Name: "app1"},
+				{Name: "app2"},
+			},
+		},
+		{
+			name: "new YAML format",
+			input: `
+- name: app1
+- name: app2
+  untrusted: true
+  locked: true
+`,
+			expected: TrustedApps{
+				{Name: "app1"},
+				{Name: "app2", Untrusted: true, Locked: true},
+			},
+		},
+		{
+			name: "mixed YAML format",
+			input: `
+- app1
+- name: app2
+  untrusted: true
+`,
+			expected: TrustedApps{
+				{Name: "app1"},
+				{Name: "app2", Untrusted: true},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var got TrustedApps
+			if err := yaml.Unmarshal([]byte(tc.input), &got); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if diff := cmp.Diff(tc.expected, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestResolveTrustedApps(t *testing.T) {
+	testCases := []struct {
+		name     string
+		config   Configuration
+		org      string
+		repo     string
+		expected []string
+	}{
+		{
+			name: "global only: trusted apps",
+			config: Configuration{
+				Triggers: []Trigger{
+					{
+						Repos: []string{"*"},
+						TrustedApps: TrustedApps{
+							{Name: "app1"},
+							{Name: "app2"},
+						},
+					},
+				},
+			},
+			org:      "myorg",
+			repo:     "myrepo",
+			expected: []string{"app1", "app2"},
+		},
+		{
+			name: "global with untrusted",
+			config: Configuration{
+				Triggers: []Trigger{
+					{
+						Repos: []string{"*"},
+						TrustedApps: TrustedApps{
+							{Name: "app1"},
+							{Name: "app2", Untrusted: true},
+						},
+					},
+				},
+			},
+			org:      "myorg",
+			repo:     "myrepo",
+			expected: []string{"app1"},
+		},
+		{
+			name: "org overrides global",
+			config: Configuration{
+				Triggers: []Trigger{
+					{
+						Repos: []string{"*"},
+						TrustedApps: TrustedApps{
+							{Name: "app1"},
+							{Name: "app2"},
+						},
+					},
+					{
+						Repos: []string{"myorg"},
+						TrustedApps: TrustedApps{
+							{Name: "app1", Untrusted: true},
+						},
+					},
+				},
+			},
+			org:      "myorg",
+			repo:     "myrepo",
+			expected: []string{"app2"},
+		},
+		{
+			name: "global locked prevents org override",
+			config: Configuration{
+				Triggers: []Trigger{
+					{
+						Repos: []string{"*"},
+						TrustedApps: TrustedApps{
+							{Name: "app1", Locked: true},
+						},
+					},
+					{
+						Repos: []string{"myorg"},
+						TrustedApps: TrustedApps{
+							{Name: "app1", Untrusted: true},
+						},
+					},
+				},
+			},
+			org:      "myorg",
+			repo:     "myrepo",
+			expected: []string{"app1"},
+		},
+		{
+			name: "global locked untrusted prevents org override",
+			config: Configuration{
+				Triggers: []Trigger{
+					{
+						Repos: []string{"*"},
+						TrustedApps: TrustedApps{
+							{Name: "app1", Untrusted: true, Locked: true},
+						},
+					},
+					{
+						Repos: []string{"myorg"},
+						TrustedApps: TrustedApps{
+							{Name: "app1"}, // tries to trust, but locked
+						},
+					},
+				},
+			},
+			org:      "myorg",
+			repo:     "myrepo",
+			expected: nil,
+		},
+		{
+			name: "repo overrides org",
+			config: Configuration{
+				Triggers: []Trigger{
+					{
+						Repos: []string{"myorg"},
+						TrustedApps: TrustedApps{
+							{Name: "app1"},
+							{Name: "app2"},
+						},
+					},
+					{
+						Repos: []string{"myorg/myrepo"},
+						TrustedApps: TrustedApps{
+							{Name: "app1", Untrusted: true},
+						},
+					},
+				},
+			},
+			org:      "myorg",
+			repo:     "myrepo",
+			expected: []string{"app2"},
+		},
+		{
+			name: "org locked prevents repo override",
+			config: Configuration{
+				Triggers: []Trigger{
+					{
+						Repos: []string{"myorg"},
+						TrustedApps: TrustedApps{
+							{Name: "app1", Locked: true},
+						},
+					},
+					{
+						Repos: []string{"myorg/myrepo"},
+						TrustedApps: TrustedApps{
+							{Name: "app1", Untrusted: true},
+						},
+					},
+				},
+			},
+			org:      "myorg",
+			repo:     "myrepo",
+			expected: []string{"app1"},
+		},
+		{
+			name: "three levels: global + org + repo",
+			config: Configuration{
+				Triggers: []Trigger{
+					{
+						Repos: []string{"*"},
+						TrustedApps: TrustedApps{
+							{Name: "global-app"},
+							{Name: "overridable-app"},
+							{Name: "locked-app", Locked: true},
+						},
+					},
+					{
+						Repos: []string{"myorg"},
+						TrustedApps: TrustedApps{
+							{Name: "org-app"},
+							{Name: "overridable-app", Untrusted: true},
+							{Name: "locked-app", Untrusted: true}, // should be ignored (locked)
+						},
+					},
+					{
+						Repos: []string{"myorg/myrepo"},
+						TrustedApps: TrustedApps{
+							{Name: "repo-app"},
+						},
+					},
+				},
+			},
+			org:      "myorg",
+			repo:     "myrepo",
+			expected: []string{"global-app", "locked-app", "org-app", "repo-app"},
+		},
+		{
+			name: "app not in lower level inherits from above",
+			config: Configuration{
+				Triggers: []Trigger{
+					{
+						Repos: []string{"*"},
+						TrustedApps: TrustedApps{
+							{Name: "inherited-app"},
+						},
+					},
+					{
+						Repos: []string{"myorg"},
+						TrustedApps: TrustedApps{
+							{Name: "org-app"},
+						},
+					},
+				},
+			},
+			org:      "myorg",
+			repo:     "myrepo",
+			expected: []string{"inherited-app", "org-app"},
+		},
+		{
+			name: "no config at any level",
+			config: Configuration{},
+			org:    "myorg",
+			repo:   "myrepo",
+		},
+		{
+			name: "org adds new trusted app",
+			config: Configuration{
+				Triggers: []Trigger{
+					{
+						Repos: []string{"*"},
+						TrustedApps: TrustedApps{
+							{Name: "app1"},
+						},
+					},
+					{
+						Repos: []string{"myorg"},
+						TrustedApps: TrustedApps{
+							{Name: "app2"},
+						},
+					},
+				},
+			},
+			org:      "myorg",
+			repo:     "myrepo",
+			expected: []string{"app1", "app2"},
+		},
+		{
+			name: "same-level duplicate cannot override lock",
+			config: Configuration{
+				Triggers: []Trigger{
+					{
+						Repos: []string{"*"},
+						TrustedApps: TrustedApps{
+							{Name: "app1", Locked: true},
+						},
+					},
+					{
+						Repos: []string{"*"},
+						TrustedApps: TrustedApps{
+							{Name: "app1", Untrusted: true},
+						},
+					},
+				},
+			},
+			org:      "myorg",
+			repo:     "myrepo",
+			expected: []string{"app1"},
+		},
+		{
+			name: "different org is not affected",
+			config: Configuration{
+				Triggers: []Trigger{
+					{
+						Repos: []string{"otherorg"},
+						TrustedApps: TrustedApps{
+							{Name: "other-app"},
+						},
+					},
+				},
+			},
+			org:  "myorg",
+			repo: "myrepo",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			trigger := tc.config.TriggerFor(tc.org, tc.repo)
+				got := trigger.GetTrustedApps()
+			if diff := cmp.Diff(tc.expected, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestGetTrustedApps(t *testing.T) {
+	testCases := []struct {
+		name     string
+		trigger  Trigger
+		expected []string
+	}{
+		{
+			name: "returns resolved apps",
+			trigger: Trigger{
+				TrustedApps:         TrustedApps{{Name: "raw-app"}},
+				resolvedTrustedApps: []string{"resolved-app"},
+			},
+			expected: []string{"resolved-app"},
+		},
+		{
+			name: "without resolution, no apps are trusted",
+			trigger: Trigger{
+				TrustedApps: TrustedApps{
+					{Name: "app1"},
+					{Name: "app3"},
+				},
+			},
+		},
+		{
+			name:    "empty",
+			trigger: Trigger{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.trigger.GetTrustedApps()
+			if diff := cmp.Diff(tc.expected, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestValidateTrustedApps(t *testing.T) {
+	testCases := []struct {
+		name    string
+		apps    TrustedApps
+		wantErr bool
+	}{
+		{
+			name: "valid apps",
+			apps: TrustedApps{
+				{Name: "app1"},
+				{Name: "app2", Untrusted: true},
+			},
+		},
+		{
+			name: "empty app name",
+			apps: TrustedApps{
+				{Name: ""},
+			},
+			wantErr: true,
+		},
+		{
+			name: "duplicate app name",
+			apps: TrustedApps{
+				{Name: "app1"},
+				{Name: "app1", Untrusted: true},
+			},
+			wantErr: true,
+		},
+		{
+			name: "empty list",
+			apps: TrustedApps{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateTrustedApps(tc.apps)
+			if tc.wantErr && err == nil {
+				t.Error("expected error, got nil")
+			}
+			if !tc.wantErr && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestTriggerForResolveTrustedApps(t *testing.T) {
+	config := Configuration{
+		Triggers: []Trigger{
+			{
+				Repos: []string{"*"},
+				TrustedApps: TrustedApps{
+					{Name: "global-app"},
+				},
+			},
+			{
+				Repos: []string{"myorg"},
+				TrustedApps: TrustedApps{
+					{Name: "org-app"},
+				},
+			},
+			{
+				Repos: []string{"myorg/myrepo"},
+				TrustedApps: TrustedApps{
+					{Name: "repo-app"},
+				},
+			},
+		},
+	}
+
+	trigger := config.TriggerFor("myorg", "myrepo")
+	got := trigger.GetTrustedApps()
+	expected := []string{"global-app", "org-app", "repo-app"}
+	if diff := cmp.Diff(expected, got); diff != "" {
+		t.Errorf("TriggerFor should resolve trusted apps, mismatch (-want +got):\n%s", diff)
 	}
 }

--- a/pkg/plugins/config_test.go
+++ b/pkg/plugins/config_test.go
@@ -31,6 +31,7 @@ import (
 
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/util/diff"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/yaml"
@@ -3459,5 +3460,150 @@ func TestTriggerForResolveTrustedApps(t *testing.T) {
 	expected := []string{"global-app", "org-app", "repo-app"}
 	if diff := cmp.Diff(expected, got); diff != "" {
 		t.Errorf("TriggerFor should resolve trusted apps, mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestValidateLockedTrustedApps(t *testing.T) {
+	tests := []struct {
+		name        string
+		config      Configuration
+		expectError bool
+		errorCount  int
+		errorSubstr string
+	}{
+		{
+			name: "no locked apps, no errors",
+			config: Configuration{
+				Triggers: []Trigger{
+					{
+						Repos:       []string{"*"},
+						TrustedApps: TrustedApps{{Name: "global-app"}},
+					},
+					{
+						Repos:       []string{"myorg"},
+						TrustedApps: TrustedApps{{Name: "global-app"}},
+					},
+				},
+			},
+		},
+		{
+			name: "global lock, org overrides: error",
+			config: Configuration{
+				Triggers: []Trigger{
+					{
+						Repos:       []string{"*"},
+						TrustedApps: TrustedApps{{Name: "locked-app", Locked: true}},
+					},
+					{
+						Repos:       []string{"myorg"},
+						TrustedApps: TrustedApps{{Name: "locked-app", Untrusted: true}},
+					},
+				},
+			},
+			expectError: true,
+			errorCount:  1,
+			errorSubstr: "locked at global level",
+		},
+		{
+			name: "global lock, repo overrides: error",
+			config: Configuration{
+				Triggers: []Trigger{
+					{
+						Repos:       []string{"*"},
+						TrustedApps: TrustedApps{{Name: "locked-app", Locked: true}},
+					},
+					{
+						Repos:       []string{"myorg/myrepo"},
+						TrustedApps: TrustedApps{{Name: "locked-app"}},
+					},
+				},
+			},
+			expectError: true,
+			errorCount:  1,
+			errorSubstr: "locked at global level",
+		},
+		{
+			name: "org lock, repo overrides: error",
+			config: Configuration{
+				Triggers: []Trigger{
+					{
+						Repos:       []string{"myorg"},
+						TrustedApps: TrustedApps{{Name: "org-locked", Locked: true}},
+					},
+					{
+						Repos:       []string{"myorg/myrepo"},
+						TrustedApps: TrustedApps{{Name: "org-locked", Untrusted: true}},
+					},
+				},
+			},
+			expectError: true,
+			errorCount:  1,
+			errorSubstr: "locked at org level",
+		},
+		{
+			name: "multiple violations",
+			config: Configuration{
+				Triggers: []Trigger{
+					{
+						Repos:       []string{"*"},
+						TrustedApps: TrustedApps{{Name: "g-locked", Locked: true}},
+					},
+					{
+						Repos:       []string{"org1"},
+						TrustedApps: TrustedApps{{Name: "g-locked"}, {Name: "o-locked", Locked: true}},
+					},
+					{
+						Repos:       []string{"org1/repo1"},
+						TrustedApps: TrustedApps{{Name: "g-locked"}, {Name: "o-locked"}},
+					},
+				},
+			},
+			expectError: true,
+			errorCount:  3, // org overrides global, repo overrides global, repo overrides org
+		},
+		{
+			name: "non-overlapping locked apps: no error",
+			config: Configuration{
+				Triggers: []Trigger{
+					{
+						Repos:       []string{"*"},
+						TrustedApps: TrustedApps{{Name: "global-only", Locked: true}},
+					},
+					{
+						Repos:       []string{"myorg"},
+						TrustedApps: TrustedApps{{Name: "different-app"}},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.config.ValidateLockedTrustedApps()
+			if tc.expectError {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				agg, ok := err.(utilerrors.Aggregate)
+				if !ok {
+					t.Fatalf("expected aggregate error, got %T", err)
+				}
+				if len(agg.Errors()) != tc.errorCount {
+					t.Errorf("expected %d errors, got %d: %v", tc.errorCount, len(agg.Errors()), agg.Errors())
+				}
+				if tc.errorSubstr != "" {
+					for _, e := range agg.Errors() {
+						if !strings.Contains(e.Error(), tc.errorSubstr) {
+							t.Errorf("expected error containing %q, got: %v", tc.errorSubstr, e)
+						}
+					}
+				}
+			} else {
+				if err != nil {
+					t.Errorf("expected no error, got: %v", err)
+				}
+			}
+		})
 	}
 }

--- a/pkg/plugins/plugin-config-documented.yaml
+++ b/pkg/plugins/plugin-config-documented.yaml
@@ -658,15 +658,23 @@ triggers:
             # Default: ">[!TIP]\n>**We noticed you've done this a few times! Consider [joining the org]({join_org_url}) ..."
             message: ' '
       # Repos is either of the form org/repos or just org.
+      # A trigger entry with an empty repos field is treated as the global level
+      # for trusted_apps resolution. Trust is resolved hierarchically:
+      # global (empty repos) -> org-level -> repo-level.
       repos:
         - ""
       # TriggerGitHubWorkflows enables workflows run by github to be triggered by prow.
       trigger_github_workflows: true
-      # TrustedApps is the explicit list of GitHub apps whose PRs will be automatically
+      # TrustedApps is the list of GitHub apps whose PRs will be automatically
       # considered as trusted. The list should contain usernames of each GitHub App without [bot] suffix.
+      # Each entry can be a plain string (legacy format) or an object with name, untrusted, and locked fields.
+      # When untrusted is true, the app is explicitly NOT trusted at this level.
+      # When locked is true (only meaningful at global and org levels), lower levels cannot override.
       # By default, trigger will ignore this list.
       trusted_apps:
-        - ""
+        - name: ""
+          untrusted: false
+          locked: false
       # TrustedOrg is the org whose members' PRs will be automatically built for
       # PRs to the above repos. The default is the PR's org.
 

--- a/pkg/plugins/retitle/retitle.go
+++ b/pkg/plugins/retitle/retitle.go
@@ -83,7 +83,7 @@ func handleGenericCommentEvent(pc plugins.Agent, e github.GenericCommentEvent) e
 	)
 	return handleGenericComment(pc.GitHubClient, func(user string) (bool, error) {
 		t := pc.PluginConfig.TriggerFor(org, repo)
-		trustedResponse, err := trigger.TrustedUser(pc.GitHubClient, t.OnlyOrgMembers, t.TrustedApps, t.TrustedOrg, user, org, repo)
+		trustedResponse, err := trigger.TrustedUser(pc.GitHubClient, t.OnlyOrgMembers, t.GetTrustedApps(), t.TrustedOrg, user, org, repo)
 		return trustedResponse.IsTrusted, err
 	}, pc.PluginConfig.Retitle.AllowClosedIssues, pc.Logger, e)
 }

--- a/pkg/plugins/trigger/generic-comment.go
+++ b/pkg/plugins/trigger/generic-comment.go
@@ -69,7 +69,7 @@ func handleGenericComment(c Client, cp commentPruner, trigger plugins.Trigger, g
 	}
 
 	// Skip untrusted users comments.
-	trustedResponse, err := TrustedUser(c.GitHubClient, trigger.OnlyOrgMembers, trigger.TrustedApps, trigger.TrustedOrg, commentAuthor, org, repo)
+	trustedResponse, err := TrustedUser(c.GitHubClient, trigger.OnlyOrgMembers, trigger.GetTrustedApps(), trigger.TrustedOrg, commentAuthor, org, repo)
 	if err != nil {
 		return fmt.Errorf("error checking trust of %s: %w", commentAuthor, err)
 	}

--- a/pkg/plugins/trigger/pull-request.go
+++ b/pkg/plugins/trigger/pull-request.go
@@ -77,7 +77,7 @@ func handlePR(c Client, trigger plugins.Trigger, pr github.PullRequestEvent) err
 		// When a PR is opened, if the author is in the org then build it.
 		// Otherwise, ask for "/ok-to-test". There's no need to look for previous
 		// "/ok-to-test" comments since the PR was just opened!
-		trustedResponse, err := TrustedUser(c.GitHubClient, trigger.OnlyOrgMembers, trigger.TrustedApps, trigger.TrustedOrg, author, org, repo)
+		trustedResponse, err := TrustedUser(c.GitHubClient, trigger.OnlyOrgMembers, trigger.GetTrustedApps(), trigger.TrustedOrg, author, org, repo)
 		member := trustedResponse.IsTrusted
 		if err != nil {
 			return fmt.Errorf("could not check membership: %s", err)
@@ -364,7 +364,7 @@ func draftMsg(ghc githubClient, pr github.PullRequest) error {
 // If already known, GitHub labels should be provided to save tokens. Otherwise, it fetches them.
 func TrustedPullRequest(tprc trustedPullRequestClient, trigger plugins.Trigger, author, org, repo string, num int, l []github.Label) ([]github.Label, bool, error) {
 	// First check if the author is a member of the org.
-	if trustedResponse, err := TrustedUser(tprc, trigger.OnlyOrgMembers, trigger.TrustedApps, trigger.TrustedOrg, author, org, repo); err != nil {
+	if trustedResponse, err := TrustedUser(tprc, trigger.OnlyOrgMembers, trigger.GetTrustedApps(), trigger.TrustedOrg, author, org, repo); err != nil {
 		return l, false, fmt.Errorf("error checking %s for trust: %w", author, err)
 	} else if trustedResponse.IsTrusted {
 		return l, true, nil

--- a/pkg/plugins/verify-owners/verify-owners.go
+++ b/pkg/plugins/verify-owners/verify-owners.go
@@ -558,7 +558,7 @@ func checkIfTrustedUser(ghc githubClient, log *logrus.Entry, triggerConfig plugi
 	var err error
 	var triggerTrustedResponse trigger.TrustedUserResponse
 	if !isAlreadyTrusted {
-		triggerTrustedResponse, err = trigger.TrustedUser(ghc, triggerConfig.OnlyOrgMembers, triggerConfig.TrustedApps, triggerConfig.TrustedOrg, owner, org, repo)
+		triggerTrustedResponse, err = trigger.TrustedUser(ghc, triggerConfig.OnlyOrgMembers, triggerConfig.GetTrustedApps(), triggerConfig.TrustedOrg, owner, org, repo)
 		if err != nil {
 			return nonTrustedUsers, err
 		}

--- a/pkg/plugins/welcome/welcome.go
+++ b/pkg/plugins/welcome/welcome.go
@@ -125,7 +125,7 @@ func handlePR(c client, t plugins.Trigger, pre github.PullRequestEvent, welcomeT
 		return nil
 	}
 
-	trustedResponse, err := trigger.TrustedUser(c.GitHubClient, t.OnlyOrgMembers, t.TrustedApps, t.TrustedOrg, user, org, repo)
+	trustedResponse, err := trigger.TrustedUser(c.GitHubClient, t.OnlyOrgMembers, t.GetTrustedApps(), t.TrustedOrg, user, org, repo)
 	if err != nil {
 		return fmt.Errorf("check if user %s is trusted: %w", user, err)
 	}


### PR DESCRIPTION
Replace the flat `[]string` TrustedApps field with a structured TrustedApp type with `untrusted` and `locked` fields. Trust is now resolved hierarchically: global -> org -> repo.

- `locked` may be used optionally to deny lower levels from changing trust
- `untrusted` may be used to override trust from layers above or (together  with `locked`) to deny lower levels from enabling trust to the given app

This allows use cases like the following:

- Prow admin may set trust on the global level for a service app to make sure the service works across the whole instance, and set `locked` to  make sure any lower lever does not remove trust and break the service.
- Prow admin or org owner may deny trust to an app on their level and set `locked` to prevent lower layers from trusting
- Prow admin or org owner may set trust on their level for a convenience app so that individual repositories do not need to opt-in individually, but without `locked` lower layers may still opt-out from trusting the app

For backward compatibility of the config, I added custom UnmarshalJSON implementation that accepts both the new list of structs as well as the legacy list of strings. List of strings will be eventually deprecated and removed.

Assisted by Claude Code