### PR TITLE
Add custom KIND_CONFIG support to make dev

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,11 +39,11 @@ test: unit
 # local development environment (kind cluster with fake external services)
 .PHONY: dev
 dev:
-	hack/dev-env.sh
+	hack/dev-env.sh $(if $(strip $(KIND_CONFIG)),-kind-config="$(KIND_CONFIG)")
 # full dev environment with all Prow components (heavier, matches integration tests)
 .PHONY: dev-full
 dev-full:
-	hack/dev-env.sh -profile=full
+	hack/dev-env.sh -profile=full $(if $(strip $(KIND_CONFIG)),-kind-config="$(KIND_CONFIG)")
 # Tilt inner loop - run 'make dev' once first, then use this for auto-rebuild
 .PHONY: dev-tilt
 dev-tilt:

--- a/hack/dev-env.sh
+++ b/hack/dev-env.sh
@@ -115,10 +115,15 @@ function check_prerequisites() {
   fi
 }
 
+#TODO: update for case where custom KIND_CONFIG is used
 function print_connection_info() {
   cat <<EOF
 
 ==> Local Prow environment is ready!
+
+Custom KIND_CONFIG Note:
+If a separate APISeverAddress was used then replace localhost below with that.
+The DEV_HTTP_PORT is the host_port used with the container 80 extra port mapping.
 
 Cluster: ${_KIND_CLUSTER_NAME}
 Kubeconfig context: ${_KIND_CONTEXT}
@@ -160,6 +165,7 @@ function main() {
   local rebuild_images=""
   local teardown=false
   local profile="core"
+  local kind_config=""
 
   for arg in "$@"; do
     case "${arg}" in
@@ -175,6 +181,9 @@ function main() {
           echo >&2 "invalid -profile value '${profile}': must be 'core' or 'full'"
           return 1
         fi
+        ;;
+      -kind-config=*)
+        kind_config="${arg#-kind-config=}"
         ;;
       -teardown)
         teardown=true
@@ -213,10 +222,15 @@ function main() {
     return 0
   fi
 
-  log "Setting up kind cluster (HTTP on :${DEV_HTTP_PORT}, HTTPS on :${DEV_HTTPS_PORT})"
-  "${INTEGRATION_DIR}/setup-kind-cluster.sh" \
-    "-http-host-port=${DEV_HTTP_PORT}" \
-    "-https-host-port=${DEV_HTTPS_PORT}"
+  if [[ -n "${kind_config}" ]]; then
+    log "Setting up kind cluster (Custom KIND_CONFIG: ${kind_config})"
+    "${INTEGRATION_DIR}/setup-kind-cluster.sh" "-kind-config=${kind_config}"
+  else
+    log "Setting up kind cluster (HTTP on :${DEV_HTTP_PORT}, HTTPS on :${DEV_HTTPS_PORT})"
+    "${INTEGRATION_DIR}/setup-kind-cluster.sh" \
+      "-http-host-port=${DEV_HTTP_PORT}" \
+      "-https-host-port=${DEV_HTTPS_PORT}"
+  fi
 
   if "${no_build}"; then
     log "Deploying Prow components (skipping image builds, profile=${profile})"

--- a/hack/dev-env.sh
+++ b/hack/dev-env.sh
@@ -115,7 +115,6 @@ function check_prerequisites() {
   fi
 }
 
-#TODO: update for case where custom KIND_CONFIG is used
 function print_connection_info() {
   cat <<EOF
 
@@ -224,6 +223,8 @@ function main() {
 
   if [[ -n "${kind_config}" ]]; then
     log "Setting up kind cluster (Custom KIND_CONFIG: ${kind_config})"
+    log "WARNING: env vars DEV_HTTP_PORT and DEV_HTTPS_PORT are not used when KIND_CONFIG is set."
+    log "All values are set in the yaml file specified at the KIND_CONFIG path."
     "${INTEGRATION_DIR}/setup-kind-cluster.sh" "-kind-config=${kind_config}"
   else
     log "Setting up kind cluster (HTTP on :${DEV_HTTP_PORT}, HTTPS on :${DEV_HTTPS_PORT})"

--- a/site/content/en/docs/local-dev-two-machines.md
+++ b/site/content/en/docs/local-dev-two-machines.md
@@ -147,7 +147,7 @@ nodes:
     apiServer:
       certSANs:
         - "100.x.y.z"
-        - "debian12-dev.pleco-koi.ts.net"
+        - "<machine-name-in-tailnet>.<your-tailnet-name>.ts.net"
         - "localhost"
         - "127.0.0.1"
   extraPortMappings:

--- a/site/content/en/docs/local-dev-two-machines.md
+++ b/site/content/en/docs/local-dev-two-machines.md
@@ -1,0 +1,198 @@
+---
+title: "Local Development with a Remote KinD Cluster"
+weight: 76
+description: >
+  How to deploy the integration Prow KinD cluster to a remote server machine connected to a dev machine for auto-updating with tilt.
+---
+
+> **NOTE**
+>
+> Keep in mind that while this doc comes with commands it is more so meant as a guide than a script. The headings and descriptions show what needs to done and the commands provided are some ways of doing them but ways are available and possibly required based on your systems.
+
+This guide assumes the server machine is a Linux machine that is Debian based but other operating systems should be fine as long as you swap a few commands. The client instruction are very minimal due to the nature of the work required there.
+
+This guides use Tailscale for a trusted machine to machine tunnel. A different VPN should be fine as well.
+
+> **WARNING**
+>
+> This guide sets the KinD APIServerAddress to one that can be reached remotely and likewise sets the Docker Daemon to listen on an address that can be reached remotely. Ensure the address you bind this behavior to is only available from your dev machine.
+
+## 1 - Install Dependencies
+### Client
+- `kubectl`
+- `docker`
+- `tilt`
+### Server
+Install go with a high enough version. You can install any Go ≥ 1.21 as a bootstrap, then let the module system handle the rest:
+```bash
+curl -OL https://go.dev/dl/go1.22.12.linux-amd64.tar.gz
+sudo rm -rf /usr/local/go
+sudo tar -C /usr/local -xzf go1.22.12.linux-amd64.tar.gz
+echo 'export PATH=$PATH:/usr/local/go/bin' >> ~/.bashrc
+source ~/.bashrc
+go version
+```
+
+Install Docker.
+https://docs.docker.com/engine/install/
+```bash
+# On the server (Ubuntu/Debian)
+sudo apt-get update
+sudo apt-get install -y docker.io
+sudo usermod -aG docker $USER
+```
+
+Install KinD.
+```bash
+curl -Lo ./kind https://kind.sigs.k8s.io/dl/latest/kind-linux-amd64
+chmod +x ./kind && sudo mv ./kind /usr/local/bin/kind
+```
+
+Install tilt.
+```bash
+curl -fsSL https://raw.githubusercontent.com/tilt-dev/tilt/master/scripts/install.sh | bash
+```
+
+## 2 - Set Environment Variables
+### Client
+Ensure the following environment variable are set in your shell.
+```bash
+export DOCKER_HOST="tcp://100.x.y.z:2375"
+export KUBECONFIG=$PWD/kind-prow-integration-kubeconfig.yaml
+```
+
+### Server
+```bash
+export KIND_CONFIG=~/kind_config.yaml
+```
+
+## 3 - Networking Foundation
+### Tailscale
+Make sure your Tailscale ACLs allow the following traffic from your dev machine to your server machine.
+- `tcp:22` - for copying files over SSH
+- `tcp:2375` - for the Docker Daemon
+- `tcp:6443` - for kubectl
+- `tcp:80` - for the Deck interface for Prow
+
+### Server
+Setup `ufw` rules to ensure incoming traffic must come from the Tailscale interface.
+https://tailscale.com/docs/how-to/secure-ubuntu-server-with-ufw
+```bash
+sudo ufw enable
+sudo ufw default deny incoming
+sudo ufw default allow outgoing
+sudo ufw allow in on tailscale0
+```
+
+## 4 - Expose the Docker Daemon
+### Server
+Edit the Docker daemon config and systemd service to listen on a remote IP address.
+https://docs.docker.com/engine/daemon/remote-access/
+
+```bash
+sudo nano /etc/docker/daemon.json
+```
+```json
+{
+  "hosts": ["unix:///var/run/docker.sock", "tcp://100.x.y.z:2375"]
+}
+```
+
+```bash
+sudo systemctl edit docker.service
+```
+```ini
+[Service]
+ExecStart=
+ExecStart=/usr/bin/dockerd
+```
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl restart docker
+```
+
+## 5 - Create the Cluster
+### Server
+First create the KIND_CONFIG for the cluster.
+```bash
+nano ~/kind_config.yaml
+```
+
+You may want to change the host var values.
+```yaml
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+networking:
+  # WARNING: BE CAREFUL EXPOSE THE API SERVER ADDRESS
+  # This case specifically goes through Tailscale which
+  # I control and the server firewall (ufw) is set to only
+  # allow incoming traffic over the Tailscale interface.
+  apiServerAddress: "100.x.y.z" # server's Tailscale IP
+  apiServerPort: 6443
+containerdConfigPatches:
+- |-
+  [plugins."io.containerd.grpc.v1.cri".registry]
+    config_path = "/etc/containerd/certs.d"
+nodes:
+- role: control-plane
+  kubeadmConfigPatches:
+  - |
+    kind: InitConfiguration
+    nodeRegistration:
+      kubeletExtraArgs:
+        node-labels: "ingress-ready=true"
+  - |
+    kind: ClusterConfiguration
+    apiServer:
+      certSANs:
+        - "100.x.y.z"
+        - "debian12-dev.pleco-koi.ts.net"
+        - "localhost"
+        - "127.0.0.1"
+  extraPortMappings:
+  - containerPort: 80
+    hostPort: 80 # flexible based on your machine
+    protocol: TCP
+  - containerPort: 443
+    hostPort: 443 # flexible based on your machine
+    protocol: TCP
+  - containerPort: 32000
+    hostPort: 32000 # flexible based on your machine
+    protocol: TCP
+  - containerPort: 30303 # flexible based on your machine
+    hostPort: 30303 # flexible based on your machine
+    protocol: TCP
+```
+
+Then clone the Prow repository and use the make command you want, either `make dev` for just the core component or `make dev-full` for core + optional components for a more production like setup.
+
+```
+git clone https://github.com/kubernetes-sigs/prow.git
+make dev
+```
+
+## 6 - Get the KUBECONFIG
+### Server
+Get the KUBECONFIG from your created KinD cluster.
+```bash
+kind get kubeconfig --name kind-prow-integration > ~/kind-prow-integration-kubeconfig.yaml
+```
+
+### Client
+Copy the retrieved config to your dev machine.
+```bash
+scp root@100.x.y.z:~/kind-prow-integration-kubeconfig.yaml kind-prow-integration-kubeconfig.yaml
+```
+
+## 7 - Test it all works.
+### Client
+```bash
+docker ps
+kubectl get nodes
+```
+
+Open the Prow UI in the browser.
+```
+http://100.x.y.z:80
+```

--- a/test/integration/setup-kind-cluster.sh
+++ b/test/integration/setup-kind-cluster.sh
@@ -157,9 +157,7 @@ function create_cluster() {
   https_host_port="${3:-443}"
   kind_config="${4:-default}"
 
-  if [ "${kind_config}" != "default" ]; then
-    kind create cluster --name "${_KIND_CLUSTER_NAME}" "--config=${kind_config}" --wait=5m
-  else
+  if [ "${kind_config}" == "default" ]; then
     cat <<EOF | kind create cluster --name "${_KIND_CLUSTER_NAME}" --config=-
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
@@ -189,6 +187,8 @@ nodes:
     hostPort: ${fakepubsub_node_port}
     protocol: TCP
 EOF
+  else
+    kind create cluster --name "${_KIND_CLUSTER_NAME}" "--config=${kind_config}" --wait=5m
   fi
 
 }

--- a/test/integration/setup-kind-cluster.sh
+++ b/test/integration/setup-kind-cluster.sh
@@ -54,6 +54,10 @@ Options:
         Host port to map to the cluster's HTTPS (port 443) ingress (default 443).
         Use a value >= 1024 to avoid requiring root privileges locally.
 
+    -kind-config='';
+        Cluster config to provide kind create cluster. (default default) for use in
+        integration testing setup. Specify a path to a custom config for development only.
+
     -help:
         Display this help message.
 EOF
@@ -63,9 +67,11 @@ function main() {
   local fakepubsub_node_port
   local http_host_port
   local https_host_port
+  local kind_config
   fakepubsub_node_port=30303
   http_host_port=80
   https_host_port=443
+  kind_config=default
   # If we abort the setup script with Ctrl+C, delete the cluster because the
   # setup process was interrupted.
   # shellcheck disable=SC2064
@@ -86,6 +92,9 @@ function main() {
         ;;
       -https-host-port=*)
         https_host_port="${arg#-https-host-port=}"
+        ;;
+      -kind-config=*)
+        kind_config="${arg#-kind-config=}"
         ;;
       -help)
         usage
@@ -112,7 +121,7 @@ function main() {
     log "Using existing KIND cluster"
   else
     "${SCRIPT_ROOT}/teardown.sh" -kind-cluster
-    create_cluster "${fakepubsub_node_port:-30303}" "${http_host_port:-80}" "${https_host_port:-443}"
+    create_cluster "${fakepubsub_node_port:-30303}" "${http_host_port:-80}" "${https_host_port:-443}" "${kind_config:-default}"
   fi
   setup_cluster
 
@@ -142,11 +151,16 @@ function create_cluster() {
   local fakepubsub_node_port
   local http_host_port
   local https_host_port
+  local kind_config
   fakepubsub_node_port="${1:-30303}"
   http_host_port="${2:-80}"
   https_host_port="${3:-443}"
+  kind_config="${4:-default}"
 
-  cat <<EOF | kind create cluster --name "${_KIND_CLUSTER_NAME}" --config=-
+  if [ "${kind_config}" != "default" ]; then
+    kind create cluster --name "${_KIND_CLUSTER_NAME}" "--config=${kind_config}" --wait=5m
+  else
+    cat <<EOF | kind create cluster --name "${_KIND_CLUSTER_NAME}" --config=-
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 containerdConfigPatches:
@@ -175,6 +189,7 @@ nodes:
     hostPort: ${fakepubsub_node_port}
     protocol: TCP
 EOF
+  fi
 
 }
 

--- a/test/integration/setup-kind-cluster.sh
+++ b/test/integration/setup-kind-cluster.sh
@@ -55,7 +55,7 @@ Options:
         Use a value >= 1024 to avoid requiring root privileges locally.
 
     -kind-config='';
-        Cluster config to provide kind create cluster. (default default) for use in
+        Cluster config to provide kind create cluster. (default empty string) for use in
         integration testing setup. Specify a path to a custom config for development only.
 
     -help:
@@ -71,7 +71,7 @@ function main() {
   fakepubsub_node_port=30303
   http_host_port=80
   https_host_port=443
-  kind_config=default
+  kind_config=""
   # If we abort the setup script with Ctrl+C, delete the cluster because the
   # setup process was interrupted.
   # shellcheck disable=SC2064
@@ -121,7 +121,7 @@ function main() {
     log "Using existing KIND cluster"
   else
     "${SCRIPT_ROOT}/teardown.sh" -kind-cluster
-    create_cluster "${fakepubsub_node_port:-30303}" "${http_host_port:-80}" "${https_host_port:-443}" "${kind_config:-default}"
+    create_cluster "${fakepubsub_node_port:-30303}" "${http_host_port:-80}" "${https_host_port:-443}" "${kind_config:-}"
   fi
   setup_cluster
 
@@ -155,9 +155,9 @@ function create_cluster() {
   fakepubsub_node_port="${1:-30303}"
   http_host_port="${2:-80}"
   https_host_port="${3:-443}"
-  kind_config="${4:-default}"
+  kind_config="${4:-}"
 
-  if [ "${kind_config}" == "default" ]; then
+  if [[ -z "${kind_config}" ]]; then
     cat <<EOF | kind create cluster --name "${_KIND_CLUSTER_NAME}" --config=-
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4


### PR DESCRIPTION
Issue: Unable to develop locally with KinD cluster created by `make dev` deployed and updated via tilt remotely.
Discussed here: https://kubernetes.slack.com/archives/CDECRSC5U/p1777856158346109

Solution:
Edit `setup-kind-cluster.sh` script to accept an argument for a custom KIND_CONFIG used for `kind cluster create config=`
This argument by default is set to default which will continue the existing behavior. Edit the Prow `Makefile` at the `make dev` and `make dev-full` entrypoints will check if the KINK_CONFIG env var is not empty and if so pass it as an parameter for the `dev-env.sh` script. Edit the `dev-env.sh` script to pass the param to the setup script and update the logs.

I also made added a doc in the docs to show the process for setting up a two machine development environment how this PR enables.