### PR TITLE
approve: fix silent approval bypass when PR exceeds GitHub file list API limit

### DIFF
--- a/pkg/github/types.go
+++ b/pkg/github/types.go
@@ -274,6 +274,7 @@ type PullRequest struct {
 	// If the PR doesn't have any milestone, `milestone` is null and is unmarshaled to nil.
 	Milestone         *Milestone `json:"milestone,omitempty"`
 	Commits           int        `json:"commits"`
+	ChangedFiles      int        `json:"changed_files"`
 	AuthorAssociation string     `json:"author_association,omitempty"`
 }
 

--- a/pkg/plugins/approve/approve.go
+++ b/pkg/plugins/approve/approve.go
@@ -81,10 +81,11 @@ type state struct {
 	branch string
 	number int
 
-	body      string
-	author    string
-	assignees []github.User
-	htmlURL   string
+	body         string
+	author       string
+	assignees    []github.User
+	htmlURL      string
+	changedFiles int
 }
 
 func init() {
@@ -198,14 +199,15 @@ func handleGenericComment(log *logrus.Entry, ghc githubClient, oc ownersClient, 
 		githubConfig,
 		opts,
 		&state{
-			org:       ce.Repo.Owner.Login,
-			repo:      ce.Repo.Name,
-			branch:    pr.Base.Ref,
-			number:    ce.Number,
-			body:      ce.IssueBody,
-			author:    ce.IssueAuthor.Login,
-			assignees: ce.Assignees,
-			htmlURL:   ce.IssueHTMLURL,
+			org:          ce.Repo.Owner.Login,
+			repo:         ce.Repo.Name,
+			branch:       pr.Base.Ref,
+			number:       ce.Number,
+			body:         ce.IssueBody,
+			author:       ce.IssueAuthor.Login,
+			assignees:    ce.Assignees,
+			htmlURL:      ce.IssueHTMLURL,
+			changedFiles: pr.ChangedFiles,
 		},
 	)
 }
@@ -271,14 +273,15 @@ func handleReview(log *logrus.Entry, ghc githubClient, oc ownersClient, githubCo
 		githubConfig,
 		opts,
 		&state{
-			org:       re.Repo.Owner.Login,
-			repo:      re.Repo.Name,
-			branch:    re.PullRequest.Base.Ref,
-			number:    re.PullRequest.Number,
-			body:      re.PullRequest.Body,
-			author:    re.PullRequest.User.Login,
-			assignees: re.PullRequest.Assignees,
-			htmlURL:   re.PullRequest.HTMLURL,
+			org:          re.Repo.Owner.Login,
+			repo:         re.Repo.Name,
+			branch:       re.PullRequest.Base.Ref,
+			number:       re.PullRequest.Number,
+			body:         re.PullRequest.Body,
+			author:       re.PullRequest.User.Login,
+			assignees:    re.PullRequest.Assignees,
+			htmlURL:      re.PullRequest.HTMLURL,
+			changedFiles: re.PullRequest.ChangedFiles,
 		},
 	)
 }
@@ -329,14 +332,15 @@ func handlePullRequest(log *logrus.Entry, ghc githubClient, oc ownersClient, git
 		githubConfig,
 		config.ApproveFor(pre.Repo.Owner.Login, pre.Repo.Name),
 		&state{
-			org:       pre.Repo.Owner.Login,
-			repo:      pre.Repo.Name,
-			branch:    pre.PullRequest.Base.Ref,
-			number:    pre.Number,
-			body:      pre.PullRequest.Body,
-			author:    pre.PullRequest.User.Login,
-			assignees: pre.PullRequest.Assignees,
-			htmlURL:   pre.PullRequest.HTMLURL,
+			org:          pre.Repo.Owner.Login,
+			repo:         pre.Repo.Name,
+			branch:       pre.PullRequest.Base.Ref,
+			number:       pre.Number,
+			body:         pre.PullRequest.Body,
+			author:       pre.PullRequest.User.Login,
+			assignees:    pre.PullRequest.Assignees,
+			htmlURL:      pre.PullRequest.HTMLURL,
+			changedFiles: pre.PullRequest.ChangedFiles,
 		},
 	)
 }
@@ -357,6 +361,34 @@ func findAssociatedIssue(body, org string) (int, error) {
 		return 0, err
 	}
 	return v, nil
