### PR TITLE
Adding first-class support for Watchers APIs

### DIFF
--- a/pkg/jira/fakejira/fake.go
+++ b/pkg/jira/fakejira/fake.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"maps"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -43,6 +44,7 @@ type FakeClient struct {
 	Users            []*jira.User
 	SearchResponses  map[SearchRequest]SearchResponse
 	ProjectVersions  map[string][]*jira.Version
+	Watchers         *[]jira.User
 }
 
 func (f *FakeClient) ListProjects() (*jira.ProjectList, error) {
@@ -388,4 +390,41 @@ func (f *FakeClient) GetProjectVersions(project string) ([]*jira.Version, error)
 		return versions, nil
 	}
 	return []*jira.Version{}, nil
+}
+
+func (f *FakeClient) GetWatchers(issueID string) (*[]jira.User, error) {
+	return f.GetWatchersWithContext(context.Background(), issueID)
+}
+
+func (f *FakeClient) GetWatchersWithContext(ctx context.Context, issueID string) (*[]jira.User, error) {
+	if _, err := f.GetIssue(issueID); err != nil {
+		return nil, err
+	}
+	return f.Watchers, nil
+}
+
+func (f *FakeClient) AddWatcher(issueID, userName string) error {
+	return f.AddWatcherWithContext(context.Background(), issueID, userName)
+}
+
+func (f *FakeClient) AddWatcherWithContext(ctx context.Context, issueID, userName string) error {
+	if _, err := f.GetIssue(issueID); err != nil {
+		return err
+	}
+	*f.Watchers = append(*f.Watchers, jira.User{Name: userName})
+	return nil
+}
+
+func (f *FakeClient) RemoveWatcher(issueID, userName string) error {
+	return f.RemoveWatcherWithContext(context.Background(), issueID, userName)
+}
+
+func (f *FakeClient) RemoveWatcherWithContext(ctx context.Context, issueID, userName string) error {
+	if _, err := f.GetIssue(issueID); err != nil {
+		return err
+	}
+	*f.Watchers = slices.DeleteFunc(*f.Watchers, func(u jira.User) bool {
+		return u.Name == userName
+	})
+	return nil
 }

--- a/pkg/jira/fakejira/fake_test.go
+++ b/pkg/jira/fakejira/fake_test.go
@@ -117,6 +117,87 @@ func TestFakeClient_SearchV2JqlWithContext(t *testing.T) {
 	}
 }
 
