### PR TITLE
Add org invite configuration options

### DIFF
--- a/pkg/plugins/config.go
+++ b/pkg/plugins/config.go
@@ -479,6 +479,43 @@ type AssignOnLabel struct {
 	Label string `json:"label"`
 }
 
+// ProminentOrgInviteConfig holds configuration for the prominent org invite
+// message shown to non-org members who have contributed multiple merged PRs.
+type ProminentOrgInviteConfig struct {
+	// Disabled disables the prominent org invite functionality entirely.
+	// When true, only the regular "join the org" message is shown without
+	// querying for merged PRs.
+	Disabled bool `json:"disabled,omitempty"`
+	// MergedPRThreshold is the number of merged PRs after which the user gets
+	// a prominent message about joining the org. Default: 3.
+	// Use a pointer so that we can distinguish between "not set" (use default)
+	// and "explicitly set to 0".
+	MergedPRThreshold *int `json:"merged_pr_threshold,omitempty"`
+	// Message is a custom message template for the prominent org invite.
+	// Supports {join_org_url} as a placeholder for the org join URL.
+	// Default: ">[!TIP]\n>**We noticed you've done this a few times! Consider [joining the org]({join_org_url}) ..."
+	Message string `json:"message,omitempty"`
+}
+
+// EffectiveMergedPRThreshold returns the configured merged PR threshold,
+// or the default of 3 when not configured.
+func (c ProminentOrgInviteConfig) EffectiveMergedPRThreshold() int {
+	if c.MergedPRThreshold != nil {
+		return *c.MergedPRThreshold
+	}
+	return 3
+}
+
+// OrgInviteConfig holds configuration for the org invite functionality
+// that is shown to non-org members when they open a PR.
+// Future top-level fields (e.g. disabled, message) may be added here to
+// control the regular (non-prominent) invitation as well.
+type OrgInviteConfig struct {
+	// Prominent configures the prominent org invite message shown to
+	// non-org members who have contributed multiple merged PRs.
+	Prominent ProminentOrgInviteConfig `json:"prominent,omitempty"`
+}
+
 // Trigger specifies a configuration for a single trigger.
 //
 // The configuration for the trigger plugin is defined as a list of these structures.
@@ -507,6 +544,9 @@ type Trigger struct {
 	IgnoreOkToTest bool `json:"ignore_ok_to_test,omitempty"`
 	// TriggerGitHubWorkflows enables workflows run by github to be triggered by prow.
 	TriggerGitHubWorkflows bool `json:"trigger_github_workflows,omitempty"`
+	// OrgInvite holds configuration for the org invite message
+	// shown to non-org members when they open a PR.
+	OrgInvite OrgInviteConfig `json:"org_invite,omitempty"`
 }
 
 // Heart contains the configuration for the heart plugin.

--- a/pkg/plugins/trigger/pull-request.go
+++ b/pkg/plugins/trigger/pull-request.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"net/url"
 	"strconv"