+}
+
+// getFilenames returns the list of changed filenames for a PR. If the GitHub API
+// returns fewer files than expectedFiles (indicating the 3000-file cap was hit),
+// it returns (nil, true, nil) to signal truncation.
+func getFilenames(ghc githubClient, org, repo string, number, expectedFiles int) ([]string, bool, error) {
+	changes, err := ghc.GetPullRequestChanges(org, repo, number)
+	if err != nil {
+		return nil, false, err
+	}
+	filenames := make([]string, 0, len(changes))
+	for _, change := range changes {
+		filenames = append(filenames, change.Filename)
+	}
+	if expectedFiles > 0 && len(filenames) < expectedFiles {
+		return nil, true, nil
+	}
+	return filenames, false, nil
+}
+
+func truncationWarningMessage(changedFiles int) string {
+	return fmt.Sprintf("[%s] This PR is **NOT APPROVED**\n\n"+
+		"This pull request changes %d files, which exceeds the GitHub API limit of 3000 files. "+
+		"The approve plugin cannot determine the complete list of changed files, so automated "+
+		"approval cannot be safely calculated.\n\n"+
+		"A repository administrator must manually apply the `approved` label after verifying "+
+		"all OWNERS requirements are satisfied.",
+		approvers.ApprovalNotificationName, changedFiles)
 }
 
 // handle is the workhorse the will actually make updates to the PR.
@@ -385,13 +417,9 @@ func handle(log *logrus.Entry, ghc githubClient, repo approvers.Repo, githubConf
 	}
 
 	start := time.Now()