+func newFakeClientWithIssuesAndWatchers(watchers []jira.User) *FakeClient {
+	return &FakeClient{
+		Issues: []*jira.Issue{
+			{ID: "1", Key: "PROJ-1", Fields: &jira.IssueFields{}},
+			{ID: "2", Key: "PROJ-2", Fields: &jira.IssueFields{}},
+		},
+		Watchers: &watchers,
+	}
+}
+
+func TestFakeClient_GetWatchers(t *testing.T) {
+	watchers := []jira.User{
+		{Name: "alice"},
+		{Name: "bob"},
+	}
+	fakeClient := newFakeClientWithIssuesAndWatchers(watchers)
+
+	got, err := fakeClient.GetWatchers("PROJ-1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if diff := cmp.Diff(&watchers, got); diff != "" {
+		t.Fatalf("unexpected watchers (-want +got):\n%s", diff)
+	}
+
+	_, err = fakeClient.GetWatchers("DOESNOTEXIST")
+	if err == nil {
+		t.Fatal("expected error for non-existent issue, got nil")
+	}
+}
+
+func TestFakeClient_AddWatcher(t *testing.T) {
+	fakeClient := newFakeClientWithIssuesAndWatchers(nil)
+
+	if err := fakeClient.AddWatcher("PROJ-1", "alice"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if err := fakeClient.AddWatcher("PROJ-1", "bob"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	want := []jira.User{{Name: "alice"}, {Name: "bob"}}
+	if diff := cmp.Diff(&want, fakeClient.Watchers); diff != "" {
+		t.Fatalf("unexpected watchers (-want +got):\n%s", diff)
+	}
+
+	if err := fakeClient.AddWatcher("DOESNOTEXIST", "alice"); err == nil {
+		t.Fatal("expected error for non-existent issue, got nil")
+	}
+}
+
+func TestFakeClient_RemoveWatcher(t *testing.T) {
+	watchers := []jira.User{
+		{Name: "alice"},
+		{Name: "bob"},
+		{Name: "charlie"},
+	}
+	fakeClient := newFakeClientWithIssuesAndWatchers(watchers)
+
+	if err := fakeClient.RemoveWatcher("PROJ-1", "bob"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	want := []jira.User{{Name: "alice"}, {Name: "charlie"}}
+	if diff := cmp.Diff(&want, fakeClient.Watchers); diff != "" {
+		t.Fatalf("unexpected watchers after removal (-want +got):\n%s", diff)
+	}
+
+	// removing a non-existent watcher should not error, just no-op
+	if err := fakeClient.RemoveWatcher("PROJ-1", "nobody"); err != nil {
+		t.Fatalf("unexpected error removing non-existent watcher: %v", err)
+	}
+	if diff := cmp.Diff(&want, fakeClient.Watchers); diff != "" {
+		t.Fatalf("watchers should be unchanged (-want +got):\n%s", diff)
+	}
+
+	if err := fakeClient.RemoveWatcher("DOESNOTEXIST", "alice"); err == nil {
+		t.Fatal("expected error for non-existent issue, got nil")
+	}
+}
+
 func TestFakeClient_GetProjectVersions(t *testing.T) {
 	fakeClient := &FakeClient{
 		ProjectVersions: map[string][]*jira.Version{

--- a/pkg/jira/jira.go
+++ b/pkg/jira/jira.go
@@ -95,6 +95,10 @@ type Client interface {
 	Used() bool
 	WithFields(fields logrus.Fields) Client
 	GetProjectVersions(project string) ([]*jira.Version, error)
+	AddWatcher(issueID, userName string) error
+	AddWatcherWithContext(ctx context.Context, issueID, userName string) error
+	GetWatchers(issueID string) (*[]jira.User, error)
+	GetWatchersWithContext(ctx context.Context, issueID string) (*[]jira.User, error)
 }
 
 type BasicAuthGenerator func() (username, password string)
@@ -901,4 +905,49 @@ func (jc *client) GetProjectVersions(project string) ([]*jira.Version, error) {
 		return nil, HandleJiraError(resp, err)
 	}
 	return versions, nil
+}
+
+func (jc *client) GetWatchers(issueID string) (*[]jira.User, error) {
+	return jc.GetWatchersWithContext(context.Background(), issueID)
+}
+
+func (jc *client) GetWatchersWithContext(ctx context.Context, issueID string) (*[]jira.User, error) {
+	watchers, response, err := jc.upstream.Issue.GetWatchersWithContext(ctx, issueID)
+	if err != nil {
+		if response != nil && response.StatusCode == http.StatusNotFound {
+			return nil, NotFoundError{err}
+		}
+		return nil, HandleJiraError(response, err)
+	}
+	return watchers, nil
+}
+
+func (jc *client) AddWatcher(issueID, userName string) error {
+	return jc.AddWatcherWithContext(context.Background(), issueID, userName)
+}
+
+func (jc *client) AddWatcherWithContext(ctx context.Context, issueID, userName string) error {
+	response, err := jc.upstream.Issue.AddWatcherWithContext(ctx, issueID, userName)
+	if err != nil {
+		if response != nil && response.StatusCode == http.StatusNotFound {
+			return NotFoundError{err}
+		}
+		return HandleJiraError(response, err)
+	}
+	return nil
+}
+
+func (jc *client) RemoveWatcher(issueID, userName string) error {
+	return jc.RemoveWatcherWithContext(context.Background(), issueID, userName)
+}
+
+func (jc *client) RemoveWatcherWithContext(ctx context.Context, issueID, userName string) error {
+	response, err := jc.upstream.Issue.RemoveWatcherWithContext(ctx, issueID, userName)
+	if err != nil {
+		if response != nil && response.StatusCode == http.StatusNotFound {
+			return NotFoundError{err}
+		}
+		return HandleJiraError(response, err)
+	}
+	return nil
 }


### PR DESCRIPTION
Adding the necessary logic to bring support for Jira's `Watchers` directly into Prow's jira library.

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED