### PR TITLE
fix(clonerefs): remove cloneDepth=1 from sparseCheckout

### DIFF
--- a/pkg/pod-utils/clone/clone.go
+++ b/pkg/pod-utils/clone/clone.go
@@ -245,9 +245,6 @@ func (g *gitCtx) commandsForBaseRef(refs prowapi.Refs, gitUserName, gitUserEmail
 	}
 
 	cloneDepth := refs.CloneDepth
-	if sparseCheckoutSet && cloneDepth == 0 {
-		cloneDepth = 1
-	}
 	var depthArgs []string
 	if cloneDepth > 0 {
 		depthArgs = append(depthArgs, "--depth", strconv.Itoa(cloneDepth))

--- a/pkg/pod-utils/clone/clone_test.go
+++ b/pkg/pod-utils/clone/clone_test.go
@@ -624,7 +624,7 @@ func TestCommandsForRefs(t *testing.T) {
 				cloneCommand{dir: "/go/src/github.com/org/repo", command: "git", args: []string{"init"}},
 				cloneCommand{dir: "/go/src/github.com/org/repo", command: "git", args: []string{"sparse-checkout", "init"}},
 				retryCommand{
-					cloneCommand{dir: "/go/src/github.com/org/repo", command: "git", args: []string{"fetch", "--depth", "1", "--filter=blob:none", "--no-tags", "https://github.com/org/repo.git", "master"}},
+					cloneCommand{dir: "/go/src/github.com/org/repo", command: "git", args: []string{"fetch", "--filter=blob:none", "--no-tags", "https://github.com/org/repo.git", "master"}},
 					fetchRetries,
 				},
 				cloneCommand{dir: "/go/src/github.com/org/repo", command: "git", args: []string{"sparse-checkout", "set", "pkg/operator"}},
@@ -650,7 +650,7 @@ func TestCommandsForRefs(t *testing.T) {
 				cloneCommand{dir: "/go/src/github.com/org/repo", command: "git", args: []string{"init"}},
 				cloneCommand{dir: "/go/src/github.com/org/repo", command: "git", args: []string{"sparse-checkout", "init"}},
 				retryCommand{
-					cloneCommand{dir: "/go/src/github.com/org/repo", command: "git", args: []string{"fetch", "--depth", "1", "--filter=blob:none", "--no-tags", "https://github.com/org/repo.git", "master"}},
+					cloneCommand{dir: "/go/src/github.com/org/repo", command: "git", args: []string{"fetch", "--filter=blob:none", "--no-tags", "https://github.com/org/repo.git", "master"}},
 					fetchRetries,
 				},
 				cloneCommand{dir: "/go/src/github.com/org/repo", command: "git", args: []string{"sparse-checkout", "set", "Dockerfile", "Makefile"}},
@@ -680,7 +680,7 @@ func TestCommandsForRefs(t *testing.T) {
 				cloneCommand{dir: "/go/src/github.com/org/repo", command: "git", args: []string{"init"}},
 				cloneCommand{dir: "/go/src/github.com/org/repo", command: "git", args: []string{"sparse-checkout", "init"}},
 				retryCommand{
-					cloneCommand{dir: "/go/src/github.com/org/repo", command: "git", args: []string{"fetch", "--depth", "1", "--filter=blob:none", "--no-tags", "https://github.com/org/repo.git", "base-sha"}},
+					cloneCommand{dir: "/go/src/github.com/org/repo", command: "git", args: []string{"fetch", "--filter=blob:none", "--no-tags", "https://github.com/org/repo.git", "base-sha"}},
 					fetchRetries,
 				},
 				cloneCommand{dir: "/go/src/github.com/org/repo", command: "git", args: []string{"sparse-checkout", "set", "images/ci-operator/Dockerfile"}},


### PR DESCRIPTION
Sparse checkout with --depth 1 --filter=blob:none, creates a shallow clone with only the sparse files. When it then tries to git merge the PR head commit, git sees unrelated histories because the shallow sparse clone doesn't have enough history to find a common ancestor.

Example failure: https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_openshift-mcp-server/281/pull-ci-openshift-openshift-mcp-server-release-0.3-images/2049471679767252992
