### PR TITLE
[WIP] fixcommitmsg: add plugin to rewrite invalid commit messages

### DIFF
--- a/cmd/hook/plugin-imports/plugin-imports.go
+++ b/cmd/hook/plugin-imports/plugin-imports.go
@@ -32,6 +32,7 @@ import (
 	_ "sigs.k8s.io/prow/pkg/plugins/cla"
 	_ "sigs.k8s.io/prow/pkg/plugins/dco"
 	_ "sigs.k8s.io/prow/pkg/plugins/dog"
+	_ "sigs.k8s.io/prow/pkg/plugins/fixcommitmsg"
 	_ "sigs.k8s.io/prow/pkg/plugins/golint"
 	_ "sigs.k8s.io/prow/pkg/plugins/goose"
 	_ "sigs.k8s.io/prow/pkg/plugins/heart"

--- a/pkg/git/v2/interactor.go
+++ b/pkg/git/v2/interactor.go
@@ -60,6 +60,10 @@ type Interactor interface {
 	MergeAndCheckout(baseSHA string, mergeStrategy string, headSHAs ...string) error
 	// Am calls `git am`
 	Am(path string) error
+	// CherryPick cherry-picks the given commit onto the current branch
+	CherryPick(commitlike string) error
+	// Amend rewrites the most recent commit with a new message
+	Amend(message string) error
 	// Fetch calls `git fetch arg...`
 	Fetch(arg ...string) error
 	// FetchRef fetches the refspec
@@ -436,6 +440,24 @@ func (i *interactor) Am(path string) error {
 		i.logger.WithError(abortErr).Warningf("Aborting patch apply failed with output: %s", string(abortOut))
 	}
 	return errors.New(string(bytes.TrimPrefix(out, []byte("The copy of the patch that failed is found in: .git/rebase-apply/patch"))))
+}
+
+// CherryPick cherry-picks the given commit onto the current branch.
+func (i *interactor) CherryPick(commitlike string) error {
+	i.logger.WithField("commitlike", commitlike).Info("Cherry-picking commit.")
+	if out, err := i.executor.Run("cherry-pick", commitlike); err != nil {
+		return fmt.Errorf("error cherry-pick %s: %w. output: %s", commitlike, err, string(out))
+	}
+	return nil
+}
+
+// Amend rewrites the most recent commit with a new message.
+func (i *interactor) Amend(message string) error {
+	i.logger.Info("Amending commit message.")
+	if out, err := i.executor.Run("commit", "--amend", "-m", message); err != nil {
+		return fmt.Errorf("error commit --amend: %w. output: %s", err, string(out))
+	}
+	return nil
 }
 
 // FetchCommits only fetches those commits which we want, and only if they are

--- a/pkg/plugins/config.go
+++ b/pkg/plugins/config.go
@@ -77,6 +77,7 @@ type Configuration struct {
 	CherryPickUnapproved CherryPickUnapproved         `json:"cherry_pick_unapproved,omitempty"`
 	ConfigUpdater        ConfigUpdater                `json:"config_updater,omitempty"`
 	Dco                  map[string]*Dco              `json:"dco,omitempty"`
+	FixCommitMsg         FixCommitMsg                 `json:"fix_commit_msg,omitempty"`
 	Golint               Golint                       `json:"golint,omitempty"`
 	Goose                Goose                        `json:"goose,omitempty"`
 	Heart                Heart                        `json:"heart,omitempty"`
@@ -263,6 +264,14 @@ func (c *Configuration) SkipCollaborators(org, repo string) bool {
 		}
 	}
 	return false
+}
+
+// FixCommitMsg contains configuration for the fixcommitmsg plugin.
+type FixCommitMsg struct {
+	// MaintainerTeam is the GitHub team slug (or display name) whose members
+	// are allowed to trigger the /fix-commit-messages command. The team is
+	// looked up in the same org as the pull request.
+	MaintainerTeam string `json:"maintainer_team,omitempty"`
 }
 
 // Retitle specifies configuration for the retitle plugin.

