### PR TITLE
register expiring tokens values in the secret agent

### DIFF
--- a/pkg/config/secret/agent.go
+++ b/pkg/config/secret/agent.go
@@ -20,6 +20,7 @@ package secret
 import (
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -34,6 +35,7 @@ var secretAgent *agent
 func init() {
 	secretAgent = &agent{
 		secretsMap:        map[string]secretReloader{},
+		expiringTokens:    make(map[string]time.Time),
 		ReloadingCensorer: secretutil.NewCensorer(),
 	}
 	logrus.SetFormatter(logrusutil.NewFormatterWithCensor(logrus.StandardLogger().Formatter, secretAgent.ReloadingCensorer))
@@ -94,11 +96,18 @@ func Censor(content []byte) []byte {
 	return secretAgent.Censor(content)
 }
 
+// AddExpiringToken registers value until expiration.
+func AddExpiringToken(value string, expiresAt time.Time) {
+	secretAgent.addExpiringToken(value, expiresAt)
+}
+
 // agent watches a path and automatically loads the secrets stored.
 type agent struct {
 	sync.RWMutex
-	secretsMap map[string]secretReloader
 	*secretutil.ReloadingCensorer
+
+	secretsMap     map[string]secretReloader
+	expiringTokens map[string]time.Time
 }
 
 type secretReloader interface {
@@ -144,12 +153,21 @@ func (a *agent) setSecret(secretPath string, secretValue secretReloader) {
 
 // refreshCensorer should be called when the secrets map changes
 func (a *agent) refreshCensorer() {
+	now := time.Now()
+	a.Lock()
+	for s, exp := range a.expiringTokens {
+		if !exp.After(now) {
+			delete(a.expiringTokens, s)
+		}
+	}
 	var secrets [][]byte
-	a.RLock()
 	for _, value := range a.secretsMap {
 		secrets = append(secrets, value.getRaw())
 	}
-	a.RUnlock()
+	for s := range a.expiringTokens {
+		secrets = append(secrets, []byte(s))
+	}
+	a.Unlock()
 	a.ReloadingCensorer.RefreshBytes(secrets...)
 }
 
@@ -180,4 +198,14 @@ func (a *agent) getSecrets() sets.Set[string] {
 		secrets.Insert(string(v.getRaw()))
 	}
 	return secrets
+}
+
+func (a *agent) addExpiringToken(value string, expiresAt time.Time) {
+	if value == "" || expiresAt.IsZero() {
+		return
+	}
+	a.Lock()
+	a.expiringTokens[value] = expiresAt
+	a.Unlock()
+	a.refreshCensorer()
 }

--- a/pkg/config/secret/agent_test.go
+++ b/pkg/config/secret/agent_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strconv"
 	"testing"
 	"time"
@@ -28,7 +29,74 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"sigs.k8s.io/prow/pkg/logrusutil"
+	"sigs.k8s.io/prow/pkg/secretutil"
 )
+
+func TestAddExpiringToken(t *testing.T) {
+	testCases := []struct {
+		name           string
+		initialSecrets map[string]time.Time
+		value          string
+		expiresAt      time.Time
+		want           map[string]time.Time
+	}{
+		{
+			name:           "records non-empty token with non-zero expiry",
+			initialSecrets: map[string]time.Time{},
+			value:          "ghs_abc",
+			expiresAt:      time.Date(2099, 1, 2, 3, 4, 5, 0, time.UTC),
+			want:           map[string]time.Time{"ghs_abc": time.Date(2099, 1, 2, 3, 4, 5, 0, time.UTC)},
+		},
+		{
+			name:           "empty value is a no-op",
+			initialSecrets: map[string]time.Time{},
+			value:          "",
+			expiresAt:      time.Date(2099, 1, 2, 3, 4, 5, 0, time.UTC),
+			want:           map[string]time.Time{},
+		},
+		{
+			name:           "zero expiresAt is a no-op",
+			initialSecrets: map[string]time.Time{},
+			value:          "skip-me",
+			expiresAt:      time.Time{},
+			want:           map[string]time.Time{},
+		},
+		{
+			name:           "past expiry is not kept on map after add",
+			initialSecrets: map[string]time.Time{},
+			value:          "dead-token",
+			expiresAt:      time.Date(1980, 6, 15, 12, 0, 0, 0, time.UTC),
+			want:           map[string]time.Time{},
+		},
+		{
+			name: "add drops expired keys already in map; keeps non-expired and new entry",
+			initialSecrets: map[string]time.Time{
+				"keep": time.Date(2099, 5, 1, 0, 0, 0, 0, time.UTC),
+				"gone": time.Date(1980, 6, 15, 12, 0, 0, 0, time.UTC),
+			},
+			value:     "newtok",
+			expiresAt: time.Date(2099, 6, 1, 0, 0, 0, 0, time.UTC),
+			want: map[string]time.Time{
+				"keep":   time.Date(2099, 5, 1, 0, 0, 0, 0, time.UTC),
+				"newtok": time.Date(2099, 6, 1, 0, 0, 0, 0, time.UTC),
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			a := &agent{
+				secretsMap:        make(map[string]secretReloader),
+				expiringTokens:    tc.initialSecrets,
+				ReloadingCensorer: secretutil.NewCensorer(),
+			}
+			a.addExpiringToken(tc.value, tc.expiresAt)
+			if !reflect.DeepEqual(a.expiringTokens, tc.want) {
+				t.Fatalf("expiringTokens = %#v, want %#v", a.expiringTokens, tc.want)
+			}
+		})
+	}
+}
 
 func TestCensoringFormatter(t *testing.T) {
 	var err error

--- a/pkg/github/app_auth_roundtripper.go
+++ b/pkg/github/app_auth_roundtripper.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/golang-jwt/jwt/v4"
 
+	"sigs.k8s.io/prow/pkg/config/secret"
 	"sigs.k8s.io/prow/pkg/ghcache"
 )
 
@@ -123,6 +124,7 @@ func (arr *appsRoundTripper) addAppAuth(r *http.Request) *appsAuthError {
 	if err != nil {
 		return &appsAuthError{fmt.Errorf("failed to generate jwt: %w", err)}
 	}
+	secret.AddExpiringToken(token, expiresAt)
 
 	r.Header.Set("Authorization", "Bearer "+token)
 	r.Header.Set(ghcache.TokenExpiryAtHeader, expiresAt.Format(time.RFC3339))
@@ -259,6 +261,7 @@ func (arr *appsRoundTripper) getTokenForInstallation(installation int64) (string
 		arr.tokens = map[int64]*AppInstallationToken{}
 	}
 	arr.tokens[installation] = token
+	secret.AddExpiringToken(token.Token, token.ExpiresAt)
 
 	return token.Token, token.ExpiresAt, nil
 }


### PR DESCRIPTION
Allow callers to register a token value with an expiry. The refreshCensorer prunes past expiries and rebuilds censor patterns.

Wire the GitHub app auth round-tripper to register minted JWTs and installation access tokens.


Description of the problem that this PR solves: 

The secret agent was implemented to censor tokens that exist as files. After GitHub Apps, the tokens are now short-lived, and there wasn't any mechanism to handle this case in the secret agent. So that token can be leaked in the logs in the form:

```json
{"client":"git","component":"pj-rehearse","file":"/go/pkg/mod/sigs.k8s.io/prow@v0.0.0-20260416015615-5aca44b7f08f/pkg/git/v2/interactor.go:523","func":"sigs.k8s.io/prow/pkg/git/v2.(*interactor).FetchRef","level":"info","msg":"Fetching \"pull/12345/head\" from https://x-access-token/:ghs_MYREALTOKEN@github.com/org/repo","org":"myorg","repo":"myrepo","severity":"info","time":"2026-04-28T10:05:26Z"}
``` 

/cc @petr-muller 