### PR TITLE
Restore HEAD after failed rebase abort in mergeRebase

### DIFF
--- a/pkg/git/v2/interactor.go
+++ b/pkg/git/v2/interactor.go
@@ -383,6 +383,12 @@ func (i *interactor) mergeRebase(commitlike string) (bool, error) {
 		if b, err := i.executor.Run("rebase", "--abort"); err != nil {
 			return false, fmt.Errorf("error aborting after failed rebase for commitlike %s: %v. output: %s", commitlike, err, string(b))
 		}
+		// git rebase <upstream> <branch> checks out <branch> before rebasing,
+		// and --abort restores HEAD to <branch>, not to the pre-rebase HEAD.
+		// Restore HEAD to where the caller left it.
+		if err := i.Checkout(headRev); err != nil {
+			return false, fmt.Errorf("error restoring HEAD after aborted rebase for commitlike %s: %w", commitlike, err)
+		}
 		return false, nil
 	}
 	return true, nil

--- a/pkg/git/v2/interactor_test.go
+++ b/pkg/git/v2/interactor_test.go
@@ -907,6 +907,111 @@ func TestInteractor_MergeWithStrategy(t *testing.T) {
 			expectedMerge: false,
 			expectedErr:   true,
 		},
+		{
+			name:       "rebase succeeds",
+			commitlike: "prHead",
+			strategy:   "rebase",
+			responses: map[string]execResponse{
+				"rev-parse HEAD": {
+					out: []byte("baseSHA\n"),
+				},
+				"rebase --no-stat baseSHA prHead": {
+					out: []byte(`ok`),
+				},
+			},
+			expectedCalls: [][]string{
+				{"rev-parse", "HEAD"},
+				{"rebase", "--no-stat", "baseSHA", "prHead"},
+			},
+			expectedMerge: true,
+			expectedErr:   false,
+		},
+		{
+			name:       "rebase fails, abort succeeds, HEAD is restored to pre-rebase state",
+			commitlike: "prHead",
+			strategy:   "rebase",
+			responses: map[string]execResponse{
+				"rev-parse HEAD": {
+					out: []byte("baseSHA\n"),
+				},
+				"rebase --no-stat baseSHA prHead": {
+					err: errors.New("conflict"),
+				},
+				"rebase --abort": {
+					out: []byte(`ok`),
+				},
+				"checkout baseSHA": {
+					out: []byte(`ok`),
+				},
+			},
+			expectedCalls: [][]string{
+				{"rev-parse", "HEAD"},
+				{"rebase", "--no-stat", "baseSHA", "prHead"},
+				{"rebase", "--abort"},
+				{"checkout", "baseSHA"},
+			},
+			expectedMerge: false,
+			expectedErr:   false,
+		},
+		{
+			name:       "rebase fails, abort fails",
+			commitlike: "prHead",
+			strategy:   "rebase",
+			responses: map[string]execResponse{
+				"rev-parse HEAD": {
+					out: []byte("baseSHA\n"),
+				},
+				"rebase --no-stat baseSHA prHead": {
+					err: errors.New("conflict"),
+				},
+				"rebase --abort": {
+					err: errors.New("oops"),
+				},
+			},
+			expectedCalls: [][]string{
+				{"rev-parse", "HEAD"},
+				{"rebase", "--no-stat", "baseSHA", "prHead"},
+				{"rebase", "--abort"},
+			},
+			expectedMerge: false,
+			expectedErr:   true,
+		},
+		{
+			name:       "rebase fails, abort succeeds, HEAD restore fails",
+			commitlike: "prHead",
+			strategy:   "rebase",
+			responses: map[string]execResponse{
+				"rev-parse HEAD": {
+					out: []byte("baseSHA\n"),
+				},
+				"rebase --no-stat baseSHA prHead": {
+					err: errors.New("conflict"),
+				},
+				"rebase --abort": {
+					out: []byte(`ok`),
+				},
+				"checkout baseSHA": {
+					err: errors.New("oops"),
+				},
+			},
+			expectedCalls: [][]string{
+				{"rev-parse", "HEAD"},
+				{"rebase", "--no-stat", "baseSHA", "prHead"},
+				{"rebase", "--abort"},
+				{"checkout", "baseSHA"},
+			},
+			expectedMerge: false,
+			expectedErr:   true,
+		},
+		{
+			name:          "rebase with empty commitlike",
+			commitlike:    "",
+			strategy:      "rebase",
+			responses:     map[string]execResponse{},
+			expectedCalls: [][]string{},
+			expectedMerge: false,
+			expectedErr:   true,
+		},
 	}
 
 	for _, testCase := range testCases {


### PR DESCRIPTION
There's a subtle bug in `mergeRebase` error path. It runs:

```
git rebase --no-stat <upstream> <branch>
```

This implicitly checks out `<branch>` before rebasing its commits on top of `<upstream>`. When the rebase fails and is aborted, `git rebase --abort` [restores HEAD to `<branch>` - not to the pre-rebase HEAD](https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---abort).

> If `<branch>` was provided when the rebase operation was started, then HEAD will be reset to `<branch>`

```console
$ git checkout upstream/main
HEAD is now at 6691f5aff Merge pull request #667 from stmcginnis/local-dev
$ git rebase -i upstream/main fix-spyglass-log-s3 # add break to the command list
Stopped at 61a57d1fb (Fix expanding skipped lines when using S3)
$ git rebase --abort
$ git status
On branch fix-spyglass-log-s3
          ^^^^^^^^^^^^^^^^^^^ not where we were before `git rebase` 
```

Add a Checkout(headRev) after successful abort to restore HEAD to where the caller left it.

Assisted by Claude Code / Opus 4.6