--- a/pkg/plugins/fixcommitmsg/fixcommitmsg.go
+++ b/pkg/plugins/fixcommitmsg/fixcommitmsg.go
@@ -1,0 +1,282 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package fixcommitmsg provides the /fix-commit-messages command. When
+// triggered, it rewrites commit messages on a pull request to remove
+// close-issue keywords and fixup/amend/squash prefixes that are flagged
+// as invalid by the invalidcommitmsg plugin. Only members of the configured
+// maintainer team can trigger this command.
+package fixcommitmsg
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+
+	"sigs.k8s.io/prow/pkg/config"
+	git "sigs.k8s.io/prow/pkg/git/v2"
+	"sigs.k8s.io/prow/pkg/github"
+	"sigs.k8s.io/prow/pkg/pluginhelp"
+	"sigs.k8s.io/prow/pkg/plugins"
+	"sigs.k8s.io/prow/pkg/plugins/invalidcommitmsg"
+)
+
+const (
+	pluginName            = "fixcommitmsg"
+	invalidCommitMsgLabel = "do-not-merge/invalid-commit-message"
+)
+
+var commandRe = regexp.MustCompile(`(?mi)^/fix-commit-messages\s*$`)
+
+func init() {
+	plugins.RegisterGenericCommentHandler(pluginName, handleGenericCommentEvent, helpProvider)
+}
+
+func helpProvider(_ *plugins.Configuration, _ []config.OrgRepo) (*pluginhelp.PluginHelp, error) {
+	pluginHelp := &pluginhelp.PluginHelp{
+		Description: "The fixcommitmsg plugin rewrites commit messages on a pull request to remove close-issue keywords and fixup/amend/squash prefixes that are flagged by the invalidcommitmsg plugin.",
+	}
+	pluginHelp.AddCommand(pluginhelp.Command{
+		Usage:       "/fix-commit-messages",
+		Description: "Rewrites commit messages in the PR to replace close-issue keywords (closes/fixes/resolves #NNN) with 'Related: NNN' and strip fixup!/amend!/squash! prefixes.",
+		Featured:    false,
+		WhoCanUse:   "Members of the configured maintainer team.",
+		Examples:    []string{"/fix-commit-messages"},
+	})
+	return pluginHelp, nil
+}
+
+type githubClient interface {
+	CreateComment(org, repo string, number int, comment string) error
+	GetPullRequest(org, repo string, number int) (*github.PullRequest, error)
+	ListPullRequestCommits(org, repo string, number int) ([]github.RepositoryCommit, error)
+	ListTeams(org string) ([]github.Team, error)
+	ListTeamMembersBySlug(org, teamSlug, role string) ([]github.TeamMember, error)
+	RemoveLabel(org, repo string, number int, label string) error
+}
+
+func handleGenericCommentEvent(pc plugins.Agent, e github.GenericCommentEvent) error {
+	return handle(pc.GitHubClient, pc.GitClient, pc.Logger, pc.PluginConfig.FixCommitMsg, e)
+}
+
+func handle(gc githubClient, gitFactory git.ClientFactory, log *logrus.Entry, cfg plugins.FixCommitMsg, e github.GenericCommentEvent) error {
+	if e.Action != github.GenericCommentActionCreated {
+		return nil
+	}
+	if !e.IsPR {
+		return nil
+	}
+	if e.IssueState != "open" {
+		return nil
+	}
+	if !commandRe.MatchString(e.Body) {
+		return nil
+	}
+
+	var (
+		org    = e.Repo.Owner.Login
+		repo   = e.Repo.Name
+		number = e.Number
+		user   = e.User.Login
+	)
+
+	if cfg.MaintainerTeam != "" {
+		member, err := isTeamMember(gc, org, cfg.MaintainerTeam, user)
+		if err != nil {
+			return err
+		}
+		if !member {
+			return gc.CreateComment(org, repo, number, plugins.FormatResponseRaw(e.Body, e.HTMLURL, user,
+				fmt.Sprintf("only members of the `%s` team can trigger this command", cfg.MaintainerTeam)))
+		}
+	}
+
+	allCommits, err := gc.ListPullRequestCommits(org, repo, number)
+	if err != nil {
+		return fmt.Errorf("failed to list PR commits: %w", err)
+	}
+
+	rewrites := computeRewrites(allCommits)
+	if len(rewrites) == 0 {
+		return gc.CreateComment(org, repo, number, plugins.FormatResponseRaw(e.Body, e.HTMLURL, user, "no commit messages need fixing"))
+	}
+
+	pr, err := gc.GetPullRequest(org, repo, number)
+	if err != nil {
+		return fmt.Errorf("failed to get pull request: %w", err)
+	}
+
+	if err := rewriteCommits(log, gitFactory, pr, allCommits, rewrites); err != nil {
+		return gc.CreateComment(org, repo, number, plugins.FormatResponseRaw(e.Body, e.HTMLURL, user,
+			fmt.Sprintf("failed to rewrite commits: %v", err)))
+	}
+
+	if err := gc.RemoveLabel(org, repo, number, invalidCommitMsgLabel); err != nil {
+		log.WithError(err).Warn("failed to remove label after fixing commits")
+	}
+
+	return gc.CreateComment(org, repo, number, plugins.FormatResponseRaw(e.Body, e.HTMLURL, user,
+		fmt.Sprintf("rewrote %d commit message(s)", len(rewrites))))
+}
+
+// computeRewrites returns a map from commit SHA to corrected message for each
+// commit whose message contains an invalid pattern.
+func computeRewrites(commits []github.RepositoryCommit) map[string]string {
+	rewrites := make(map[string]string)
+	for _, c := range commits {
+		msg := c.Commit.Message
+		fixed := fixMessage(msg)
+		if fixed != msg {
+			rewrites[c.SHA] = fixed
+		}
+	}
+	return rewrites
+}
+
+// fixMessage returns a corrected version of msg with all invalid patterns
+// removed. If the message is already valid it is returned unchanged.
+func fixMessage(msg string) string {
+	subject, body, _ := strings.Cut(msg, "\n")
+	fixed := fixSubject(subject)
+	if body != "" {
+		fixed += "\n" + body
+	}
+	return fixCloseKeywords(fixed)
+}
+
+// fixSubject removes a leading fixup!/amend!/squash! prefix from the commit
+// subject line, leaving the remainder trimmed.
+func fixSubject(subject string) string {
+	return strings.TrimSpace(invalidcommitmsg.FixupCommitRegex.ReplaceAllString(subject, ""))
+}
+
+// fixCloseKeywords replaces close-issue patterns such as "closes #NNN" or
+// "fixes org/repo#NNN" with "Related: NNN" or "Related: org/repo NNN"
+// respectively, removing the "#" that GitHub would otherwise turn into a link.
+func fixCloseKeywords(msg string) string {
+	return invalidcommitmsg.CloseIssueRegex.ReplaceAllStringFunc(msg, func(match string) string {
+		sub := invalidcommitmsg.CloseIssueRegex.FindStringSubmatch(match)
+		// sub[6] is the optional "org/repo" cross-repo prefix; sub[7] is the issue number.
+		repoRef, issueNum := sub[6], sub[7]
+		if repoRef != "" {
+			return "Related: " + repoRef + " " + issueNum
+		}
+		return "Related: " + issueNum
+	})
+}
+
+// rewriteCommits clones the repository that hosts the PR branch, rewrites the
+// commit messages identified in rewrites by cherry-picking each commit and
+// amending where necessary, then force-pushes the result back to the PR branch.
+func rewriteCommits(log *logrus.Entry, gitFactory git.ClientFactory, pr *github.PullRequest, commits []github.RepositoryCommit, rewrites map[string]string) error {
+	if len(commits) == 0 {
+		return nil
+	}
+
+	var (
+		headOrg  = pr.Head.Repo.Owner.Login
+		headRepo = pr.Head.Repo.Name
+		prBranch = pr.Head.Ref
+	)
+
+	r, err := gitFactory.ClientFor(headOrg, headRepo)
+	if err != nil {
+		return fmt.Errorf("failed to clone %s/%s: %w", headOrg, headRepo, err)
+	}
+	defer func() {
+		if cerr := r.Clean(); cerr != nil {
+			log.WithError(cerr).Error("failed to clean up git checkout")
+		}
+	}()
+
+	if err := r.Checkout(prBranch); err != nil {
+		return fmt.Errorf("failed to checkout %s: %w", prBranch, err)
+	}
+
+	// The parent of the oldest PR commit serves as the base for the rewrite.
+	baseSHA, err := r.RevParse(commits[0].SHA + "^")
+	if err != nil {
+		return fmt.Errorf("failed to resolve base commit: %w", err)
+	}
+	baseSHA = strings.TrimSpace(baseSHA)
+
+	// Create a temporary branch at the base commit, cherry-pick all PR commits
+	// onto it in order, and amend the message for each flagged commit.
+	tempBranch := "fix-commit-messages-temp"
+	if err := r.Checkout(baseSHA); err != nil {
+		return fmt.Errorf("failed to checkout base %s: %w", baseSHA, err)
+	}
+	if err := r.CheckoutNewBranch(tempBranch); err != nil {
+		return fmt.Errorf("failed to create temp branch: %w", err)
+	}
+
+	for _, commit := range commits {
+		if err := r.CherryPick(commit.SHA); err != nil {
+			return fmt.Errorf("cherry-pick of %s failed: %w", commit.SHA, err)
+		}
+		if newMsg, ok := rewrites[commit.SHA]; ok {
+			if err := r.Amend(newMsg); err != nil {
+				return fmt.Errorf("amend of %s failed: %w", commit.SHA, err)
+			}
+		}
+	}
+
+	newHEAD, err := r.RevParse("HEAD")
+	if err != nil {
+		return fmt.Errorf("failed to resolve new HEAD: %w", err)
+	}
+	newHEAD = strings.TrimSpace(newHEAD)
+
+	// Reset the PR branch to the rewritten tip and force-push.
+	if err := r.Checkout(prBranch); err != nil {
+		return fmt.Errorf("failed to re-checkout %s: %w", prBranch, err)
+	}
+	if err := r.ResetHard(newHEAD); err != nil {
+		return fmt.Errorf("failed to reset %s: %w", prBranch, err)
+	}
+	if err := r.PushToCentral(prBranch, true); err != nil {
+		return fmt.Errorf("failed to push: %v — the author may need to enable 'Allow edits from maintainers' on this PR", err)
+	}
+
+	return nil
+}
+
+// isTeamMember reports whether user belongs to the GitHub team identified by
+// team (matched against both slug and display name) in the given org.
+func isTeamMember(gc githubClient, org, team, user string) (bool, error) {
+	teams, err := gc.ListTeams(org)
+	if err != nil {
+		return false, fmt.Errorf("failed to list teams in org %s: %w", org, err)
+	}
+	for _, t := range teams {
+		if t.Slug != team && t.Name != team {
+			continue
+		}
+		members, err := gc.ListTeamMembersBySlug(org, t.Slug, github.RoleAll)
+		if err != nil {
+			return false, fmt.Errorf("failed to list members of team %s: %w", team, err)
+		}
+		for _, m := range members {
+			if m.Login == user {
+				return true, nil
+			}
+		}
+		return false, nil
+	}
+	return false, nil
+}

