### PR TITLE
Fix DCO plugin trusted_apps not working without skip flags

### DIFF
--- a/pkg/plugins/dco/dco.go
+++ b/pkg/plugins/dco/dco.go
@@ -297,7 +297,7 @@ func handle(config plugins.Dco, gc gitHubClient, cp commentPruner, log *logrus.E
 		return err
 	}
 
-	if config.SkipDCOCheckForMembers || config.SkipDCOCheckForCollaborators {
+	if config.SkipDCOCheckForMembers || config.SkipDCOCheckForCollaborators || len(config.TrustedApps) > 0 {
 		commitsMissingDCO, err = filterTrustedUsers(gc, l, config.SkipDCOCheckForCollaborators, config.TrustedApps, config.TrustedOrg, org, repo, commitsMissingDCO)
 		if err != nil {
 			l.WithError(err).Infof("Error running trusted org member check against commits in PR")

--- a/pkg/plugins/dco/dco_test.go
+++ b/pkg/plugins/dco/dco_test.go
@@ -529,6 +529,31 @@ Instructions for interacting with me using PR comments are available [here](http
 `,
 		},
 		{
+			name: "should skip dco check for trusted app even without skip flags",
+			config: plugins.Dco{
+				TrustedApps: []string{"dependabot"},
+			},
+			pullRequestEvent: github.PullRequestEvent{
+				Action:      github.PullRequestActionOpened,
+				PullRequest: github.PullRequest{Number: 3, Head: github.PullRequestBranch{SHA: "sha"}},
+			},
+			commits: []github.RepositoryCommit{
+				{
+					SHA:    "sha",
+					Commit: github.GitCommit{Message: "not signed off"},
+					Author: github.User{
+						Login: "dependabot[bot]",
+					},
+				},
+			},
+			issueState: "open",
+			hasDCONo:   false,
+			hasDCOYes:  false,
+
+			addedLabel:     fmt.Sprintf("/#3:%s", dcoYesLabel),
+			expectedStatus: github.StatusSuccess,
+		},
+		{
 			name: "should use custom CONTRIBUTING.md repo, branch and path in comment",
 			config: plugins.Dco{
 				ContributingRepo:   "kubernetes/org",


### PR DESCRIPTION
## Summary

- Fix `trusted_apps` config having no effect when both `SkipDCOCheckForMembers` and `SkipDCOCheckForCollaborators` are `false`
- The `filterTrustedUsers()` call was gated behind `config.SkipDCOCheckForMembers || config.SkipDCOCheckForCollaborators`, but `trusted_apps` should work independently of those flags
- Add `len(config.TrustedApps) > 0` to the condition so trusted apps (e.g. `dependabot`) are filtered even without the skip flags

Fixes #606

## Root Cause

In `handle()` (`pkg/plugins/dco/dco.go`), `filterTrustedUsers` — which processes `trusted_apps` via `trigger.TrustedUser()` — was only invoked when skip flags were enabled:

```go
// Before (broken):
if config.SkipDCOCheckForMembers || config.SkipDCOCheckForCollaborators {
    commitsMissingDCO, err = filterTrustedUsers(...)
}

// After (fixed):
if config.SkipDCOCheckForMembers || config.SkipDCOCheckForCollaborators || len(config.TrustedApps) > 0 {
    commitsMissingDCO, err = filterTrustedUsers(...)
}
```

## Test plan

- [x] Added test case: `should skip dco check for trusted app even without skip flags` — configures only `TrustedApps: ["dependabot"]` (no skip flags) and verifies a `dependabot[bot]` commit passes DCO
- [x] All existing DCO tests pass (`go test ./pkg/plugins/dco/...`)

```
=== RUN   TestHandlePullRequest
--- PASS: TestHandlePullRequest (0.00s)
    --- PASS: .../should_skip_dco_check_for_trusted_app_even_without_skip_flags (0.00s)
    ... (17 other subtests all PASS)
PASS
ok  	sigs.k8s.io/prow/pkg/plugins/dco	0.019s
```