### PR TITLE
Migrate webhook validation from HMAC-SHA1 to HMAC-SHA256

### DIFF
--- a/pkg/github/hmac.go
+++ b/pkg/github/hmac.go
@@ -18,7 +18,7 @@ package github
 
 import (
 	"crypto/hmac"
-	"crypto/sha1"
+	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -46,10 +46,10 @@ func ValidatePayload(payload []byte, sig string, tokenGenerator func() []byte) b
 		return false
 	}
 
-	if !strings.HasPrefix(sig, "sha1=") {
+	if !strings.HasPrefix(sig, "sha256=") {
 		return false
 	}
-	sig = sig[5:]
+	sig = sig[7:]
 	sb, err := hex.DecodeString(sig)
 	if err != nil {
 		return false
@@ -68,7 +68,7 @@ func ValidatePayload(payload []byte, sig string, tokenGenerator func() []byte) b
 
 	// If we have a match with any valid hmac, we can validate successfully.
 	for _, key := range hmacs {
-		mac := hmac.New(sha1.New, key)
+		mac := hmac.New(sha256.New, key)
 		mac.Write(payload)
 		expected := mac.Sum(nil)
 		if hmac.Equal(sb, expected) {
@@ -80,10 +80,10 @@ func ValidatePayload(payload []byte, sig string, tokenGenerator func() []byte) b
 
 // PayloadSignature returns the signature that matches the payload.
 func PayloadSignature(payload []byte, key []byte) string {
-	mac := hmac.New(sha1.New, key)
+	mac := hmac.New(sha256.New, key)
 	mac.Write(payload)
 	sum := mac.Sum(nil)
-	return "sha1=" + hex.EncodeToString(sum)
+	return "sha256=" + hex.EncodeToString(sum)
 }
 
 // extractHMACs returns all *valid* HMAC tokens for given repository/organization.

--- a/pkg/github/hmac_test.go
+++ b/pkg/github/hmac_test.go
@@ -42,7 +42,7 @@ var defaultTokenGenerator = func() []byte {
 	return []byte(tokens)
 }
 
-// echo -n 'BODY' | openssl dgst -sha1 -hmac KEY
+// echo -n 'BODY' | openssl dgst -sha256 -hmac KEY
 func TestValidatePayload(t *testing.T) {
 	var testcases = []struct {
 		name           string
@@ -54,14 +54,14 @@ func TestValidatePayload(t *testing.T) {
 		{
 			"empty payload with a correct signature can pass the check",
 			"{}",
-			"sha1=db5c76f4264d0ad96cf21baec394964b4b8ce580",
+			"sha256=19092633e5aa9a849dfcc9d2df4e76db2df1fcba7f38915f2c7833bd8a510f2f",
 			defaultTokenGenerator,
 			true,
 		},
 		{
 			"empty payload with a wrong formatted signature cannot pass the check",
 			"{}",
-			"db5c76f4264d0ad96cf21baec394964b4b8ce580",
+			"19092633e5aa9a849dfcc9d2df4e76db2df1fcba7f38915f2c7833bd8a510f2f",
 			defaultTokenGenerator,
 			false,
 		},
@@ -75,21 +75,21 @@ func TestValidatePayload(t *testing.T) {
 		{
 			"org-level webhook event with a correct signature can pass the check",
 			`{"organization": {"login": "org1"}}`,
-			"sha1=cf2d7e20aa4863abe204a61a8adf53ddaef0b33b",
+			"sha256=87e9dcd175b5188a43e6ba0511da057b51f38f5a88088b198f26db13f1409280",
 			defaultTokenGenerator,
 			true,
 		},
 		{
 			"repo-level webhook event with a correct signature can pass the check",
 			`{"repository": {"full_name": "org2/repo"}}`,
-			"sha1=0b5ea8bf5683e4bf89cf900271e1c8a021b4b0b3",
+			"sha256=489ff461f227239a8b2ae0ec5b452dc134712ef2e23a9939ecf7a889b467351b",
 			defaultTokenGenerator,
 			true,
 		},
 		{
 			"payload with both repository and organization is considered as a repo-level webhook event",
 			`{"repository": {"full_name": "org2/repo"}, "organization": {"login": "org2"}}`,
-			"sha1=db5ba00c9ed0153322d33decb7ad579401e917f6",
+			"sha256=1ec548cd58f7846a1af4736d08d29604de0b85edd19e3b8569c5eda544c200fc",
 			defaultTokenGenerator,
 			true,
 		},
@@ -99,5 +99,18 @@ func TestValidatePayload(t *testing.T) {
 		if res != tc.valid {
 			t.Errorf("Wrong validation for the test %q: expected %t but got %t", tc.name, tc.valid, res)
 		}
+	}
+}
+
+func TestPayloadSignatureGitHubVector(t *testing.T) {
+	// GitHub's official test vector from
+	// https://docs.github.com/en/webhooks/using-webhooks/validating-webhook-deliveries
+	secret := []byte("It's a Secret to Everybody")
+	payload := []byte("Hello, World!")
+	expected := "sha256=757107ea0eb2509fc211221cce984b8a37570b6d7586c22c46f4379c8b043e17"
+
+	got := PayloadSignature(payload, secret)
+	if got != expected {
+		t.Errorf("PayloadSignature mismatch: got %s, want %s", got, expected)
 	}
 }

--- a/pkg/github/webhooks.go
+++ b/pkg/github/webhooks.go
@@ -46,9 +46,9 @@ func ValidateWebhook(w http.ResponseWriter, r *http.Request, tokenGenerator func
 		responseHTTPError(w, http.StatusBadRequest, "400 Bad Request: Missing X-GitHub-Delivery Header")
 		return "", "", nil, false, http.StatusBadRequest
 	}
-	sig := r.Header.Get("X-Hub-Signature")
+	sig := r.Header.Get("X-Hub-Signature-256")
 	if sig == "" {
-		responseHTTPError(w, http.StatusForbidden, "403 Forbidden: Missing X-Hub-Signature")
+		responseHTTPError(w, http.StatusForbidden, "403 Forbidden: Missing X-Hub-Signature-256")
 		return "", "", nil, false, http.StatusForbidden
 	}
 	contentType := r.Header.Get("content-type")
@@ -63,7 +63,7 @@ func ValidateWebhook(w http.ResponseWriter, r *http.Request, tokenGenerator func
 	}
 	// Validate the payload with our HMAC secret.
 	if !ValidatePayload(payload, sig, tokenGenerator) {
-		responseHTTPError(w, http.StatusForbidden, "403 Forbidden: Invalid X-Hub-Signature")
+		responseHTTPError(w, http.StatusForbidden, "403 Forbidden: Invalid X-Hub-Signature-256")
 		return "", "", nil, false, http.StatusForbidden
 	}
 

--- a/pkg/githubeventserver/githubeventserver_test.go
+++ b/pkg/githubeventserver/githubeventserver_test.go
@@ -54,9 +54,9 @@ foo/bar:
 		metrics:            NewMetrics(),
 	}
 
-	// This is the SHA1 signature for payload "{}" and signature "abc"
-	// echo -n '{}' | openssl dgst -sha1 -hmac abc
-	const hmac string = "sha1=db5c76f4264d0ad96cf21baec394964b4b8ce580"
+	// This is the SHA256 signature for payload "{}" and secret "abc"
+	// echo -n '{}' | openssl dgst -sha256 -hmac abc
+	const hmac string = "sha256=19092633e5aa9a849dfcc9d2df4e76db2df1fcba7f38915f2c7833bd8a510f2f"
 	const body string = "{}"
 	var testcases = []struct {
 		name string
@@ -71,10 +71,10 @@ foo/bar:
 
 			Method: http.MethodDelete,
 			Header: map[string]string{
-				"X-GitHub-Event":    "ping",
-				"X-GitHub-Delivery": "I am unique",
-				"X-Hub-Signature":   hmac,
-				"content-type":      "application/json",
+				"X-GitHub-Event":      "ping",
+				"X-GitHub-Delivery":   "I am unique",
+				"X-Hub-Signature-256": hmac,
+				"content-type":        "application/json",
 			},
 			Body: body,
 			Code: http.StatusMethodNotAllowed,
@@ -84,9 +84,9 @@ foo/bar:
 
 			Method: http.MethodPost,
 			Header: map[string]string{
-				"X-GitHub-Delivery": "I am unique",
-				"X-Hub-Signature":   hmac,
-				"content-type":      "application/json",
+				"X-GitHub-Delivery":   "I am unique",
+				"X-Hub-Signature-256": hmac,
+				"content-type":        "application/json",
 			},
 			Body: body,
 			Code: http.StatusBadRequest,
@@ -96,9 +96,9 @@ foo/bar:
 
 			Method: http.MethodPost,
 			Header: map[string]string{
-				"X-GitHub-Event":    "ping",
-				"X-GitHub-Delivery": "I am unique",
-				"X-Hub-Signature":   hmac,
+				"X-GitHub-Event":      "ping",
+				"X-GitHub-Delivery":   "I am unique",
+				"X-Hub-Signature-256": hmac,
 			},
 			Body: body,
 			Code: http.StatusBadRequest,
@@ -108,9 +108,9 @@ foo/bar:
 
 			Method: http.MethodPost,
 			Header: map[string]string{
-				"X-GitHub-Event":  "ping",
-				"X-Hub-Signature": hmac,
-				"content-type":    "application/json",
+				"X-GitHub-Event":      "ping",
+				"X-Hub-Signature-256": hmac,
+				"content-type":        "application/json",
 			},
 			Body: body,
 			Code: http.StatusBadRequest,
@@ -132,10 +132,10 @@ foo/bar:
 
 			Method: http.MethodPost,
 			Header: map[string]string{
-				"X-GitHub-Event":    "ping",
-				"X-GitHub-Delivery": "I am unique",
-				"X-Hub-Signature":   "this doesn't work",
-				"content-type":      "application/json",
+				"X-GitHub-Event":      "ping",
+				"X-GitHub-Delivery":   "I am unique",
+				"X-Hub-Signature-256": "this doesn't work",
+				"content-type":        "application/json",
 			},
 			Body: body,
 			Code: http.StatusForbidden,
@@ -145,10 +145,10 @@ foo/bar:
 
 			Method: http.MethodPost,
 			Header: map[string]string{
-				"X-GitHub-Event":    "ping",
-				"X-GitHub-Delivery": "I am unique",
-				"X-Hub-Signature":   hmac,
-				"content-type":      "application/json",
+				"X-GitHub-Event":      "ping",
+				"X-GitHub-Delivery":   "I am unique",
+				"X-Hub-Signature-256": hmac,
+				"content-type":        "application/json",
 			},
 			Body: body,
 			Code: http.StatusOK,

--- a/pkg/hook/server_test.go
+++ b/pkg/hook/server_test.go
@@ -60,9 +60,9 @@ foo/bar:
 		TokenGenerator: getSecret,
 		RepoEnabled:    func(org, repo string) bool { return true },
 	}
-	// This is the SHA1 signature for payload "{}" and signature "abc"
-	// echo -n '{}' | openssl dgst -sha1 -hmac abc
-	const hmac string = "sha1=db5c76f4264d0ad96cf21baec394964b4b8ce580"
+	// This is the SHA256 signature for payload "{}" and secret "abc"
+	// echo -n '{}' | openssl dgst -sha256 -hmac abc
+	const hmac string = "sha256=19092633e5aa9a849dfcc9d2df4e76db2df1fcba7f38915f2c7833bd8a510f2f"
 	const body string = "{}"
 	var testcases = []struct {
 		name string
@@ -77,10 +77,10 @@ foo/bar:
 
 			Method: http.MethodDelete,
 			Header: map[string]string{
-				"X-GitHub-Event":    "ping",
-				"X-GitHub-Delivery": "I am unique",
-				"X-Hub-Signature":   hmac,
-				"content-type":      "application/json",
+				"X-GitHub-Event":      "ping",
+				"X-GitHub-Delivery":   "I am unique",
+				"X-Hub-Signature-256": hmac,
+				"content-type":        "application/json",
 			},
 			Body: body,
 			Code: http.StatusMethodNotAllowed,
@@ -90,9 +90,9 @@ foo/bar:
 
 			Method: http.MethodPost,
 			Header: map[string]string{
-				"X-GitHub-Delivery": "I am unique",
-				"X-Hub-Signature":   hmac,
-				"content-type":      "application/json",
+				"X-GitHub-Delivery":   "I am unique",
+				"X-Hub-Signature-256": hmac,
+				"content-type":        "application/json",
 			},
 			Body: body,
 			Code: http.StatusBadRequest,
@@ -102,9 +102,9 @@ foo/bar:
 
 			Method: http.MethodPost,
 			Header: map[string]string{
-				"X-GitHub-Event":    "ping",
-				"X-GitHub-Delivery": "I am unique",
-				"X-Hub-Signature":   hmac,
+				"X-GitHub-Event":      "ping",
+				"X-GitHub-Delivery":   "I am unique",
+				"X-Hub-Signature-256": hmac,
 			},
 			Body: body,
 			Code: http.StatusBadRequest,
@@ -114,9 +114,9 @@ foo/bar:
 
 			Method: http.MethodPost,
 			Header: map[string]string{
-				"X-GitHub-Event":  "ping",
-				"X-Hub-Signature": hmac,
-				"content-type":    "application/json",
+				"X-GitHub-Event":      "ping",
+				"X-Hub-Signature-256": hmac,
+				"content-type":        "application/json",
 			},
 			Body: body,
 			Code: http.StatusBadRequest,
@@ -138,10 +138,10 @@ foo/bar:
 
 			Method: http.MethodPost,
 			Header: map[string]string{
-				"X-GitHub-Event":    "ping",
-				"X-GitHub-Delivery": "I am unique",
-				"X-Hub-Signature":   "this doesn't work",
-				"content-type":      "application/json",
+				"X-GitHub-Event":      "ping",
+				"X-GitHub-Delivery":   "I am unique",
+				"X-Hub-Signature-256": "this doesn't work",
+				"content-type":        "application/json",
 			},
 			Body: body,
 			Code: http.StatusForbidden,
@@ -151,10 +151,10 @@ foo/bar:
 
 			Method: http.MethodPost,
 			Header: map[string]string{
-				"X-GitHub-Event":    "ping",
-				"X-GitHub-Delivery": "I am unique",
-				"X-Hub-Signature":   hmac,
-				"content-type":      "application/json",
+				"X-GitHub-Event":      "ping",
+				"X-GitHub-Delivery":   "I am unique",
+				"X-Hub-Signature-256": hmac,
+				"content-type":        "application/json",
 			},
 			Body: body,
 			Code: http.StatusOK,
@@ -459,9 +459,9 @@ foo/bar:
 		},
 	}
 
-	// This is the SHA1 signature for payload "$BODY" and signature "abc"
-	// echo -n $BODY | openssl dgst -sha1 -hmac abc
-	const hmac string = "sha1=d5f926df2d39006bdb5b6acb18f8fcdebad7a052"
+	// This is the SHA256 signature for payload "$BODY" and secret "abc"
+	// echo -n $BODY | openssl dgst -sha256 -hmac abc
+	const hmac string = "sha256=f15983ee7ef10c82bbf4bb76bb5f1cffb7dc885909ca9cd745aaf281df5dd036"
 	const body string = `{
   "action": "edited",
   "changes": {
@@ -495,10 +495,10 @@ foo/bar:
 
 			Method: http.MethodPost,
 			Header: map[string]string{
-				"X-GitHub-Event":    "repository",
-				"X-GitHub-Delivery": "I am unique",
-				"X-Hub-Signature":   hmac,
-				"content-type":      "application/json",
+				"X-GitHub-Event":      "repository",
+				"X-GitHub-Delivery":   "I am unique",
+				"X-Hub-Signature-256": hmac,
+				"content-type":        "application/json",
 			},
 			Body: body,
 
@@ -509,10 +509,10 @@ foo/bar:
 
 			Method: http.MethodPost,
 			Header: map[string]string{
-				"X-GitHub-Event":    "issue_comment",
-				"X-GitHub-Delivery": "I am unique",
-				"X-Hub-Signature":   hmac,
-				"content-type":      "application/json",
+				"X-GitHub-Event":      "issue_comment",
+				"X-GitHub-Delivery":   "I am unique",
+				"X-Hub-Signature-256": hmac,
+				"content-type":        "application/json",
 			},
 			Body: body,
 
@@ -523,10 +523,10 @@ foo/bar:
 
 			Method: http.MethodPost,
 			Header: map[string]string{
-				"X-GitHub-Event":    "unknown_event",
-				"X-GitHub-Delivery": "I am unique",
-				"X-Hub-Signature":   hmac,
-				"content-type":      "application/json",
+				"X-GitHub-Event":      "unknown_event",
+				"X-GitHub-Delivery":   "I am unique",
+				"X-Hub-Signature-256": hmac,
+				"content-type":        "application/json",
 			},
 			Body: body,
 

--- a/pkg/phony/phony.go
+++ b/pkg/phony/phony.go
@@ -33,7 +33,7 @@ func SendHook(address, eventType string, payload, hmac []byte) error {
 	}
 	req.Header.Set("X-GitHub-Event", eventType)
 	req.Header.Set("X-GitHub-Delivery", "GUID")
-	req.Header.Set("X-Hub-Signature", github.PayloadSignature(payload, hmac))
+	req.Header.Set("X-Hub-Signature-256", github.PayloadSignature(payload, hmac))
 	req.Header.Set("content-type", "application/json")
 
 	c := &http.Client{}


### PR DESCRIPTION
## Summary

- Switch webhook HMAC validation from SHA1 (`X-Hub-Signature`) to SHA256 (`X-Hub-Signature-256`), as [recommended by GitHub](https://docs.github.com/en/webhooks/using-webhooks/validating-webhook-deliveries). The SHA1 header is kept by GitHub only for legacy purposes.
- This is a safe in-place algorithm swap — GitHub already sends both headers when a webhook secret is configured, so no configuration changes are needed on the GitHub side.
- Add a test case using GitHub's official HMAC-SHA256 test vector to verify correctness.

## Test plan

- [x] All existing HMAC test signatures recomputed with SHA256 and verified
- [x] `go test ./pkg/github/...` passes
- [x] `go test ./pkg/hook/...` passes
- [x] `go test ./pkg/phony/...` passes (no test files, compiles OK)
- [x] New `TestPayloadSignatureGitHubVector` validates against GitHub's official test vector
- [ ] External plugins (cherrypicker, refresh, needs-rebase) call `github.ValidateWebhook()` whose signature is unchanged — no changes needed