--- a/pkg/plugins/fixcommitmsg/fixcommitmsg_test.go
+++ b/pkg/plugins/fixcommitmsg/fixcommitmsg_test.go
@@ -1,0 +1,243 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fixcommitmsg
+
+import (
+	"errors"
+	"testing"
+
+	"sigs.k8s.io/prow/pkg/github"
+	"sigs.k8s.io/prow/pkg/plugins"
+)
+
+// ---- pure-function tests ------------------------------------------------
+
+func TestFixMessage(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "close keyword simple",
+			input: "my commit\n\ncloses #123",
+			want:  "my commit\n\nRelated: 123",
+		},
+		{
+			name:  "fixes with cross-repo ref",
+			input: "something\n\nfixes kubernetes/kubernetes#456",
+			want:  "something\n\nRelated: kubernetes/kubernetes 456",
+		},
+		{
+			name:  "resolves keyword",
+			input: "resolves #99",
+			want:  "Related: 99",
+		},
+		{
+			name:  "keyword with colon separator",
+			input: "Closes: #10",
+			want:  "Related: 10",
+		},
+		{
+			name:  "fixup prefix stripped from subject",
+			input: "fixup! my commit message",
+			want:  "my commit message",
+		},
+		{
+			name:  "amend prefix stripped",
+			input: "amend! my commit message\n\nsome body",
+			want:  "my commit message\n\nsome body",
+		},
+		{
+			name:  "squash prefix stripped",
+			input: "squash! my commit message",
+			want:  "my commit message",
+		},
+		{
+			name:  "fixup prefix and close keyword in body",
+			input: "fixup! tweak auth\n\nfixes #77",
+			want:  "tweak auth\n\nRelated: 77",
+		},
+		{
+			name:  "clean message unchanged",
+			input: "my normal commit message",
+			want:  "my normal commit message",
+		},
+		{
+			name:  "body only keyword",
+			input: "subject line\n\nsome text\ncloses #5\nmore text",
+			want:  "subject line\n\nsome text\nRelated: 5\nmore text",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := fixMessage(tc.input)
+			if got != tc.want {
+				t.Errorf("fixMessage(%q)\n got  %q\n want %q", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestComputeRewrites(t *testing.T) {
+	commits := []github.RepositoryCommit{
+		{SHA: "aaa", Commit: github.GitCommit{Message: "good message"}},
+		{SHA: "bbb", Commit: github.GitCommit{Message: "closes #1"}},
+		{SHA: "ccc", Commit: github.GitCommit{Message: "fixup! something"}},
+		{SHA: "ddd", Commit: github.GitCommit{Message: "another good one"}},
+	}
+
+	got := computeRewrites(commits)
+
+	if len(got) != 2 {
+		t.Fatalf("expected 2 rewrites, got %d", len(got))
+	}
+	if got["bbb"] != "Related: 1" {
+		t.Errorf("bbb: got %q, want %q", got["bbb"], "Related: 1")
+	}
+	if got["ccc"] != "something" {
+		t.Errorf("ccc: got %q, want %q", got["ccc"], "something")
+	}
+	if _, ok := got["aaa"]; ok {
+		t.Error("aaa should not be in rewrites")
+	}
+}
+
+// ---- handle() unit tests (mocked GitHub client, no git ops) -------------
+
+type fakeGHClient struct {
+	comments        []string
+	labelRemoved    bool
+	pr              *github.PullRequest
+	commits         []github.RepositoryCommit
+	teams           []github.Team
+	teamMembers     map[string][]github.TeamMember
+	createCommentFn func(org, repo string, number int, comment string) error
+}
+
+func (f *fakeGHClient) CreateComment(org, repo string, number int, comment string) error {
+	if f.createCommentFn != nil {
+		return f.createCommentFn(org, repo, number, comment)
+	}
+	f.comments = append(f.comments, comment)
+	return nil
+}
+func (f *fakeGHClient) GetPullRequest(_, _ string, _ int) (*github.PullRequest, error) {
+	if f.pr == nil {
+		return nil, errors.New("no PR configured")
+	}
+	return f.pr, nil
+}
+func (f *fakeGHClient) ListPullRequestCommits(_, _ string, _ int) ([]github.RepositoryCommit, error) {
+	return f.commits, nil
+}
+func (f *fakeGHClient) ListTeams(_ string) ([]github.Team, error) {
+	return f.teams, nil
+}
+func (f *fakeGHClient) ListTeamMembersBySlug(_, slug, _ string) ([]github.TeamMember, error) {
+	return f.teamMembers[slug], nil
+}
+func (f *fakeGHClient) RemoveLabel(_, _ string, _ int, _ string) error {
+	f.labelRemoved = true
+	return nil
+}
+
+func newOpenPREvent(user, body string) github.GenericCommentEvent {
+	return github.GenericCommentEvent{
+		Action:     github.GenericCommentActionCreated,
+		IsPR:       true,
+		IssueState: "open",
+		Body:       body,
+		HTMLURL:    "https://github.com/org/repo/pull/1#issuecomment-1",
+		Number:     1,
+		User:       github.User{Login: user},
+		Repo:       github.Repo{Owner: github.User{Login: "org"}, Name: "repo"},
+	}
+}
+
+func TestHandleIgnoresNonCommand(t *testing.T) {
+	gc := &fakeGHClient{}
+	e := newOpenPREvent("user", "just a regular comment")
+	if err := handle(gc, nil, nil, plugins.FixCommitMsg{}, e); err != nil {
+		t.Fatal(err)
+	}
+	if len(gc.comments) != 0 {
+		t.Errorf("expected no comments, got %d", len(gc.comments))
+	}
+}
+
+func TestHandleIgnoresClosedPR(t *testing.T) {
+	gc := &fakeGHClient{}
+	e := newOpenPREvent("user", "/fix-commit-messages")
+	e.IssueState = "closed"
+	if err := handle(gc, nil, nil, plugins.FixCommitMsg{}, e); err != nil {
+		t.Fatal(err)
+	}
+	if len(gc.comments) != 0 {
+		t.Errorf("expected no comments for closed PR, got %d", len(gc.comments))
+	}
+}
+
+func TestHandleUnauthorizedUser(t *testing.T) {
+	gc := &fakeGHClient{
+		teams:       []github.Team{{Name: "maintainers", Slug: "maintainers"}},
+		teamMembers: map[string][]github.TeamMember{"maintainers": {{Login: "alice"}}},
+	}
+	e := newOpenPREvent("bob", "/fix-commit-messages")
+	if err := handle(gc, nil, nil, plugins.FixCommitMsg{MaintainerTeam: "maintainers"}, e); err != nil {
+		t.Fatal(err)
+	}
+	if len(gc.comments) != 1 {
+		t.Fatalf("expected 1 comment, got %d", len(gc.comments))
+	}
+	if !containsStr(gc.comments[0], "maintainers") {
+		t.Errorf("expected comment to mention team name, got: %s", gc.comments[0])
+	}
+}
+
+func TestHandleNothingToFix(t *testing.T) {
+	gc := &fakeGHClient{
+		teams:       []github.Team{{Name: "maintainers", Slug: "maintainers"}},
+		teamMembers: map[string][]github.TeamMember{"maintainers": {{Login: "alice"}}},
+		commits: []github.RepositoryCommit{
+			{SHA: "aaa", Commit: github.GitCommit{Message: "good commit"}},
+		},
+	}
+	e := newOpenPREvent("alice", "/fix-commit-messages")
+	if err := handle(gc, nil, nil, plugins.FixCommitMsg{MaintainerTeam: "maintainers"}, e); err != nil {
+		t.Fatal(err)
+	}
+	if len(gc.comments) != 1 {
+		t.Fatalf("expected 1 comment, got %d", len(gc.comments))
+	}
+	if !containsStr(gc.comments[0], "no commit messages need fixing") {
+		t.Errorf("unexpected comment: %s", gc.comments[0])
+	}
+}
+
+func containsStr(s, sub string) bool {
+	return len(s) >= len(sub) && (s == sub || len(sub) == 0 ||
+		func() bool {
+			for i := 0; i <= len(s)-len(sub); i++ {
+				if s[i:i+len(sub)] == sub {
+					return true
+				}
+			}
+			return false
+		}())
+}

--- a/pkg/plugins/invalidcommitmsg/invalidcommitmsg.go
+++ b/pkg/plugins/invalidcommitmsg/invalidcommitmsg.go
@@ -40,7 +40,7 @@ const (
 )
 
 var CloseIssueRegex = regexp.MustCompile(`((?i)(clos(?:e[sd]?))|(fix(?:(es|ed)?))|(resolv(?:e[sd]?)))[\s:]+(\w+/\w+)?#(\d+)`)
-var fixupCommitRegex = regexp.MustCompile(`^(fixup!|amend!|squash!)`)
+var FixupCommitRegex = regexp.MustCompile(`^(fixup!|amend!|squash!)`)
 
 func init() {
 	plugins.RegisterPullRequestHandler(pluginName, handlePullRequest, helpProvider)
@@ -113,7 +113,7 @@ func handle(gc githubClient, log *logrus.Entry, pr github.PullRequestEvent, cp c
 			invalidCommits = append(invalidCommits, commit)
 		}
 
-		if checkFixup && fixupCommitRegex.MatchString(subject) {
+		if checkFixup && FixupCommitRegex.MatchString(subject) {
 			fixupCommits = append(fixupCommits, commit)
 		}
 	}

--- a/pkg/plugins/invalidcommitmsg/invalidcommitmsg_test.go
+++ b/pkg/plugins/invalidcommitmsg/invalidcommitmsg_test.go
@@ -333,7 +333,7 @@ func containsInvalidCommits(commits []github.RepositoryCommit) bool {
 
 func containsFixup(commits []github.RepositoryCommit) bool {
 	for _, c := range commits {
-		if fixupCommitRegex.MatchString(strings.Split(c.Commit.Message, "\n")[0]) {
+		if FixupCommitRegex.MatchString(strings.Split(c.Commit.Message, "\n")[0]) {
 			return true
 		}
 	}


### PR DESCRIPTION
Introduces the fixcommitmsg plugin, which exposes a /fix-commit-messages comment command. When triggered by a member of the configured maintainer team on an open pull request, the plugin:

  - Replaces close-issue keywords (closes/fixes/resolves #NNN) in commit messages with "Related: NNN", removing the "#" that GitHub resolves into a hyperlink and an automatic issue close action.
  - Strips fixup!/amend!/squash! prefixes from commit subject lines.
  - Force-pushes the rewritten history back to the PR branch.

If the push fails (e.g., the author has not enabled "Allow edits from maintainers" on a fork-based PR), the plugin posts the error as a comment and takes no further action.

Also exports FixupCommitRegex from the invalidcommitmsg package so the new plugin can reuse the same pattern without duplicating it, and adds CherryPick and Amend to the git/v2 Interactor interface so the plugin uses the standard git client abstraction rather than shelling out directly.