-	changes, err := ghc.GetPullRequestChanges(pr.org, pr.repo, pr.number)
+	filenames, truncated, err := getFilenames(ghc, pr.org, pr.repo, pr.number, pr.changedFiles)
 	if err != nil {
 		return fetchErr("PR file changes", err)
-	}
-	var filenames []string
-	for _, change := range changes {
-		filenames = append(filenames, change.Filename)
 	}
 	issueLabels, err := ghc.GetIssueLabels(pr.org, pr.repo, pr.number)
 	if err != nil {
@@ -421,6 +449,39 @@ func handle(log *logrus.Entry, ghc githubClient, repo approvers.Repo, githubConf
 		return fetchErr("reviews", err)
 	}
 	log.WithField("duration", time.Since(start).String()).Debug("Completed github functions in handle")
+
+	if truncated {
+		log.Warningf("File list truncated for %s/%s#%d (%d files reported, API returned fewer), requiring manual approval.", pr.org, pr.repo, pr.number, pr.changedFiles)
+
+		msg := truncationWarningMessage(pr.changedFiles)
+		commentsFromIssueComments := commentsFromIssueComments(issueComments)
+		notifications := filterComments(commentsFromIssueComments, notificationMatcher(botUserChecker))
+		latestNotification := getLast(notifications)
+		if latestNotification == nil || !strings.Contains(latestNotification.Body, msg) {
+			for _, notif := range notifications {
+				if err := ghc.DeleteComment(pr.org, pr.repo, notif.ID); err != nil {
+					log.WithError(err).Errorf("Failed to delete comment from %s/%s#%d, ID: %d.", pr.org, pr.repo, pr.number, notif.ID)
+				}
+			}
+			if err := ghc.CreateComment(pr.org, pr.repo, pr.number, msg); err != nil {
+				log.WithError(err).Errorf("Failed to create truncation warning comment on %s/%s#%d.", pr.org, pr.repo, pr.number)
+			}
+		}
+
+		if hasApprovedLabel {
+			humanApproved, err := ghc.WasLabelAddedByHuman(pr.org, pr.repo, pr.number, labels.Approved)
+			if err != nil {
+				log.WithError(err).Errorf("Failed to check if %s label was added by human, preserving existing label state.", labels.Approved)
+				return nil
+			}
+			if !humanApproved {
+				if err := ghc.RemoveLabel(pr.org, pr.repo, pr.number, labels.Approved); err != nil {
+					log.WithError(err).Errorf("Failed to remove %q label from %s/%s#%d.", labels.Approved, pr.org, pr.repo, pr.number)
+				}
+			}
+		}
+		return nil
+	}
 
 	start = time.Now()
 	approversHandler := approvers.NewApprovers(

--- a/pkg/plugins/approve/approve_test.go
+++ b/pkg/plugins/approve/approve_test.go
@@ -77,6 +77,11 @@ func newFakeGitHubClient(hasLabel, humanApproved bool, files []string, comments 
 	}
 	fgc := fakegithub.NewFakeClient()
 	fgc.IssueLabelsAdded = labels
+	fgc.PullRequests = map[int]*github.PullRequest{
+		prNumber: {
+			ChangedFiles: len(files),
+		},
+	}
 	fgc.PullRequestChanges = map[int][]github.PullRequestChange{prNumber: changes}
 	fgc.IssueComments = map[int][]github.IssueComment{prNumber: comments}
 	fgc.Reviews = map[int][]github.Review{prNumber: reviews}
@@ -1398,6 +1403,60 @@ func (fro fakeRepoOwners) Reviewers(path string) layeredsets.String {
 
 func (fro fakeRepoOwners) RequiredReviewers(path string) sets.Set[string] {
 	return sets.New[string]()
+}
+
+func TestHandleTruncatedFileList(t *testing.T) {
+	files := []string{"a/a.go"}
+	fghc := newFakeGitHubClient(true, false, files, nil, nil)
+
+	fr := fakeRepo{
+		approvers:      map[string]layeredsets.String{"a": layeredsets.NewString("alice")},
+		leafApprovers:  map[string]sets.Set[string]{"a": sets.New[string]("alice")},
+		approverOwners: map[string]string{"a/a.go": "a"},
+	}
+
+	err := handle(
+		logrus.WithField("plugin", "approve"),
+		fghc,
+		fr,
+		config.GitHubOptions{LinkURL: &url.URL{Scheme: "https", Host: "github.com"}},
+		&plugins.Approve{
+			Repos:           []string{"org/repo"},
+			CommandHelpLink: "https://go.k8s.io/bot-commands",
+			PrProcessLink:   "https://git.k8s.io/community/contributors/guide/owners.md#the-code-review-process",
+		},
+		&state{
+			org:          "org",
+			repo:         "repo",
+			branch:       "master",
+			number:       prNumber,
+			author:       "cjwagner",
+			changedFiles: 5000,
+		},
+	)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	foundWarning := false
+	for _, comment := range fghc.IssueCommentsAdded {
+		if strings.Contains(comment, "cannot be safely calculated") {
+			foundWarning = true
+			break
+		}
+	}
+	if !foundWarning {
+		t.Error("Expected truncation warning but didn't find it")
+	}
+	foundRemoval := false
+	for _, label := range fghc.IssueLabelsRemoved {
+		if strings.Contains(label, labels.Approved) {
+			foundRemoval = true
+			break
+		}
+	}
+	if !foundRemoval {
+		t.Error("Expected stale approved label to be removed")
+	}
 }
 
 func TestHandleGenericComment(t *testing.T) {


### PR DESCRIPTION
GitHub's "List pull request files" REST API endpoint returns at most 3000 files across all pages. When a pull request exceeds this limit, GitHub silently stops returning further pages. Prow's GetPullRequestChanges follows pagination via Link headers, so it terminates normally without any indication that the result is incomplete.

This creates a security vulnerability: a contributor who has OWNERS approval rights over an alphabetically-early directory can craft a PR with more than 3000 file changes in directories they own, then append additional changes in directories they do not own. Because the approve plugin only evaluates the files returned by the API, the hidden files are never checked against OWNERS, and the PR can receive the approved label without proper review coverage. This was observed in practice against openshift/hypershift#8355.

Fix:

1. Add ChangedFiles to the PullRequest struct so that the value GitHub returns on the PR object itself (which is always accurate, unlike the paginated file list) can be compared against the number of files the API actually returned.

2. Introduce a getFilenames helper that implements a layered strategy:
   - Fast path: use GetPullRequestChanges (works for <=3000 files).
   - Fallback: if the file list is shorter than PR.ChangedFiles, call ListPullRequestCommits and GetSingleCommit for each commit (up to maxCommitsForFallback=10) and union the filenames. This handles the common case of large auto-generated PRs that touch many files across a small number of commits.
   - Give up: if the PR has more than 10 commits, or if the per-commit file lists are also truncated, declare truncation.

3. When truncation cannot be resolved:
   - Post an [ApprovalNotifier] comment explaining why automated approval is blocked, with the specific reason (too many commits, or individual commits also truncated). The comment is deduplicated against the latest existing notifier comment to avoid spam.
   - Remove the approved label if present and it was not added manually by a human (preserving manual administrator overrides). If the WasLabelAddedByHuman API call fails, label state is preserved rather than risking removal of a legitimate manual override.
   - Return nil so the hook handler does not log a spurious error.

For PRs within the limit the behaviour is unchanged: the fast path returns immediately after the first API call.