### PR TITLE
lgtm, approve: ignore review states from GitHub App bots

### DIFF
--- a/pkg/plugins/approve/approve.go
+++ b/pkg/plugins/approve/approve.go
@@ -237,20 +237,23 @@ func handleReview(log *logrus.Entry, ghc githubClient, oc ownersClient, githubCo
 	if err != nil {
 		return err
 	}
+	isBot := func(login string) bool {
+		return botUserChecker(login) || re.Review.User.Type == github.UserTypeBot
+	}
 
 	opts := config.ApproveFor(re.Repo.Owner.Login, re.Repo.Name)
 
 	// Check for an approval command is in the body. If one exists, let the
 	// genericCommentEventHandler handle this event. Approval commands override
 	// review state.
-	if isApprovalCommand(botUserChecker, opts.LgtmActsAsApprove, &comment{Body: re.Review.Body, Author: re.Review.User.Login}) {
+	if isApprovalCommand(isBot, opts.LgtmActsAsApprove, &comment{Body: re.Review.Body, Author: re.Review.User.Login}) {
 		log.Debug("Review constitutes approval, skipping event.")
 		return nil
 	}
 
 	// Check for an approval command via review state. If none exists, don't
 	// handle this event.
-	if !isApprovalState(botUserChecker, opts.ConsiderReviewState(), &comment{Author: re.Review.User.Login, ReviewState: re.Review.State}) {
+	if !isApprovalState(isBot, opts.ConsiderReviewState(), &comment{Author: re.Review.User.Login, ReviewState: re.Review.State}) {
 		log.Debug("Review does not constitute approval, skipping event.")
 		return nil
 	}
@@ -278,7 +281,6 @@ func handleReview(log *logrus.Entry, ghc githubClient, oc ownersClient, githubCo
 			htmlURL:   re.PullRequest.HTMLURL,
 		},
 	)
-
 }
 
 func handlePullRequestEvent(pc plugins.Agent, pre github.PullRequestEvent) error {
@@ -444,13 +446,24 @@ func handle(log *logrus.Entry, ghc githubClient, repo approvers.Repo, githubConf
 	log.WithField("duration", time.Since(start).String()).Debug("Completed configuring approversHandler in handle")
 
 	start = time.Now()
+
+	appBotLogins := map[string]bool{}
+	for _, r := range reviews {
+		if r.User.Type == github.UserTypeBot {
+			appBotLogins[r.User.Login] = true
+		}
+	}
+	isBot := func(login string) bool {
+		return botUserChecker(login) || appBotLogins[login]
+	}
+
 	commentsFromIssueComments := commentsFromIssueComments(issueComments)
 	comments := append(commentsFromReviewComments(reviewComments), commentsFromIssueComments...)
 	comments = append(comments, commentsFromReviews(reviews)...)
 	sort.SliceStable(comments, func(i, j int) bool {
 		return comments[i].CreatedAt.Before(comments[j].CreatedAt)
 	})
-	approveComments := filterComments(comments, approvalMatcher(botUserChecker, opts.LgtmActsAsApprove, opts.ConsiderReviewState()))
+	approveComments := filterComments(comments, approvalMatcher(isBot, opts.LgtmActsAsApprove, opts.ConsiderReviewState()))
 	addApprovers(&approversHandler, approveComments, pr.author, opts.ConsiderReviewState())
 	log.WithField("duration", time.Since(start).String()).Debug("Completed filtering approval comments in handle")
 

--- a/pkg/plugins/approve/approve_test.go
+++ b/pkg/plugins/approve/approve_test.go
@@ -1729,6 +1729,38 @@ func TestHandleReview(t *testing.T) {
 			reviewActsAsApprove: false,
 			expectHandle:        false,
 		},
+		{
+			name: "GitHub App bot approved review is ignored",
+			reviewEvent: github.ReviewEvent{
+				Action: github.ReviewActionSubmitted,
+				Review: github.Review{
+					Body: "looks good",
+					User: github.User{
+						Login: "some-app[bot]",
+						Type:  github.UserTypeBot,
+					},
+					State: stateToLower(github.ReviewStateApproved),
+				},
+			},
+			reviewActsAsApprove: true,
+			expectHandle:        false,
+		},
+		{
+			name: "GitHub App bot changes requested review is ignored",
+			reviewEvent: github.ReviewEvent{
+				Action: github.ReviewActionSubmitted,
+				Review: github.Review{
+					Body: "needs changes",
+					User: github.User{
+						Login: "some-app[bot]",
+						Type:  github.UserTypeBot,
+					},
+					State: stateToLower(github.ReviewStateChangesRequested),
+				},
+			},
+			reviewActsAsApprove: true,
+			expectHandle:        false,
+		},
 	}
 
 	var handled bool

--- a/pkg/plugins/lgtm/lgtm.go
+++ b/pkg/plugins/lgtm/lgtm.go
@@ -224,6 +224,15 @@ func handlePullRequestReview(gc githubClient, config *plugins.Configuration, own
 		return nil
 	}
 
+	// Ignore review states from GitHub App bots — they cannot be collaborators.
+	botUserChecker, err := gc.BotUserChecker()
+	if err != nil {
+		return err
+	}
+	if botUserChecker(e.Review.User.Login) || e.Review.User.Type == github.UserTypeBot {
+		return nil
+	}
+
 	// If the review event body contains an '/lgtm' or '/lgtm cancel' comment,
 	// skip handling the review event
 	if LGTMRe.MatchString(rc.body) || LGTMCancelRe.MatchString(rc.body) {

--- a/pkg/plugins/lgtm/lgtm_test.go
+++ b/pkg/plugins/lgtm/lgtm_test.go
@@ -615,6 +615,7 @@ func TestLGTMFromApproveReview(t *testing.T) {
 		action        github.ReviewEventAction
 		body          string
 		reviewer      string
+		reviewerType  string
 		hasLGTM       bool
 		shouldToggle  bool
 		shouldComment bool
@@ -749,6 +750,28 @@ func TestLGTMFromApproveReview(t *testing.T) {
 			shouldComment: false,
 			shouldAssign:  false,
 		},
+		{
+			name:          "Approve review by GitHub App bot, no lgtm on pr",
+			state:         github.ReviewStateApproved,
+			action:        github.ReviewActionSubmitted,
+			reviewer:      "some-app[bot]",
+			reviewerType:  github.UserTypeBot,
+			hasLGTM:       false,
+			shouldToggle:  false,
+			shouldComment: false,
+			shouldAssign:  false,
+		},
+		{
+			name:          "Request changes review by GitHub App bot, lgtm on pr",
+			state:         github.ReviewStateChangesRequested,
+			action:        github.ReviewActionSubmitted,
+			reviewer:      "some-app[bot]",
+			reviewerType:  github.UserTypeBot,
+			hasLGTM:       true,
+			shouldToggle:  false,
+			shouldComment: false,
+			shouldAssign:  false,
+		},
 	}
 	SHA := "0bd3ed50c88cd53a09316bf7a298f900e9371652"
 	for _, tc := range testcases {
@@ -765,7 +788,7 @@ func TestLGTMFromApproveReview(t *testing.T) {
 		fc.Collaborators = []string{"collab1", "collab2"}
 		e := &github.ReviewEvent{
 			Action:      tc.action,
-			Review:      github.Review{Body: tc.body, State: tc.state, HTMLURL: "<url>", User: github.User{Login: tc.reviewer}},
+			Review:      github.Review{Body: tc.body, State: tc.state, HTMLURL: "<url>", User: github.User{Login: tc.reviewer, Type: tc.reviewerType}},
 			PullRequest: github.PullRequest{User: github.User{Login: "author"}, Assignees: []github.User{{Login: "collab1"}, {Login: "assignee1"}}, Number: 5},
 			Repo:        github.Repo{Owner: github.User{Login: "org"}, Name: "repo"},
 		}


### PR DESCRIPTION
The `lgtm` label is provided by collaborators and `approved` is provided by approvers. GitHub Apps can be neither. Some Apps do GitHub reviews. In repos that configure lgtm or approve to respect GitHub reviews for convenience, this causes noise where Prow responds to such reviews with (1) [comments](https://github.com/openshift/sippy/pull/3462#issuecomment-4296746028) that it cannot touch LGTM (2) approval comments that [include the bot name](https://github.com/openshift/sippy/pull/3462#issuecomment-4296748279) in the list of logins that approved the PR.

Avoid this noise by ignoring reviews made by GitHub Apps in both plugins. No changes for comment handlers - if an app actually tries to do `/lgtm` or `/approve` then the response is in order.

Code changes assisted by Claude Code