+	"strings"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -39,8 +40,7 @@ import (
 )
 
 const (
-	abortedDescription                      = "Aborted by trigger plugin."
-	mergedPRCountForProminentJoinOrgMessage = 3
+	abortedDescription = "Aborted by trigger plugin."
 )
 
 func handlePR(c Client, trigger plugins.Trigger, pr github.PullRequestEvent) error {
@@ -279,7 +279,7 @@ I understand the commands that are listed [here](https://go.k8s.io/bot-commands?
 </details>
 `, author, encodedRepoFullName, plugins.AboutThisBotWithoutCommands)
 	} else {
-		membershipGuidance := orgInvitationGuidance(c, org, pr.User, joinOrgURL)
+		membershipGuidance := orgInvitationGuidance(c, org, pr.User, joinOrgURL, trigger.OrgInvite)
 		comment = fmt.Sprintf(`Hi @%s. Thanks for your PR.
 
 I'm waiting for a [%s](https://%s/orgs/%s/people) %smember to verify that this patch is reasonable to test. If it is, they should reply with `+"`/ok-to-test`"+` on its own line. Until that is done, I will not automatically test new commits in this PR, but the usual testing commands by org members will still work.
@@ -319,15 +319,22 @@ I understand the commands that are listed [here](https://go.k8s.io/bot-commands?
 	return nil
 }
 
-func orgInvitationGuidance(c Client, org string, author github.User, joinOrgURL string) string {
-	if shouldHighlightJoinOrgMessage(c, org, author) {
+func orgInvitationGuidance(c Client, org string, author github.User, joinOrgURL string, cfg plugins.OrgInviteConfig) string {
+	if cfg.Prominent.Disabled {
+		return fmt.Sprintf("Regular contributors should [join the org](%s) to skip this step.", joinOrgURL)
+	}
+
+	if shouldHighlightJoinOrgMessage(c, org, author, cfg) {
+		if cfg.Prominent.Message != "" {
+			return strings.ReplaceAll(cfg.Prominent.Message, "{join_org_url}", joinOrgURL)
+		}
 		return fmt.Sprintf(">[!TIP]\n>**We noticed you've done this a few times! Consider [joining the org](%s) to skip this step and gain `/lgtm` and other bot rights.** We recommend asking approvers on your previous PRs to sponsor you.", joinOrgURL)
 	}
 
 	return fmt.Sprintf("Regular contributors should [join the org](%s) to skip this step.", joinOrgURL)
 }
 
-func shouldHighlightJoinOrgMessage(c Client, org string, author github.User) bool {
+func shouldHighlightJoinOrgMessage(c Client, org string, author github.User, cfg plugins.OrgInviteConfig) bool {
 	if author.Type == github.UserTypeBot {
 		return false
 	}
@@ -342,7 +349,7 @@ func shouldHighlightJoinOrgMessage(c Client, org string, author github.User) boo
 		return false
 	}
 
-	return len(issues) >= mergedPRCountForProminentJoinOrgMessage
+	return len(issues) >= cfg.Prominent.EffectiveMergedPRThreshold()
 }
 
 func draftMsg(ghc githubClient, pr github.PullRequest) error {

--- a/pkg/plugins/trigger/pull-request_test.go
+++ b/pkg/plugins/trigger/pull-request_test.go
@@ -21,12 +21,14 @@ import (
 	"encoding/json"
 	"fmt"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clienttesting "k8s.io/client-go/testing"
+	"k8s.io/utils/ptr"
 
 	prowapi "sigs.k8s.io/prow/pkg/apis/prowjobs/v1"
 	"sigs.k8s.io/prow/pkg/client/clientset/versioned/fake"
@@ -706,7 +708,7 @@ func TestShouldHighlightJoinOrgMessage(t *testing.T) {
 				Logger:       logrus.WithField("test", "TestShouldHighlightJoinOrgMessage"),
 			}
 
-			highlight := shouldHighlightJoinOrgMessage(c, "org", github.User{Login: "author"})
+			highlight := shouldHighlightJoinOrgMessage(c, "org", github.User{Login: "author"}, plugins.OrgInviteConfig{})
 			if highlight != tc.expecting {
 				t.Fatalf("shouldHighlightJoinOrgMessage() = %t, want %t", highlight, tc.expecting)
 			}
@@ -725,7 +727,7 @@ func TestShouldHighlightJoinOrgMessageUsesFilteredQuery(t *testing.T) {
 		Logger:       logrus.WithField("test", "TestShouldHighlightJoinOrgMessageUsesFilteredQuery"),
 	}
 
-	if highlight := shouldHighlightJoinOrgMessage(c, "org", github.User{Login: "author"}); highlight {
+	if highlight := shouldHighlightJoinOrgMessage(c, "org", github.User{Login: "author"}, plugins.OrgInviteConfig{}); highlight {
 		t.Fatalf("shouldHighlightJoinOrgMessage() = true, want false")
 	}
 
@@ -755,7 +757,7 @@ func TestShouldHighlightJoinOrgMessageIgnoresSearchErrors(t *testing.T) {
 		Logger:       logrus.WithField("test", "TestShouldHighlightJoinOrgMessageIgnoresSearchErrors"),
 	}
 
-	if highlight := shouldHighlightJoinOrgMessage(c, "org", github.User{Login: "author"}); highlight {
+	if highlight := shouldHighlightJoinOrgMessage(c, "org", github.User{Login: "author"}, plugins.OrgInviteConfig{}); highlight {
 		t.Fatalf("shouldHighlightJoinOrgMessage() = true, want false when search fails")
 	}
 }
@@ -771,10 +773,180 @@ func TestShouldHighlightJoinOrgMessageSkipsBotAuthors(t *testing.T) {
 		Logger:       logrus.WithField("test", "TestShouldHighlightJoinOrgMessageSkipsBotAuthors"),
 	}
 
-	if highlight := shouldHighlightJoinOrgMessage(c, "org", github.User{Login: "ci-robot", Type: github.UserTypeBot}); highlight {
+	if highlight := shouldHighlightJoinOrgMessage(c, "org", github.User{Login: "ci-robot", Type: github.UserTypeBot}, plugins.OrgInviteConfig{}); highlight {
 		t.Fatalf("shouldHighlightJoinOrgMessage() = true, want false for bot author")
 	}
 	if fc.called {
 		t.Fatalf("expected no search call for bot author")
+	}
+}
+
+func TestShouldHighlightJoinOrgMessageCustomThreshold(t *testing.T) {
+	t.Parallel()
+
+	mergedPRIssue := func(number int, author string) *github.Issue {
+		return &github.Issue{
+			Number:      number,
+			State:       github.PullRequestStateClosed,
+			User:        github.User{Login: author},
+			PullRequest: &struct{}{},
+		}
+	}
+
+	testCases := []struct {
+		name      string
+		threshold *int
+		issues    map[int]*github.Issue
+		expecting bool
+	}{
+		{
+			name:      "custom threshold of 5, only 3 merged PRs",
+			threshold: ptr.To(5),
+			issues: map[int]*github.Issue{
+				1: mergedPRIssue(1, "author"),
+				2: mergedPRIssue(2, "author"),
+				3: mergedPRIssue(3, "author"),
+			},
+			expecting: false,
+		},
+		{
+			name:      "custom threshold of 5, 5 merged PRs",
+			threshold: ptr.To(5),
+			issues: map[int]*github.Issue{
+				1: mergedPRIssue(1, "author"),
+				2: mergedPRIssue(2, "author"),
+				3: mergedPRIssue(3, "author"),
+				4: mergedPRIssue(4, "author"),
+				5: mergedPRIssue(5, "author"),
+			},
+			expecting: true,
+		},
+		{
+			name:      "custom threshold of 1, 1 merged PR",
+			threshold: ptr.To(1),
+			issues: map[int]*github.Issue{
+				1: mergedPRIssue(1, "author"),
+			},
+			expecting: true,
+		},
+		{
+			name:      "custom threshold of 0, no merged PRs",
+			threshold: ptr.To(0),
+			issues:    map[int]*github.Issue{},
+			expecting: true,
+		},
+		{
+			name:      "nil threshold uses default of 3, exactly 3 merged PRs",
+			threshold: nil,
+			issues: map[int]*github.Issue{
+				1: mergedPRIssue(1, "author"),
+				2: mergedPRIssue(2, "author"),
+				3: mergedPRIssue(3, "author"),
+			},
+			expecting: true,
+		},
+		{
+			name:      "nil threshold uses default of 3, only 2 merged PRs",
+			threshold: nil,
+			issues: map[int]*github.Issue{
+				1: mergedPRIssue(1, "author"),
+				2: mergedPRIssue(2, "author"),
+			},
+			expecting: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			fc := fakegithub.NewFakeClient()
+			fc.Issues = tc.issues
+			c := Client{
+				GitHubClient: fc,
+				Logger:       logrus.WithField("test", "TestShouldHighlightJoinOrgMessageCustomThreshold"),
+			}
+
+			cfg := plugins.OrgInviteConfig{
+				Prominent: plugins.ProminentOrgInviteConfig{
+					MergedPRThreshold: tc.threshold,
+				},
+			}
+			highlight := shouldHighlightJoinOrgMessage(c, "org", github.User{Login: "author"}, cfg)
+			if highlight != tc.expecting {
+				t.Fatalf("shouldHighlightJoinOrgMessage() = %t, want %t", highlight, tc.expecting)
+			}
+		})
+	}
+}
+
+func TestOrgInvitationGuidance(t *testing.T) {
+	t.Parallel()
+
+	mergedPRIssue := func(number int, author string) *github.Issue {
+		return &github.Issue{
+			Number:      number,
+			State:       github.PullRequestStateClosed,
+			User:        github.User{Login: author},
+			PullRequest: &struct{}{},
+		}
+	}
+
+	testCases := []struct {
+		name             string
+		cfg              plugins.OrgInviteConfig
+		issues           map[int]*github.Issue
+		expectedContains string
+	}{
+		{
+			name:             "disabled returns regular message without searching",
+			cfg:              plugins.OrgInviteConfig{Prominent: plugins.ProminentOrgInviteConfig{Disabled: true}},
+			issues:           map[int]*github.Issue{},
+			expectedContains: "Regular contributors should [join the org](https://example.com/join) to skip this step.",
+		},
+		{
+			name: "custom message above threshold",
+			cfg:  plugins.OrgInviteConfig{Prominent: plugins.ProminentOrgInviteConfig{Message: "Please consider [joining us]({join_org_url}) for full access!"}},
+			issues: map[int]*github.Issue{
+				1: mergedPRIssue(1, "author"),
+				2: mergedPRIssue(2, "author"),
+				3: mergedPRIssue(3, "author"),
+			},
+			expectedContains: "Please consider [joining us](https://example.com/join) for full access!",
+		},
+		{
+			name: "default message above threshold",
+			cfg:  plugins.OrgInviteConfig{},
+			issues: map[int]*github.Issue{
+				1: mergedPRIssue(1, "author"),
+				2: mergedPRIssue(2, "author"),
+				3: mergedPRIssue(3, "author"),
+			},
+			expectedContains: ">[!TIP]",
+		},
+		{
+			name:             "below threshold returns regular message",
+			cfg:              plugins.OrgInviteConfig{},
+			issues:           map[int]*github.Issue{},
+			expectedContains: "Regular contributors should [join the org](https://example.com/join) to skip this step.",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			fc := fakegithub.NewFakeClient()
+			fc.Issues = tc.issues
+			c := Client{
+				GitHubClient: fc,
+				Logger:       logrus.WithField("test", t.Name()),
+			}
+
+			result := orgInvitationGuidance(c, "org", github.User{Login: "author"}, "https://example.com/join", tc.cfg)
+
+			if !strings.Contains(result, tc.expectedContains) {
+				t.Fatalf("expected result to contain %q, got %q", tc.expectedContains, result)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Add `OrgInviteConfig` and sub-field `ProminentOrgInviteConfig` to allow
customizing the prominent organization invitation message shown to
non-members with multiple merged PRs.

Configuration for the prominent invite includes:
- `disabled`: Disable the prominent message entirely
- `merged_pr_threshold`: Customize the PR count threshold (default: 3)
- `message`: Custom message template with `{join_org_url}` placeholder

Fixes: #670