### PR TITLE
statusreconciler: skip draft PRs in triggerNewPresubmits

### DIFF
--- a/pkg/statusreconciler/controller.go
+++ b/pkg/statusreconciler/controller.go
@@ -234,6 +234,9 @@ func (c *Controller) triggerNewPresubmits(addedPresubmits map[string][]config.Pr
 			continue
 		}
 		for _, pr := range prs {
+			if pr.Draft {
+				continue
+			}
 			if pr.Mergable != nil && !*pr.Mergable {
 				// the PR cannot be merged as it is, so the user will need to update the PR (and trigger
 				// testing via the PR push event) or re-test if the HEAD of the branch they are targeting

--- a/pkg/statusreconciler/controller_test.go
+++ b/pkg/statusreconciler/controller_test.go
@@ -856,6 +856,25 @@ func TestControllerReconcile(t *testing.T) {
 		},
 		Mergable: &notMergable,
 	}
+	draftPr := github.PullRequest{
+		User: github.User{
+			Login: author,
+		},
+		Number: secondPrNumber,
+		Base: github.PullRequestBranch{
+			Repo: github.Repo{
+				Owner: github.User{
+					Login: org,
+				},
+				Name: repo,
+			},
+			Ref: baseRef,
+		},
+		Head: github.PullRequestBranch{
+			SHA: "prsha-draft",
+		},
+		Draft: true,
+	}
 	thirdPr := github.PullRequest{
 		User: github.User{
 			Login: author,
@@ -1039,6 +1058,31 @@ func TestControllerReconcile(t *testing.T) {
 				fghc := newFakeGitHubClient(orgRepoKey)
 				fghc.prs[orgRepoKey] = []github.PullRequest{secondPr}
 				fghc.refs[orgRepoKey]["heads/"+secondPr.Base.Ref] = baseSha
+				fsm := newFakeMigrator(orgRepoKey)
+				ftc := newFakeTrustedChecker(orgRepoKey)
+				ftc.trusted[orgRepoKey][secondPrAuthorKey] = true
+				controller := Controller{
+					continueOnError:        true,
+					addedPresubmitDenylist: sets.New[string](),
+					prowJobTriggerer:       &fpjt,
+					githubClient:           &fghc,
+					statusMigrator:         &fsm,
+					trustedChecker:         &ftc,
+				}
+				checker := func(t *testing.T) {
+					checkTriggerer(t, fpjt, map[prKey]sets.Set[string]{})
+					checkMigrator(t, fsm, map[orgRepo]sets.Set[string]{orgRepoKey: sets.New[string]("required-job")}, map[orgRepo]migrationSet{orgRepoKey: {migrate: nil}})
+				}
+				return controller, checker
+			},
+		},
+		{
+			name: "no errors and draft PR means we should see no trigger, a retire and a migrate",
+			generator: func() (Controller, func(*testing.T)) {
+				fpjt := newfakeProwJobTriggerer()
+				fghc := newFakeGitHubClient(orgRepoKey)
+				fghc.prs[orgRepoKey] = []github.PullRequest{draftPr}
+				fghc.refs[orgRepoKey]["heads/"+draftPr.Base.Ref] = baseSha
 				fsm := newFakeMigrator(orgRepoKey)
 				ftc := newFakeTrustedChecker(orgRepoKey)
 				ftc.trusted[orgRepoKey][secondPrAuthorKey] = true

--- a/site/content/en/docs/components/optional/status-reconciler.md
+++ b/site/content/en/docs/components/optional/status-reconciler.md
@@ -10,7 +10,7 @@ in flight do not cause those PRs to get stuck.
 
 When the set of blocking presubmits changes for a repository, one of three cases occurs:
 
-- a new blocking presubmit exists and should be triggered for every trusted pull request in flight
+- a new blocking presubmit exists and should be triggered for every trusted, non-draft pull request in flight
 - an existing blocking presubmit is removed and should have its' status retired
 - an existing blocking presubmit is renamed and should have its' status migrated
 


### PR DESCRIPTION
GetPullRequests returns all open PRs, including drafts. In status-reconciler, triggerNewPresubmits iterated all open PRs and called RunRequested directly, so trusted draft PRs could receive newly-added blocking presubmits during config reconciliation.

The trigger plugin already skips drafts via buildAllButDrafts, but status-reconciler bypassed that path. This change adds the same draft guard in triggerNewPresubmits (before the existing mergeable check) so drafts are skipped early. Non-draft behavior is unchanged.

Retire and migrate operations are intentionally unchanged: they continue to apply to all PRs (including drafts) because status contexts still need cleanup/migration.

Test follows the existing unmergable-PR pattern and verifies draft PRs are not triggered.

Fixes: #190