### PR TITLE
external-plugins: add netlify-preview plugin to retry deploy previews

### DIFF
--- a/.prow-images.yaml
+++ b/.prow-images.yaml
@@ -38,5 +38,6 @@ images:
     arch: all
   - dir: cmd/external-plugins/needs-rebase
   - dir: cmd/external-plugins/cherrypicker
+  - dir: cmd/external-plugins/netlify-preview
   - dir: cmd/external-plugins/refresh
   - dir: cmd/ghproxy

--- a/cmd/external-plugins/netlify-preview/config/config.go
+++ b/cmd/external-plugins/netlify-preview/config/config.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/external-plugins/netlify-preview/config/config.go
+++ b/cmd/external-plugins/netlify-preview/config/config.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"fmt"
+	"os"
+
+	"sigs.k8s.io/yaml"
+)
+
+type Config struct {
+	Repos map[string]Repo `json:"repos,omitempty"`
+}
+
+type Repo struct {
+	SiteID string `json:"site_id,omitempty"`
+}
+
+func Load(path string) (*Config, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var cfg Config
+	if err := yaml.UnmarshalStrict(data, &cfg); err != nil {
+		return nil, err
+	}
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+	return &cfg, nil
+}
+
+func (c *Config) Validate() error {
+	for repo, cfg := range c.Repos {
+		if cfg.SiteID == "" {
+			return fmt.Errorf("missing site_id for repo %q", repo)
+		}
+	}
+	return nil
+}
+
+func (c *Config) Repo(org, repo string) (Repo, bool) {
+	if c == nil {
+		return Repo{}, false
+	}
+	cfg, ok := c.Repos[org+"/"+repo]
+	return cfg, ok
+}

--- a/cmd/external-plugins/netlify-preview/config/config.go
+++ b/cmd/external-plugins/netlify-preview/config/config.go
@@ -24,10 +24,10 @@ import (
 )
 
 type Config struct {
-	Repos map[string]Repo `json:"repos,omitempty"`
+	Repos map[string]SiteConfig `json:"repos,omitempty"`
 }
 
-type Repo struct {
+type SiteConfig struct {
 	SiteID string `json:"site_id,omitempty"`
 }
 
@@ -55,9 +55,9 @@ func (c *Config) Validate() error {
 	return nil
 }
 
-func (c *Config) Repo(org, repo string) (Repo, bool) {
+func (c *Config) Repo(org, repo string) (SiteConfig, bool) {
 	if c == nil {
-		return Repo{}, false
+		return SiteConfig{}, false
 	}
 	cfg, ok := c.Repos[org+"/"+repo]
 	return cfg, ok

--- a/cmd/external-plugins/netlify-preview/config/config_test.go
+++ b/cmd/external-plugins/netlify-preview/config/config_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/external-plugins/netlify-preview/config/config_test.go
+++ b/cmd/external-plugins/netlify-preview/config/config_test.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoad(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(path, []byte(`repos:
+  kubernetes/website:
+    site_id: site-123
+`), 0600); err != nil {
+		t.Fatalf("failed to write config: %v", err)
+	}
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("failed to load config: %v", err)
+	}
+
+	repo, ok := cfg.Repo("kubernetes", "website")
+	if !ok {
+		t.Fatal("expected kubernetes/website mapping")
+	}
+	if repo.SiteID != "site-123" {
+		t.Fatalf("expected site id %q, got %q", "site-123", repo.SiteID)
+	}
+}
+
+func TestLoadRejectsMissingSiteID(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(path, []byte(`repos:
+  kubernetes/website: {}
+`), 0600); err != nil {
+		t.Fatalf("failed to write config: %v", err)
+	}
+
+	if _, err := Load(path); err == nil {
+		t.Fatal("expected error for missing site id")
+	}
+}

--- a/cmd/external-plugins/netlify-preview/main.go
+++ b/cmd/external-plugins/netlify-preview/main.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/external-plugins/netlify-preview/main.go
+++ b/cmd/external-plugins/netlify-preview/main.go
@@ -1,0 +1,147 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// netlify-preview retries Netlify deploy previews for pull requests.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"net/http"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/sirupsen/logrus"
+
+	previewconfig "sigs.k8s.io/prow/cmd/external-plugins/netlify-preview/config"
+	"sigs.k8s.io/prow/cmd/external-plugins/netlify-preview/netlify"
+	netlifypreview "sigs.k8s.io/prow/cmd/external-plugins/netlify-preview/plugin"
+	"sigs.k8s.io/prow/pkg/config/secret"
+	"sigs.k8s.io/prow/pkg/flagutil"
+	prowflagutil "sigs.k8s.io/prow/pkg/flagutil"
+	pluginsflagutil "sigs.k8s.io/prow/pkg/flagutil/plugins"
+	"sigs.k8s.io/prow/pkg/interrupts"
+	"sigs.k8s.io/prow/pkg/logrusutil"
+	"sigs.k8s.io/prow/pkg/pjutil"
+	"sigs.k8s.io/prow/pkg/pluginhelp/externalplugins"
+)
+
+type options struct {
+	port int
+
+	pluginsConfig          pluginsflagutil.PluginOptions
+	dryRun                 bool
+	github                 prowflagutil.GitHubOptions
+	instrumentationOptions prowflagutil.InstrumentationOptions
+	logLevel               string
+
+	webhookSecretFile string
+	netlifyTokenFile  string
+	configPath        string
+	netlifyAPIURL     string
+}
+
+func (o *options) Validate() error {
+	for idx, group := range []flagutil.OptionGroup{&o.github} {
+		if err := group.Validate(o.dryRun); err != nil {
+			return fmt.Errorf("%d: %w", idx, err)
+		}
+	}
+	if o.netlifyTokenFile == "" {
+		return fmt.Errorf("--netlify-token-file is required")
+	}
+	if o.configPath == "" {
+		return fmt.Errorf("--config-path is required")
+	}
+	if o.netlifyAPIURL == "" {
+		return fmt.Errorf("--netlify-api-url is required")
+	}
+	return nil
+}
+
+func gatherOptions() options {
+	o := options{}
+	fs := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+	fs.IntVar(&o.port, "port", 8888, "Port to listen on.")
+	fs.BoolVar(&o.dryRun, "dry-run", true, "Dry run for testing. Uses API tokens but does not mutate.")
+	fs.StringVar(&o.webhookSecretFile, "hmac-secret-file", "/etc/webhook/hmac", "Path to the file containing the GitHub HMAC secret.")
+	fs.StringVar(&o.netlifyTokenFile, "netlify-token-file", "/etc/netlify-preview/token", "Path to the file containing the Netlify API token.")
+	fs.StringVar(&o.configPath, "config-path", "/etc/netlify-preview/config.yaml", "Path to the netlify-preview plugin config file.")
+	fs.StringVar(&o.netlifyAPIURL, "netlify-api-url", "https://api.netlify.com", "Base URL for the Netlify API.")
+	fs.StringVar(&o.logLevel, "log-level", "debug", fmt.Sprintf("Log level is one of %v.", logrus.AllLevels))
+	o.pluginsConfig.PluginConfigPathDefault = "/etc/plugins/plugins.yaml"
+	for _, group := range []flagutil.OptionGroup{&o.github, &o.instrumentationOptions, &o.pluginsConfig} {
+		group.AddFlags(fs)
+	}
+	fs.Parse(os.Args[1:])
+	return o
+}
+
+func main() {
+	logrusutil.ComponentInit()
+	o := gatherOptions()
+	if err := o.Validate(); err != nil {
+		logrus.Fatalf("Invalid options: %v", err)
+	}
+
+	logLevel, err := logrus.ParseLevel(o.logLevel)
+	if err != nil {
+		logrus.WithError(err).Fatal("Failed to parse loglevel")
+	}
+	logrus.SetLevel(logLevel)
+	log := logrus.StandardLogger().WithField("plugin", netlifypreview.PluginName)
+
+	if err := secret.Add(o.webhookSecretFile); err != nil {
+		logrus.WithError(err).Fatal("Error starting webhook secret agent.")
+	}
+	if err := secret.Add(o.netlifyTokenFile); err != nil {
+		logrus.WithError(err).Fatal("Error starting Netlify token secret agent.")
+	}
+
+	pluginAgent, err := o.pluginsConfig.PluginAgent()
+	if err != nil {
+		log.WithError(err).Fatal("Error loading plugin config.")
+	}
+	previewConfig, err := previewconfig.Load(o.configPath)
+	if err != nil {
+		log.WithError(err).Fatal("Error loading netlify-preview config.")
+	}
+	githubClient, err := o.github.GitHubClient(o.dryRun)
+	if err != nil {
+		logrus.WithError(err).Fatal("Error getting GitHub client.")
+	}
+
+	serv := &server{
+		tokenGenerator: secret.GetTokenGenerator(o.webhookSecretFile),
+		ghc:            githubClient,
+		netlifyClient:  netlify.NewClient(o.netlifyAPIURL, http.DefaultClient, secret.GetTokenGenerator(o.netlifyTokenFile)),
+		pluginConfig:   pluginAgent,
+		previewConfig:  previewConfig,
+		log:            log,
+		dryRun:         o.dryRun,
+	}
+
+	health := pjutil.NewHealthOnPort(o.instrumentationOptions.HealthPort)
+	health.ServeReady()
+
+	mux := http.NewServeMux()
+	mux.Handle("/", serv)
+	externalplugins.ServeExternalPluginHelp(mux, log, netlifypreview.HelpProvider)
+	httpServer := &http.Server{Addr: ":" + strconv.Itoa(o.port), Handler: mux}
+	defer interrupts.WaitForGracefulShutdown()
+	interrupts.ListenAndServe(httpServer, 5*time.Second)
+}

--- a/cmd/external-plugins/netlify-preview/netlify/client.go
+++ b/cmd/external-plugins/netlify-preview/netlify/client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/external-plugins/netlify-preview/netlify/client.go
+++ b/cmd/external-plugins/netlify-preview/netlify/client.go
@@ -1,0 +1,107 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package netlify
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// Deploy is the subset of Netlify deploy data needed to retry PR deploy previews.
+type Deploy struct {
+	ID           string    `json:"id"`
+	Context      string    `json:"context"`
+	State        string    `json:"state"`
+	ReviewID     int       `json:"review_id"`
+	Branch       string    `json:"branch"`
+	DeploySSLURL string    `json:"deploy_ssl_url"`
+	CreatedAt    time.Time `json:"created_at"`
+}
+
+type Client struct {
+	baseURL        string
+	httpClient     *http.Client
+	tokenGenerator func() []byte
+}
+
+func NewClient(baseURL string, httpClient *http.Client, tokenGenerator func() []byte) *Client {
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+	return &Client{
+		baseURL:        strings.TrimRight(baseURL, "/"),
+		httpClient:     httpClient,
+		tokenGenerator: tokenGenerator,
+	}
+}
+
+func (c *Client) ListDeploys(ctx context.Context, siteID string) ([]Deploy, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("%s/api/v1/sites/%s/deploys", c.baseURL, url.PathEscape(siteID)), nil)
+	if err != nil {
+		return nil, err
+	}
+	c.authorize(req)
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("list deploys returned %s: %s", resp.Status, strings.TrimSpace(string(body)))
+	}
+	var deploys []Deploy
+	if err := json.NewDecoder(resp.Body).Decode(&deploys); err != nil {
+		return nil, err
+	}
+	return deploys, nil
+}
+
+func (c *Client) RetryDeploy(ctx context.Context, deployID string) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, fmt.Sprintf("%s/api/v1/deploys/%s/retry", c.baseURL, url.PathEscape(deployID)), nil)
+	if err != nil {
+		return err
+	}
+	c.authorize(req)
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("retry deploy returned %s: %s", resp.Status, strings.TrimSpace(string(body)))
+	}
+	return nil
+}
+
+func (c *Client) authorize(req *http.Request) {
+	if c.tokenGenerator == nil {
+		return
+	}
+	token := strings.TrimSpace(string(c.tokenGenerator()))
+	if token == "" {
+		return
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+}

--- a/cmd/external-plugins/netlify-preview/netlify/client.go
+++ b/cmd/external-plugins/netlify-preview/netlify/client.go
@@ -23,8 +23,16 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
+)
+
+const (
+	listDeploysPerPage = 100
+	// maxListDeployPages bounds the search so busy sites cannot make a single
+	// command walk the whole deploy history.
+	maxListDeployPages = 10
 )
 
 // Deploy is the subset of Netlify deploy data needed to retry PR deploy previews.
@@ -55,26 +63,73 @@ func NewClient(baseURL string, httpClient *http.Client, tokenGenerator func() []
 	}
 }
 
-func (c *Client) ListDeploys(ctx context.Context, siteID string) ([]Deploy, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("%s/api/v1/sites/%s/deploys", c.baseURL, url.PathEscape(siteID)), nil)
+// ForEachDeployPage calls fn with successive pages of the site's deploy
+// previews, newest first. Iteration stops when fn returns false, the pages
+// are exhausted, or maxListDeployPages pages have been fetched.
+func (c *Client) ForEachDeployPage(ctx context.Context, siteID string, fn func(page []Deploy) bool) error {
+	deploysURL, err := url.Parse(fmt.Sprintf("%s/api/v1/sites/%s/deploys", c.baseURL, url.PathEscape(siteID)))
 	if err != nil {
-		return nil, err
+		return err
+	}
+	query := deploysURL.Query()
+	query.Set("deploy-previews", "true")
+	query.Set("page", "1")
+	query.Set("per_page", strconv.Itoa(listDeploysPerPage))
+	deploysURL.RawQuery = query.Encode()
+
+	nextURL := deploysURL.String()
+	for page := 0; nextURL != "" && page < maxListDeployPages; page++ {
+		pageDeploys, next, err := c.listDeploysPage(ctx, nextURL)
+		if err != nil {
+			return err
+		}
+		if !fn(pageDeploys) {
+			return nil
+		}
+		nextURL = next
+	}
+	return nil
+}
+
+func (c *Client) listDeploysPage(ctx context.Context, deploysURL string) ([]Deploy, string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, deploysURL, nil)
+	if err != nil {
+		return nil, "", err
 	}
 	c.authorize(req)
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode < 200 || resp.StatusCode > 299 {
 		body, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("list deploys returned %s: %s", resp.Status, strings.TrimSpace(string(body)))
+		return nil, "", fmt.Errorf("list deploys returned %s: %s", resp.Status, strings.TrimSpace(string(body)))
 	}
 	var deploys []Deploy
 	if err := json.NewDecoder(resp.Body).Decode(&deploys); err != nil {
-		return nil, err
+		return nil, "", err
 	}
-	return deploys, nil
+	return deploys, nextLink(resp.Header.Get("Link")), nil
+}
+
+func nextLink(header string) string {
+	for link := range strings.SplitSeq(header, ",") {
+		sections := strings.Split(link, ";")
+		if len(sections) < 2 {
+			continue
+		}
+		target := strings.TrimSpace(sections[0])
+		if !strings.HasPrefix(target, "<") || !strings.HasSuffix(target, ">") {
+			continue
+		}
+		for _, parameter := range sections[1:] {
+			if strings.TrimSpace(parameter) == `rel="next"` {
+				return strings.TrimSuffix(strings.TrimPrefix(target, "<"), ">")
+			}
+		}
+	}
+	return ""
 }
 
 func (c *Client) RetryDeploy(ctx context.Context, deployID string) error {

--- a/cmd/external-plugins/netlify-preview/netlify/client_test.go
+++ b/cmd/external-plugins/netlify-preview/netlify/client_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/external-plugins/netlify-preview/netlify/client_test.go
+++ b/cmd/external-plugins/netlify-preview/netlify/client_test.go
@@ -1,0 +1,106 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package netlify
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestListDeploys(t *testing.T) {
+	httpClient := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		if r.URL.Path != "/api/v1/sites/site-123/deploys" {
+			t.Fatalf("unexpected path %q", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer token-123" {
+			t.Fatalf("unexpected auth header %q", got)
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Status:     "200 OK",
+			Body: io.NopCloser(strings.NewReader(`[{
+			"id": "deploy-123",
+			"context": "deploy-preview",
+			"state": "ready",
+			"review_id": 5,
+			"branch": "feature",
+			"deploy_ssl_url": "https://deploy-preview-5.example.netlify.app",
+			"created_at": "2026-04-28T22:10:06.585Z"
+		}]`)),
+			Header: make(http.Header),
+		}, nil
+	})}
+
+	client := NewClient("https://api.netlify.test", httpClient, func() []byte { return []byte("token-123") })
+	deploys, err := client.ListDeploys(context.Background(), "site-123")
+	if err != nil {
+		t.Fatalf("failed to list deploys: %v", err)
+	}
+	if len(deploys) != 1 {
+		t.Fatalf("expected one deploy, got %d", len(deploys))
+	}
+	if deploys[0].ID != "deploy-123" || deploys[0].ReviewID != 5 {
+		t.Fatalf("unexpected deploy: %#v", deploys[0])
+	}
+}
+
+func TestRetryDeploy(t *testing.T) {
+	httpClient := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("unexpected method %q", r.Method)
+		}
+		if r.URL.Path != "/api/v1/deploys/deploy-123/retry" {
+			t.Fatalf("unexpected path %q", r.URL.Path)
+		}
+		return &http.Response{
+			StatusCode: http.StatusCreated,
+			Status:     "201 Created",
+			Body:       io.NopCloser(strings.NewReader(`{}`)),
+			Header:     make(http.Header),
+		}, nil
+	})}
+
+	client := NewClient("https://api.netlify.test", httpClient, func() []byte { return []byte("token-123") })
+	if err := client.RetryDeploy(context.Background(), "deploy-123"); err != nil {
+		t.Fatalf("failed to retry deploy: %v", err)
+	}
+}
+
+func TestRetryDeployReportsNonSuccess(t *testing.T) {
+	httpClient := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusTooManyRequests,
+			Status:     "429 Too Many Requests",
+			Body:       io.NopCloser(strings.NewReader("rate limited")),
+			Header:     make(http.Header),
+		}, nil
+	})}
+
+	client := NewClient("https://api.netlify.test", httpClient, func() []byte { return []byte("token-123") })
+	if err := client.RetryDeploy(context.Background(), "deploy-123"); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) {
+	return f(r)
+}

--- a/cmd/external-plugins/netlify-preview/netlify/client_test.go
+++ b/cmd/external-plugins/netlify-preview/netlify/client_test.go
@@ -18,16 +18,27 @@ package netlify
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"net/http"
+	"strconv"
 	"strings"
 	"testing"
 )
 
-func TestListDeploys(t *testing.T) {
+func TestForEachDeployPage(t *testing.T) {
 	httpClient := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
 		if r.URL.Path != "/api/v1/sites/site-123/deploys" {
 			t.Fatalf("unexpected path %q", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("deploy-previews"); got != "true" {
+			t.Fatalf("unexpected deploy-previews query %q", got)
+		}
+		if got := r.URL.Query().Get("page"); got != "1" {
+			t.Fatalf("unexpected page query %q", got)
+		}
+		if got := r.URL.Query().Get("per_page"); got != "100" {
+			t.Fatalf("unexpected per_page query %q", got)
 		}
 		if got := r.Header.Get("Authorization"); got != "Bearer token-123" {
 			t.Fatalf("unexpected auth header %q", got)
@@ -49,7 +60,11 @@ func TestListDeploys(t *testing.T) {
 	})}
 
 	client := NewClient("https://api.netlify.test", httpClient, func() []byte { return []byte("token-123") })
-	deploys, err := client.ListDeploys(context.Background(), "site-123")
+	var deploys []Deploy
+	err := client.ForEachDeployPage(context.Background(), "site-123", func(page []Deploy) bool {
+		deploys = append(deploys, page...)
+		return true
+	})
 	if err != nil {
 		t.Fatalf("failed to list deploys: %v", err)
 	}
@@ -58,6 +73,136 @@ func TestListDeploys(t *testing.T) {
 	}
 	if deploys[0].ID != "deploy-123" || deploys[0].ReviewID != 5 {
 		t.Fatalf("unexpected deploy: %#v", deploys[0])
+	}
+}
+
+func TestForEachDeployPageFollowsNextLink(t *testing.T) {
+	var requests []string
+	httpClient := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		requests = append(requests, r.URL.String())
+		if got := r.Header.Get("Authorization"); got != "Bearer token-123" {
+			t.Fatalf("unexpected auth header %q", got)
+		}
+		switch r.URL.Query().Get("page") {
+		case "1":
+			header := make(http.Header)
+			header.Set("Link", `<https://api.netlify.test/api/v1/sites/site-123/deploys?deploy-previews=true&page=2&per_page=100>; rel="next"`)
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Status:     "200 OK",
+				Body: io.NopCloser(strings.NewReader(`[{
+					"id": "deploy-1",
+					"context": "deploy-preview",
+					"state": "ready",
+					"review_id": 5,
+					"branch": "feature",
+					"deploy_ssl_url": "https://deploy-preview-5.example.netlify.app",
+					"created_at": "2026-04-28T22:10:06.585Z"
+				}]`)),
+				Header: header,
+			}, nil
+		case "2":
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Status:     "200 OK",
+				Body: io.NopCloser(strings.NewReader(`[{
+					"id": "deploy-2",
+					"context": "deploy-preview",
+					"state": "error",
+					"review_id": 6,
+					"branch": "other-feature",
+					"deploy_ssl_url": "https://deploy-preview-6.example.netlify.app",
+					"created_at": "2026-04-28T23:10:06.585Z"
+				}]`)),
+				Header: make(http.Header),
+			}, nil
+		default:
+			t.Fatalf("unexpected page query %q", r.URL.Query().Get("page"))
+			return nil, nil
+		}
+	})}
+
+	client := NewClient("https://api.netlify.test", httpClient, func() []byte { return []byte("token-123") })
+	var deploys []Deploy
+	err := client.ForEachDeployPage(context.Background(), "site-123", func(page []Deploy) bool {
+		deploys = append(deploys, page...)
+		return true
+	})
+	if err != nil {
+		t.Fatalf("failed to list deploys: %v", err)
+	}
+	if len(deploys) != 2 {
+		t.Fatalf("expected two deploys, got %d", len(deploys))
+	}
+	if deploys[0].ID != "deploy-1" || deploys[1].ID != "deploy-2" {
+		t.Fatalf("unexpected deploys: %#v", deploys)
+	}
+	if len(requests) != 2 {
+		t.Fatalf("expected two requests, got %d: %v", len(requests), requests)
+	}
+}
+
+func TestForEachDeployPageStopsWhenCallbackIsDone(t *testing.T) {
+	var requests int
+	httpClient := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		requests++
+		header := make(http.Header)
+		header.Set("Link", `<https://api.netlify.test/api/v1/sites/site-123/deploys?deploy-previews=true&page=2&per_page=100>; rel="next"`)
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Status:     "200 OK",
+			Body: io.NopCloser(strings.NewReader(`[{
+				"id": "deploy-1",
+				"context": "deploy-preview",
+				"state": "error",
+				"review_id": 5,
+				"branch": "feature",
+				"deploy_ssl_url": "https://deploy-preview-5.example.netlify.app",
+				"created_at": "2026-04-28T22:10:06.585Z"
+			}]`)),
+			Header: header,
+		}, nil
+	})}
+
+	client := NewClient("https://api.netlify.test", httpClient, func() []byte { return []byte("token-123") })
+	err := client.ForEachDeployPage(context.Background(), "site-123", func(page []Deploy) bool {
+		return false
+	})
+	if err != nil {
+		t.Fatalf("failed to list deploys: %v", err)
+	}
+	if requests != 1 {
+		t.Fatalf("expected one request, got %d", requests)
+	}
+}
+
+func TestForEachDeployPageStopsAtPageCap(t *testing.T) {
+	var requests int
+	httpClient := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		requests++
+		page, err := strconv.Atoi(r.URL.Query().Get("page"))
+		if err != nil {
+			t.Fatalf("unexpected page query %q", r.URL.Query().Get("page"))
+		}
+		header := make(http.Header)
+		header.Set("Link", fmt.Sprintf(`<https://api.netlify.test/api/v1/sites/site-123/deploys?deploy-previews=true&page=%d&per_page=100>; rel="next"`, page+1))
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Status:     "200 OK",
+			Body:       io.NopCloser(strings.NewReader(`[]`)),
+			Header:     header,
+		}, nil
+	})}
+
+	client := NewClient("https://api.netlify.test", httpClient, func() []byte { return []byte("token-123") })
+	err := client.ForEachDeployPage(context.Background(), "site-123", func(page []Deploy) bool {
+		return true
+	})
+	if err != nil {
+		t.Fatalf("failed to list deploys: %v", err)
+	}
+	if requests != maxListDeployPages {
+		t.Fatalf("expected %d requests, got %d", maxListDeployPages, requests)
 	}
 }
 

--- a/cmd/external-plugins/netlify-preview/plugin/plugin.go
+++ b/cmd/external-plugins/netlify-preview/plugin/plugin.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/external-plugins/netlify-preview/plugin/plugin.go
+++ b/cmd/external-plugins/netlify-preview/plugin/plugin.go
@@ -1,0 +1,117 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package plugin
+
+import (
+	"regexp"
+
+	"sigs.k8s.io/prow/cmd/external-plugins/netlify-preview/netlify"
+	"sigs.k8s.io/prow/pkg/config"
+	"sigs.k8s.io/prow/pkg/markdown"
+	"sigs.k8s.io/prow/pkg/pluginhelp"
+)
+
+const PluginName = "netlify-preview"
+
+type Command string
+
+const (
+	RetestCommand         Command = "retest"
+	RebuildPreviewCommand Command = "rebuild-preview"
+)
+
+var commandRe = regexp.MustCompile(`(?mi)^/(retest|rebuild-preview)\s*$`)
+
+func ParseCommand(body string) (Command, bool) {
+	body = markdown.DropCodeBlock(body)
+	matches := commandRe.FindStringSubmatch(body)
+	if len(matches) != 2 {
+		return "", false
+	}
+	return Command(matches[1]), true
+}
+
+func LatestDeployPreview(deploys []netlify.Deploy, reviewID int) (netlify.Deploy, bool) {
+	var latest netlify.Deploy
+	var found bool
+	for _, deploy := range deploys {
+		if deploy.Context != "deploy-preview" || deploy.ReviewID != reviewID {
+			continue
+		}
+		if !found || deploy.CreatedAt.After(latest.CreatedAt) {
+			latest = deploy
+			found = true
+		}
+	}
+	return latest, found
+}
+
+type Action string
+
+const (
+	ActionRetry                Action = "retry"
+	ActionNoPreview            Action = "no_preview"
+	ActionAlreadyRunning       Action = "already_running"
+	ActionReadyRequiresRebuild Action = "ready_requires_rebuild"
+	ActionUnsupportedState     Action = "unsupported_state"
+)
+
+type Decision struct {
+	Action      Action
+	ShouldRetry bool
+}
+
+func Evaluate(command Command, preview *netlify.Deploy) Decision {
+	if preview == nil {
+		return Decision{Action: ActionNoPreview}
+	}
+	if preview.State == "building" || preview.State == "enqueued" {
+		return Decision{Action: ActionAlreadyRunning}
+	}
+	if command == RebuildPreviewCommand {
+		return Decision{Action: ActionRetry, ShouldRetry: true}
+	}
+	switch preview.State {
+	case "error":
+		return Decision{Action: ActionRetry, ShouldRetry: true}
+	case "ready":
+		return Decision{Action: ActionReadyRequiresRebuild}
+	default:
+		return Decision{Action: ActionUnsupportedState}
+	}
+}
+
+func HelpProvider(_ []config.OrgRepo) (*pluginhelp.PluginHelp, error) {
+	pluginHelp := &pluginhelp.PluginHelp{
+		Description: "The netlify-preview plugin retries Netlify deploy previews for pull requests.",
+	}
+	pluginHelp.AddCommand(pluginhelp.Command{
+		Usage:       "/retest",
+		Description: "Retry the latest Netlify deploy preview for a PR when that preview is in error state.",
+		Featured:    true,
+		WhoCanUse:   "Anyone can trigger this command on a trusted PR.",
+		Examples:    []string{"/retest"},
+	})
+	pluginHelp.AddCommand(pluginhelp.Command{
+		Usage:       "/rebuild-preview",
+		Description: "Force a retry of the latest Netlify deploy preview for a PR regardless of its current state, except when a build is already running.",
+		Featured:    true,
+		WhoCanUse:   "Anyone can trigger this command on a trusted PR.",
+		Examples:    []string{"/rebuild-preview"},
+	})
+	return pluginHelp, nil
+}

--- a/cmd/external-plugins/netlify-preview/plugin/plugin.go
+++ b/cmd/external-plugins/netlify-preview/plugin/plugin.go
@@ -31,10 +31,10 @@ type Command string
 
 const (
 	RetestCommand         Command = "retest"
-	RebuildPreviewCommand Command = "rebuild-preview"
+	NetlifyRebuildCommand Command = "netlify-rebuild"
 )
 
-var commandRe = regexp.MustCompile(`(?mi)^/(retest|rebuild-preview)\s*$`)
+var commandRe = regexp.MustCompile(`(?mi)^/(retest|netlify-rebuild)\s*$`)
 
 func ParseCommand(body string) (Command, bool) {
 	body = markdown.DropCodeBlock(body)
@@ -82,7 +82,7 @@ func Evaluate(command Command, preview *netlify.Deploy) Decision {
 	if preview.State == "building" || preview.State == "enqueued" {
 		return Decision{Action: ActionAlreadyRunning}
 	}
-	if command == RebuildPreviewCommand {
+	if command == NetlifyRebuildCommand {
 		return Decision{Action: ActionRetry, ShouldRetry: true}
 	}
 	switch preview.State {
@@ -107,11 +107,11 @@ func HelpProvider(_ []config.OrgRepo) (*pluginhelp.PluginHelp, error) {
 		Examples:    []string{"/retest"},
 	})
 	pluginHelp.AddCommand(pluginhelp.Command{
-		Usage:       "/rebuild-preview",
+		Usage:       "/netlify-rebuild",
 		Description: "Force a retry of the latest Netlify deploy preview for a PR regardless of its current state, except when a build is already running.",
 		Featured:    true,
 		WhoCanUse:   "Anyone can trigger this command on a trusted PR.",
-		Examples:    []string{"/rebuild-preview"},
+		Examples:    []string{"/netlify-rebuild"},
 	})
 	return pluginHelp, nil
 }

--- a/cmd/external-plugins/netlify-preview/plugin/plugin_test.go
+++ b/cmd/external-plugins/netlify-preview/plugin/plugin_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/external-plugins/netlify-preview/plugin/plugin_test.go
+++ b/cmd/external-plugins/netlify-preview/plugin/plugin_test.go
@@ -1,0 +1,173 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package plugin
+
+import (
+	"testing"
+	"time"
+
+	"sigs.k8s.io/prow/cmd/external-plugins/netlify-preview/netlify"
+)
+
+func TestParseCommand(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want Command
+		ok   bool
+	}{
+		{
+			name: "retest",
+			body: "/retest",
+			want: RetestCommand,
+			ok:   true,
+		},
+		{
+			name: "rebuild preview",
+			body: "/rebuild-preview",
+			want: RebuildPreviewCommand,
+			ok:   true,
+		},
+		{
+			name: "command inside multiline comment",
+			body: "please try this again\n/rebuild-preview\nthanks",
+			want: RebuildPreviewCommand,
+			ok:   true,
+		},
+		{
+			name: "trailing words are rejected",
+			body: "/rebuild-preview please",
+			ok:   false,
+		},
+		{
+			name: "command in code block is ignored",
+			body: "```\n/rebuild-preview\n```",
+			ok:   false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := ParseCommand(tc.body)
+			if ok != tc.ok {
+				t.Fatalf("expected ok=%v, got %v", tc.ok, ok)
+			}
+			if got != tc.want {
+				t.Fatalf("expected command %q, got %q", tc.want, got)
+			}
+		})
+	}
+}
+
+func TestLatestDeployPreview(t *testing.T) {
+	old := time.Date(2026, 4, 28, 17, 0, 0, 0, time.UTC)
+	newer := old.Add(time.Hour)
+	deploys := []netlify.Deploy{
+		{ID: "branch", Context: "branch-deploy", ReviewID: 5, CreatedAt: newer},
+		{ID: "other-pr", Context: "deploy-preview", ReviewID: 6, CreatedAt: newer},
+		{ID: "old", Context: "deploy-preview", ReviewID: 5, CreatedAt: old},
+		{ID: "new", Context: "deploy-preview", ReviewID: 5, CreatedAt: newer},
+	}
+
+	got, ok := LatestDeployPreview(deploys, 5)
+	if !ok {
+		t.Fatal("expected to find a deploy preview")
+	}
+	if got.ID != "new" {
+		t.Fatalf("expected latest deploy preview %q, got %q", "new", got.ID)
+	}
+}
+
+func TestEvaluate(t *testing.T) {
+	tests := []struct {
+		name       string
+		command    Command
+		preview    *netlify.Deploy
+		wantAction Action
+		wantRetry  bool
+	}{
+		{
+			name:       "no preview",
+			command:    RebuildPreviewCommand,
+			wantAction: ActionNoPreview,
+		},
+		{
+			name:       "building preview is already running",
+			command:    RebuildPreviewCommand,
+			preview:    &netlify.Deploy{State: "building"},
+			wantAction: ActionAlreadyRunning,
+		},
+		{
+			name:       "enqueued preview is already running",
+			command:    RebuildPreviewCommand,
+			preview:    &netlify.Deploy{State: "enqueued"},
+			wantAction: ActionAlreadyRunning,
+		},
+		{
+			name:       "retest retries error preview",
+			command:    RetestCommand,
+			preview:    &netlify.Deploy{State: "error"},
+			wantAction: ActionRetry,
+			wantRetry:  true,
+		},
+		{
+			name:       "rebuild preview retries error preview",
+			command:    RebuildPreviewCommand,
+			preview:    &netlify.Deploy{State: "error"},
+			wantAction: ActionRetry,
+			wantRetry:  true,
+		},
+		{
+			name:       "retest does not retry ready preview",
+			command:    RetestCommand,
+			preview:    &netlify.Deploy{State: "ready"},
+			wantAction: ActionReadyRequiresRebuild,
+		},
+		{
+			name:       "rebuild preview retries ready preview",
+			command:    RebuildPreviewCommand,
+			preview:    &netlify.Deploy{State: "ready"},
+			wantAction: ActionRetry,
+			wantRetry:  true,
+		},
+		{
+			name:       "retest does not retry unknown state",
+			command:    RetestCommand,
+			preview:    &netlify.Deploy{State: "uploaded"},
+			wantAction: ActionUnsupportedState,
+		},
+		{
+			name:       "rebuild preview overrides unknown state",
+			command:    RebuildPreviewCommand,
+			preview:    &netlify.Deploy{State: "uploaded"},
+			wantAction: ActionRetry,
+			wantRetry:  true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := Evaluate(tc.command, tc.preview)
+			if got.Action != tc.wantAction {
+				t.Fatalf("expected action %q, got %q", tc.wantAction, got.Action)
+			}
+			if got.ShouldRetry != tc.wantRetry {
+				t.Fatalf("expected ShouldRetry=%v, got %v", tc.wantRetry, got.ShouldRetry)
+			}
+		})
+	}
+}

--- a/cmd/external-plugins/netlify-preview/plugin/plugin_test.go
+++ b/cmd/external-plugins/netlify-preview/plugin/plugin_test.go
@@ -37,25 +37,30 @@ func TestParseCommand(t *testing.T) {
 			ok:   true,
 		},
 		{
-			name: "rebuild preview",
-			body: "/rebuild-preview",
-			want: RebuildPreviewCommand,
+			name: "netlify rebuild",
+			body: "/netlify-rebuild",
+			want: NetlifyRebuildCommand,
 			ok:   true,
 		},
 		{
 			name: "command inside multiline comment",
-			body: "please try this again\n/rebuild-preview\nthanks",
-			want: RebuildPreviewCommand,
+			body: "please try this again\n/netlify-rebuild\nthanks",
+			want: NetlifyRebuildCommand,
 			ok:   true,
 		},
 		{
 			name: "trailing words are rejected",
-			body: "/rebuild-preview please",
+			body: "/netlify-rebuild please",
+			ok:   false,
+		},
+		{
+			name: "old rebuild preview command is rejected",
+			body: "/rebuild-preview",
 			ok:   false,
 		},
 		{
 			name: "command in code block is ignored",
-			body: "```\n/rebuild-preview\n```",
+			body: "```\n/netlify-rebuild\n```",
 			ok:   false,
 		},
 	}
@@ -102,18 +107,18 @@ func TestEvaluate(t *testing.T) {
 	}{
 		{
 			name:       "no preview",
-			command:    RebuildPreviewCommand,
+			command:    NetlifyRebuildCommand,
 			wantAction: ActionNoPreview,
 		},
 		{
 			name:       "building preview is already running",
-			command:    RebuildPreviewCommand,
+			command:    NetlifyRebuildCommand,
 			preview:    &netlify.Deploy{State: "building"},
 			wantAction: ActionAlreadyRunning,
 		},
 		{
 			name:       "enqueued preview is already running",
-			command:    RebuildPreviewCommand,
+			command:    NetlifyRebuildCommand,
 			preview:    &netlify.Deploy{State: "enqueued"},
 			wantAction: ActionAlreadyRunning,
 		},
@@ -126,7 +131,7 @@ func TestEvaluate(t *testing.T) {
 		},
 		{
 			name:       "rebuild preview retries error preview",
-			command:    RebuildPreviewCommand,
+			command:    NetlifyRebuildCommand,
 			preview:    &netlify.Deploy{State: "error"},
 			wantAction: ActionRetry,
 			wantRetry:  true,
@@ -139,7 +144,7 @@ func TestEvaluate(t *testing.T) {
 		},
 		{
 			name:       "rebuild preview retries ready preview",
-			command:    RebuildPreviewCommand,
+			command:    NetlifyRebuildCommand,
 			preview:    &netlify.Deploy{State: "ready"},
 			wantAction: ActionRetry,
 			wantRetry:  true,
@@ -152,7 +157,7 @@ func TestEvaluate(t *testing.T) {
 		},
 		{
 			name:       "rebuild preview overrides unknown state",
-			command:    RebuildPreviewCommand,
+			command:    NetlifyRebuildCommand,
 			preview:    &netlify.Deploy{State: "uploaded"},
 			wantAction: ActionRetry,
 			wantRetry:  true,

--- a/cmd/external-plugins/netlify-preview/server.go
+++ b/cmd/external-plugins/netlify-preview/server.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/external-plugins/netlify-preview/server.go
+++ b/cmd/external-plugins/netlify-preview/server.go
@@ -1,0 +1,207 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/sirupsen/logrus"
+
+	previewconfig "sigs.k8s.io/prow/cmd/external-plugins/netlify-preview/config"
+	"sigs.k8s.io/prow/cmd/external-plugins/netlify-preview/netlify"
+	netlifypreview "sigs.k8s.io/prow/cmd/external-plugins/netlify-preview/plugin"
+	"sigs.k8s.io/prow/pkg/github"
+	"sigs.k8s.io/prow/pkg/plugins"
+	"sigs.k8s.io/prow/pkg/plugins/trigger"
+)
+
+type githubClient interface {
+	BotUserChecker() (func(candidate string) bool, error)
+	CreateComment(org, repo string, number int, comment string) error
+	GetIssueLabels(org, repo string, number int) ([]github.Label, error)
+	IsCollaborator(owner, repo, login string) (bool, error)
+	IsMember(org, user string) (bool, error)
+}
+
+type netlifyClient interface {
+	ListDeploys(ctx context.Context, siteID string) ([]netlify.Deploy, error)
+	RetryDeploy(ctx context.Context, deployID string) error
+}
+
+type pluginConfigAgent interface {
+	Config() *plugins.Configuration
+}
+
+type server struct {
+	tokenGenerator func() []byte
+	ghc            githubClient
+	netlifyClient  netlifyClient
+	pluginConfig   pluginConfigAgent
+	previewConfig  *previewconfig.Config
+	log            *logrus.Entry
+	dryRun         bool
+}
+
+func (s *server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	eventType, eventGUID, payload, ok, _ := github.ValidateWebhook(w, r, s.tokenGenerator)
+	if !ok {
+		return
+	}
+	fmt.Fprint(w, "Event received. Have a nice day.")
+
+	if err := s.handleEvent(eventType, eventGUID, payload); err != nil {
+		s.log.WithError(err).Error("Error parsing event.")
+	}
+}
+
+func (s *server) handleEvent(eventType, eventGUID string, payload []byte) error {
+	l := s.log.WithFields(logrus.Fields{
+		"event-type":     eventType,
+		github.EventGUID: eventGUID,
+	})
+	switch eventType {
+	case "issue_comment":
+		var ic github.IssueCommentEvent
+		if err := json.Unmarshal(payload, &ic); err != nil {
+			return err
+		}
+		go func() {
+			if err := s.handleIssueComment(l, ic); err != nil {
+				s.log.WithError(err).WithFields(l.Data).Info("Failed to handle issue comment.")
+			}
+		}()
+	default:
+		l.Debugf("skipping event of type %q", eventType)
+	}
+	return nil
+}
+
+func (s *server) handleIssueComment(l *logrus.Entry, ic github.IssueCommentEvent) error {
+	if !ic.Issue.IsPullRequest() || ic.Action != github.IssueCommentActionCreated || ic.Issue.State == "closed" {
+		return nil
+	}
+
+	command, ok := netlifypreview.ParseCommand(ic.Comment.Body)
+	if !ok {
+		return nil
+	}
+
+	org := ic.Repo.Owner.Login
+	repo := ic.Repo.Name
+	number := ic.Issue.Number
+	commentAuthor := ic.Comment.User.Login
+	l = l.WithFields(logrus.Fields{
+		github.OrgLogField:  org,
+		github.RepoLogField: repo,
+		github.PrLogField:   number,
+		"command":           command,
+	})
+
+	botUserChecker, err := s.ghc.BotUserChecker()
+	if err != nil {
+		return err
+	}
+	if botUserChecker(commentAuthor) {
+		l.Debug("Comment is made by the bot, skipping.")
+		return nil
+	}
+
+	if trusted, err := s.trustedForCommand(org, repo, number, ic.Issue.User.Login, commentAuthor); err != nil {
+		return err
+	} else if !trusted {
+		return s.comment(ic, "Cannot retry the Netlify deploy preview until a trusted user reviews the PR and leaves an `/ok-to-test` message.")
+	}
+
+	repoConfig, ok := s.previewConfig.Repo(org, repo)
+	if !ok {
+		l.WithField("action", "config_error").Info("Repository has no Netlify preview site mapping.")
+		return s.comment(ic, "This repository does not have a Netlify preview site mapping configured, so I can't retry a deploy preview for it.")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	deploys, err := s.netlifyClient.ListDeploys(ctx, repoConfig.SiteID)
+	if err != nil {
+		return err
+	}
+	preview, found := netlifypreview.LatestDeployPreview(deploys, number)
+	var previewPtr *netlify.Deploy
+	if found {
+		previewPtr = &preview
+	}
+	decision := netlifypreview.Evaluate(command, previewPtr)
+	l = l.WithFields(logrus.Fields{
+		"site-id": repoConfig.SiteID,
+		"action":  decision.Action,
+	})
+	if found {
+		l = l.WithFields(logrus.Fields{
+			"deploy-id":    preview.ID,
+			"deploy-state": preview.State,
+			"preview-link": preview.DeploySSLURL,
+		})
+	}
+
+	if decision.ShouldRetry {
+		if !s.dryRun {
+			if err := s.netlifyClient.RetryDeploy(ctx, preview.ID); err != nil {
+				return err
+			}
+		}
+		l.Info("Requested Netlify deploy preview retry.")
+		return s.comment(ic, fmt.Sprintf("Retrying the latest Netlify deploy preview for this PR: %s", preview.DeploySSLURL))
+	}
+
+	l.Info("Did not request Netlify deploy preview retry.")
+	return s.comment(ic, responseForDecision(command, decision, previewPtr))
+}
+
+func (s *server) trustedForCommand(org, repo string, number int, issueAuthor, commentAuthor string) (bool, error) {
+	triggerConfig := s.pluginConfig.Config().TriggerFor(org, repo)
+	trustedResponse, err := trigger.TrustedUser(s.ghc, triggerConfig.OnlyOrgMembers, triggerConfig.TrustedApps, triggerConfig.TrustedOrg, commentAuthor, org, repo)
+	if err != nil {
+		return false, fmt.Errorf("error checking trust of %s: %w", commentAuthor, err)
+	}
+	if trustedResponse.IsTrusted {
+		return true, nil
+	}
+	_, trusted, err := trigger.TrustedPullRequest(s.ghc, triggerConfig, issueAuthor, org, repo, number, nil)
+	return trusted, err
+}
+
+func (s *server) comment(ic github.IssueCommentEvent, response string) error {
+	return s.ghc.CreateComment(ic.Repo.Owner.Login, ic.Repo.Name, ic.Issue.Number, plugins.FormatICResponse(ic.Comment, response))
+}
+
+func responseForDecision(command netlifypreview.Command, decision netlifypreview.Decision, preview *netlify.Deploy) string {
+	switch decision.Action {
+	case netlifypreview.ActionNoPreview:
+		return "No Netlify deploy preview was found for this PR, so there is nothing to retry."
+	case netlifypreview.ActionAlreadyRunning:
+		return fmt.Sprintf("A Netlify deploy preview is already in progress for this PR: %s", preview.DeploySSLURL)
+	case netlifypreview.ActionReadyRequiresRebuild:
+		return fmt.Sprintf("The latest Netlify deploy preview is `ready`. `/retest` only retries previews in `error` state. Use `/rebuild-preview` to refresh it: %s", preview.DeploySSLURL)
+	case netlifypreview.ActionUnsupportedState:
+		return fmt.Sprintf("The latest Netlify deploy preview is in state `%s`. `/retest` does not retry this state. Use `/rebuild-preview` to force a retry: %s", preview.State, preview.DeploySSLURL)
+	default:
+		return fmt.Sprintf("No Netlify deploy preview retry was requested for command `%s`.", command)
+	}
+}

--- a/cmd/external-plugins/netlify-preview/server.go
+++ b/cmd/external-plugins/netlify-preview/server.go
@@ -42,7 +42,7 @@ type githubClient interface {
 }
 
 type netlifyClient interface {
-	ListDeploys(ctx context.Context, siteID string) ([]netlify.Deploy, error)
+	ForEachDeployPage(ctx context.Context, siteID string, fn func(page []netlify.Deploy) bool) error
 	RetryDeploy(ctx context.Context, deployID string) error
 }
 
@@ -114,6 +114,10 @@ func (s *server) handleIssueComment(l *logrus.Entry, ic github.IssueCommentEvent
 		github.PrLogField:   number,
 		"command":           command,
 	})
+	noopLevel := logrus.DebugLevel
+	if command == netlifypreview.NetlifyRebuildCommand {
+		noopLevel = logrus.InfoLevel
+	}
 
 	botUserChecker, err := s.ghc.BotUserChecker()
 	if err != nil {
@@ -127,22 +131,32 @@ func (s *server) handleIssueComment(l *logrus.Entry, ic github.IssueCommentEvent
 	if trusted, err := s.trustedForCommand(org, repo, number, ic.Issue.User.Login, commentAuthor); err != nil {
 		return err
 	} else if !trusted {
-		return s.comment(ic, "Cannot retry the Netlify deploy preview until a trusted user reviews the PR and leaves an `/ok-to-test` message.")
+		l.Log(noopLevel, "Comment author is not trusted to retry the Netlify deploy preview.")
+		if command == netlifypreview.NetlifyRebuildCommand {
+			return s.comment(ic, "Cannot retry the Netlify deploy preview until a trusted user reviews the PR and leaves an `/ok-to-test` message.")
+		}
+		return nil
 	}
 
 	repoConfig, ok := s.previewConfig.Repo(org, repo)
 	if !ok {
-		l.WithField("action", "config_error").Info("Repository has no Netlify preview site mapping.")
-		return s.comment(ic, "This repository does not have a Netlify preview site mapping configured, so I can't retry a deploy preview for it.")
+		l.WithField("action", "config_error").Log(noopLevel, "Repository has no Netlify preview site mapping.")
+		if command == netlifypreview.NetlifyRebuildCommand {
+			return s.comment(ic, "This repository does not have a Netlify preview site mapping configured, so I can't retry a deploy preview for it.")
+		}
+		return nil
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
-	deploys, err := s.netlifyClient.ListDeploys(ctx, repoConfig.SiteID)
-	if err != nil {
+	var preview netlify.Deploy
+	var found bool
+	if err := s.netlifyClient.ForEachDeployPage(ctx, repoConfig.SiteID, func(page []netlify.Deploy) bool {
+		preview, found = netlifypreview.LatestDeployPreview(page, number)
+		return !found
+	}); err != nil {
 		return err
 	}
-	preview, found := netlifypreview.LatestDeployPreview(deploys, number)
 	var previewPtr *netlify.Deploy
 	if found {
 		previewPtr = &preview
@@ -167,11 +181,17 @@ func (s *server) handleIssueComment(l *logrus.Entry, ic github.IssueCommentEvent
 			}
 		}
 		l.Info("Requested Netlify deploy preview retry.")
-		return s.comment(ic, fmt.Sprintf("Retrying the latest Netlify deploy preview for this PR: %s", preview.DeploySSLURL))
+		if command == netlifypreview.NetlifyRebuildCommand {
+			return s.comment(ic, fmt.Sprintf("Retrying the latest Netlify deploy preview for this PR: %s", preview.DeploySSLURL))
+		}
+		return nil
 	}
 
-	l.Info("Did not request Netlify deploy preview retry.")
-	return s.comment(ic, responseForDecision(command, decision, previewPtr))
+	l.Log(noopLevel, "Did not request Netlify deploy preview retry.")
+	if command == netlifypreview.NetlifyRebuildCommand {
+		return s.comment(ic, responseForDecision(command, decision, previewPtr))
+	}
+	return nil
 }
 
 func (s *server) trustedForCommand(org, repo string, number int, issueAuthor, commentAuthor string) (bool, error) {
@@ -198,9 +218,9 @@ func responseForDecision(command netlifypreview.Command, decision netlifypreview
 	case netlifypreview.ActionAlreadyRunning:
 		return fmt.Sprintf("A Netlify deploy preview is already in progress for this PR: %s", preview.DeploySSLURL)
 	case netlifypreview.ActionReadyRequiresRebuild:
-		return fmt.Sprintf("The latest Netlify deploy preview is `ready`. `/retest` only retries previews in `error` state. Use `/rebuild-preview` to refresh it: %s", preview.DeploySSLURL)
+		return fmt.Sprintf("The latest Netlify deploy preview is `ready`. `/retest` only retries previews in `error` state. Use `/netlify-rebuild` to refresh it: %s", preview.DeploySSLURL)
 	case netlifypreview.ActionUnsupportedState:
-		return fmt.Sprintf("The latest Netlify deploy preview is in state `%s`. `/retest` does not retry this state. Use `/rebuild-preview` to force a retry: %s", preview.State, preview.DeploySSLURL)
+		return fmt.Sprintf("The latest Netlify deploy preview is in state `%s`. `/retest` does not retry this state. Use `/netlify-rebuild` to force a retry: %s", preview.State, preview.DeploySSLURL)
 	default:
 		return fmt.Sprintf("No Netlify deploy preview retry was requested for command `%s`.", command)
 	}

--- a/cmd/external-plugins/netlify-preview/server_test.go
+++ b/cmd/external-plugins/netlify-preview/server_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/external-plugins/netlify-preview/server_test.go
+++ b/cmd/external-plugins/netlify-preview/server_test.go
@@ -1,0 +1,207 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+
+	previewconfig "sigs.k8s.io/prow/cmd/external-plugins/netlify-preview/config"
+	"sigs.k8s.io/prow/cmd/external-plugins/netlify-preview/netlify"
+	"sigs.k8s.io/prow/pkg/github"
+	"sigs.k8s.io/prow/pkg/labels"
+	"sigs.k8s.io/prow/pkg/plugins"
+)
+
+func TestHandleIssueCommentIgnoresNonActionableComments(t *testing.T) {
+	tests := []struct {
+		name string
+		ice  github.IssueCommentEvent
+	}{
+		{
+			name: "non pr comment",
+			ice:  issueCommentEvent("/rebuild-preview", "open", false),
+		},
+		{
+			name: "closed pr comment",
+			ice:  issueCommentEvent("/rebuild-preview", "closed", true),
+		},
+		{
+			name: "non command comment",
+			ice:  issueCommentEvent("hello", "open", true),
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ghc := &fakeGitHubClient{member: true}
+			netlifyClient := &fakeNetlifyClient{}
+			s := newTestServer(ghc, netlifyClient, &previewconfig.Config{})
+			if err := s.handleIssueComment(logrus.NewEntry(logrus.New()), tc.ice); err != nil {
+				t.Fatalf("handleIssueComment returned error: %v", err)
+			}
+			if len(ghc.comments) != 0 {
+				t.Fatalf("expected no comments, got %v", ghc.comments)
+			}
+			if netlifyClient.listCalled {
+				t.Fatal("expected Netlify not to be called")
+			}
+		})
+	}
+}
+
+func TestHandleIssueCommentRejectsUntrustedComment(t *testing.T) {
+	ghc := &fakeGitHubClient{}
+	s := newTestServer(ghc, &fakeNetlifyClient{}, &previewconfig.Config{})
+
+	if err := s.handleIssueComment(logrus.NewEntry(logrus.New()), issueCommentEvent("/rebuild-preview", "open", true)); err != nil {
+		t.Fatalf("handleIssueComment returned error: %v", err)
+	}
+	if len(ghc.comments) != 1 {
+		t.Fatalf("expected one comment, got %d", len(ghc.comments))
+	}
+	if !strings.Contains(ghc.comments[0], "Cannot retry the Netlify deploy preview") {
+		t.Fatalf("unexpected comment: %s", ghc.comments[0])
+	}
+}
+
+func TestHandleIssueCommentAllowsTrustedPullRequest(t *testing.T) {
+	ghc := &fakeGitHubClient{labels: []github.Label{{Name: labels.OkToTest}}}
+	netlifyClient := &fakeNetlifyClient{deploys: []netlify.Deploy{{
+		ID:           "deploy-123",
+		Context:      "deploy-preview",
+		State:        "error",
+		ReviewID:     5,
+		DeploySSLURL: "https://deploy-preview-5.example.netlify.app",
+		CreatedAt:    time.Now(),
+	}}}
+	cfg := &previewconfig.Config{Repos: map[string]previewconfig.Repo{"kubernetes/website": {SiteID: "site-123"}}}
+	s := newTestServer(ghc, netlifyClient, cfg)
+
+	if err := s.handleIssueComment(logrus.NewEntry(logrus.New()), issueCommentEvent("/retest", "open", true)); err != nil {
+		t.Fatalf("handleIssueComment returned error: %v", err)
+	}
+	if !netlifyClient.retryCalled {
+		t.Fatal("expected Netlify retry")
+	}
+	if len(ghc.comments) != 1 || !strings.Contains(ghc.comments[0], "Retrying the latest Netlify deploy preview") {
+		t.Fatalf("unexpected comments: %v", ghc.comments)
+	}
+}
+
+func TestHandleIssueCommentFailsClosedWhenMappingMissing(t *testing.T) {
+	ghc := &fakeGitHubClient{member: true}
+	s := newTestServer(ghc, &fakeNetlifyClient{}, &previewconfig.Config{})
+
+	if err := s.handleIssueComment(logrus.NewEntry(logrus.New()), issueCommentEvent("/rebuild-preview", "open", true)); err != nil {
+		t.Fatalf("handleIssueComment returned error: %v", err)
+	}
+	if len(ghc.comments) != 1 {
+		t.Fatalf("expected one comment, got %d", len(ghc.comments))
+	}
+	if !strings.Contains(ghc.comments[0], "does not have a Netlify preview site mapping configured") {
+		t.Fatalf("unexpected comment: %s", ghc.comments[0])
+	}
+}
+
+func newTestServer(ghc *fakeGitHubClient, netlifyClient *fakeNetlifyClient, cfg *previewconfig.Config) *server {
+	return &server{
+		ghc:           ghc,
+		netlifyClient: netlifyClient,
+		pluginConfig:  fakePluginConfigAgent{cfg: &plugins.Configuration{}},
+		previewConfig: cfg,
+		log:           logrus.NewEntry(logrus.New()),
+	}
+}
+
+func issueCommentEvent(body, state string, isPR bool) github.IssueCommentEvent {
+	issue := github.Issue{
+		Number: 5,
+		State:  state,
+		User:   github.User{Login: "pr-author"},
+	}
+	if isPR {
+		issue.PullRequest = &struct{}{}
+	}
+	return github.IssueCommentEvent{
+		Action: github.IssueCommentActionCreated,
+		Issue:  issue,
+		Comment: github.IssueComment{
+			Body: body,
+			User: github.User{Login: "commenter"},
+		},
+		Repo: github.Repo{
+			Owner: github.User{Login: "kubernetes"},
+			Name:  "website",
+		},
+	}
+}
+
+type fakeGitHubClient struct {
+	member       bool
+	collaborator bool
+	labels       []github.Label
+	comments     []string
+}
+
+func (f *fakeGitHubClient) BotUserChecker() (func(candidate string) bool, error) {
+	return func(candidate string) bool { return candidate == "k8s-ci-robot" }, nil
+}
+
+func (f *fakeGitHubClient) CreateComment(org, repo string, number int, comment string) error {
+	f.comments = append(f.comments, comment)
+	return nil
+}
+
+func (f *fakeGitHubClient) GetIssueLabels(org, repo string, number int) ([]github.Label, error) {
+	return f.labels, nil
+}
+
+func (f *fakeGitHubClient) IsCollaborator(owner, repo, login string) (bool, error) {
+	return f.collaborator, nil
+}
+
+func (f *fakeGitHubClient) IsMember(org, user string) (bool, error) {
+	return f.member, nil
+}
+
+type fakeNetlifyClient struct {
+	deploys     []netlify.Deploy
+	listCalled  bool
+	retryCalled bool
+}
+
+func (f *fakeNetlifyClient) ListDeploys(ctx context.Context, siteID string) ([]netlify.Deploy, error) {
+	f.listCalled = true
+	return f.deploys, nil
+}
+
+func (f *fakeNetlifyClient) RetryDeploy(ctx context.Context, deployID string) error {
+	f.retryCalled = true
+	return nil
+}
+
+type fakePluginConfigAgent struct {
+	cfg *plugins.Configuration
+}
+
+func (f fakePluginConfigAgent) Config() *plugins.Configuration {
+	return f.cfg
+}

--- a/cmd/external-plugins/netlify-preview/server_test.go
+++ b/cmd/external-plugins/netlify-preview/server_test.go
@@ -38,11 +38,11 @@ func TestHandleIssueCommentIgnoresNonActionableComments(t *testing.T) {
 	}{
 		{
 			name: "non pr comment",
-			ice:  issueCommentEvent("/rebuild-preview", "open", false),
+			ice:  issueCommentEvent("/netlify-rebuild", "open", false),
 		},
 		{
 			name: "closed pr comment",
-			ice:  issueCommentEvent("/rebuild-preview", "closed", true),
+			ice:  issueCommentEvent("/netlify-rebuild", "closed", true),
 		},
 		{
 			name: "non command comment",
@@ -71,7 +71,7 @@ func TestHandleIssueCommentRejectsUntrustedComment(t *testing.T) {
 	ghc := &fakeGitHubClient{}
 	s := newTestServer(ghc, &fakeNetlifyClient{}, &previewconfig.Config{})
 
-	if err := s.handleIssueComment(logrus.NewEntry(logrus.New()), issueCommentEvent("/rebuild-preview", "open", true)); err != nil {
+	if err := s.handleIssueComment(logrus.NewEntry(logrus.New()), issueCommentEvent("/netlify-rebuild", "open", true)); err != nil {
 		t.Fatalf("handleIssueComment returned error: %v", err)
 	}
 	if len(ghc.comments) != 1 {
@@ -82,7 +82,23 @@ func TestHandleIssueCommentRejectsUntrustedComment(t *testing.T) {
 	}
 }
 
-func TestHandleIssueCommentAllowsTrustedPullRequest(t *testing.T) {
+func TestHandleIssueCommentKeepsRetestQuietForUntrustedComment(t *testing.T) {
+	ghc := &fakeGitHubClient{}
+	netlifyClient := &fakeNetlifyClient{}
+	s := newTestServer(ghc, netlifyClient, &previewconfig.Config{})
+
+	if err := s.handleIssueComment(logrus.NewEntry(logrus.New()), issueCommentEvent("/retest", "open", true)); err != nil {
+		t.Fatalf("handleIssueComment returned error: %v", err)
+	}
+	if len(ghc.comments) != 0 {
+		t.Fatalf("expected no comments, got %v", ghc.comments)
+	}
+	if netlifyClient.listCalled {
+		t.Fatal("expected Netlify not to be called")
+	}
+}
+
+func TestHandleIssueCommentAllowsTrustedPullRequestRetest(t *testing.T) {
 	ghc := &fakeGitHubClient{labels: []github.Label{{Name: labels.OkToTest}}}
 	netlifyClient := &fakeNetlifyClient{deploys: []netlify.Deploy{{
 		ID:           "deploy-123",
@@ -92,10 +108,34 @@ func TestHandleIssueCommentAllowsTrustedPullRequest(t *testing.T) {
 		DeploySSLURL: "https://deploy-preview-5.example.netlify.app",
 		CreatedAt:    time.Now(),
 	}}}
-	cfg := &previewconfig.Config{Repos: map[string]previewconfig.Repo{"kubernetes/website": {SiteID: "site-123"}}}
+	cfg := &previewconfig.Config{Repos: map[string]previewconfig.SiteConfig{"kubernetes/website": {SiteID: "site-123"}}}
 	s := newTestServer(ghc, netlifyClient, cfg)
 
 	if err := s.handleIssueComment(logrus.NewEntry(logrus.New()), issueCommentEvent("/retest", "open", true)); err != nil {
+		t.Fatalf("handleIssueComment returned error: %v", err)
+	}
+	if !netlifyClient.retryCalled {
+		t.Fatal("expected Netlify retry")
+	}
+	if len(ghc.comments) != 0 {
+		t.Fatalf("unexpected comments: %v", ghc.comments)
+	}
+}
+
+func TestHandleIssueCommentCommentsAfterNetlifyRebuildRetry(t *testing.T) {
+	ghc := &fakeGitHubClient{labels: []github.Label{{Name: labels.OkToTest}}}
+	netlifyClient := &fakeNetlifyClient{deploys: []netlify.Deploy{{
+		ID:           "deploy-123",
+		Context:      "deploy-preview",
+		State:        "ready",
+		ReviewID:     5,
+		DeploySSLURL: "https://deploy-preview-5.example.netlify.app",
+		CreatedAt:    time.Now(),
+	}}}
+	cfg := &previewconfig.Config{Repos: map[string]previewconfig.SiteConfig{"kubernetes/website": {SiteID: "site-123"}}}
+	s := newTestServer(ghc, netlifyClient, cfg)
+
+	if err := s.handleIssueComment(logrus.NewEntry(logrus.New()), issueCommentEvent("/netlify-rebuild", "open", true)); err != nil {
 		t.Fatalf("handleIssueComment returned error: %v", err)
 	}
 	if !netlifyClient.retryCalled {
@@ -110,7 +150,7 @@ func TestHandleIssueCommentFailsClosedWhenMappingMissing(t *testing.T) {
 	ghc := &fakeGitHubClient{member: true}
 	s := newTestServer(ghc, &fakeNetlifyClient{}, &previewconfig.Config{})
 
-	if err := s.handleIssueComment(logrus.NewEntry(logrus.New()), issueCommentEvent("/rebuild-preview", "open", true)); err != nil {
+	if err := s.handleIssueComment(logrus.NewEntry(logrus.New()), issueCommentEvent("/netlify-rebuild", "open", true)); err != nil {
 		t.Fatalf("handleIssueComment returned error: %v", err)
 	}
 	if len(ghc.comments) != 1 {
@@ -118,6 +158,127 @@ func TestHandleIssueCommentFailsClosedWhenMappingMissing(t *testing.T) {
 	}
 	if !strings.Contains(ghc.comments[0], "does not have a Netlify preview site mapping configured") {
 		t.Fatalf("unexpected comment: %s", ghc.comments[0])
+	}
+}
+
+func TestHandleIssueCommentKeepsRetestQuietWhenMappingMissing(t *testing.T) {
+	ghc := &fakeGitHubClient{member: true}
+	netlifyClient := &fakeNetlifyClient{}
+	s := newTestServer(ghc, netlifyClient, &previewconfig.Config{})
+
+	if err := s.handleIssueComment(logrus.NewEntry(logrus.New()), issueCommentEvent("/retest", "open", true)); err != nil {
+		t.Fatalf("handleIssueComment returned error: %v", err)
+	}
+	if len(ghc.comments) != 0 {
+		t.Fatalf("expected no comments, got %v", ghc.comments)
+	}
+	if netlifyClient.listCalled {
+		t.Fatal("expected Netlify not to be called")
+	}
+}
+
+func TestHandleIssueCommentKeepsRetestQuietWhenNoRetryIsRequested(t *testing.T) {
+	tests := []struct {
+		name    string
+		deploys []netlify.Deploy
+	}{
+		{
+			name: "no preview",
+		},
+		{
+			name: "ready preview",
+			deploys: []netlify.Deploy{{
+				ID:           "deploy-123",
+				Context:      "deploy-preview",
+				State:        "ready",
+				ReviewID:     5,
+				DeploySSLURL: "https://deploy-preview-5.example.netlify.app",
+				CreatedAt:    time.Now(),
+			}},
+		},
+		{
+			name: "already running preview",
+			deploys: []netlify.Deploy{{
+				ID:           "deploy-123",
+				Context:      "deploy-preview",
+				State:        "building",
+				ReviewID:     5,
+				DeploySSLURL: "https://deploy-preview-5.example.netlify.app",
+				CreatedAt:    time.Now(),
+			}},
+		},
+		{
+			name: "unsupported preview state",
+			deploys: []netlify.Deploy{{
+				ID:           "deploy-123",
+				Context:      "deploy-preview",
+				State:        "uploaded",
+				ReviewID:     5,
+				DeploySSLURL: "https://deploy-preview-5.example.netlify.app",
+				CreatedAt:    time.Now(),
+			}},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ghc := &fakeGitHubClient{member: true}
+			netlifyClient := &fakeNetlifyClient{deploys: tc.deploys}
+			cfg := &previewconfig.Config{Repos: map[string]previewconfig.SiteConfig{"kubernetes/website": {SiteID: "site-123"}}}
+			s := newTestServer(ghc, netlifyClient, cfg)
+
+			if err := s.handleIssueComment(logrus.NewEntry(logrus.New()), issueCommentEvent("/retest", "open", true)); err != nil {
+				t.Fatalf("handleIssueComment returned error: %v", err)
+			}
+			if len(ghc.comments) != 0 {
+				t.Fatalf("expected no comments, got %v", ghc.comments)
+			}
+			if netlifyClient.retryCalled {
+				t.Fatal("expected Netlify retry not to be called")
+			}
+		})
+	}
+}
+
+func TestHandleIssueCommentCommentsForNetlifyRebuildNoRetryDecisions(t *testing.T) {
+	tests := []struct {
+		name        string
+		deploys     []netlify.Deploy
+		wantComment string
+	}{
+		{
+			name:        "no preview",
+			wantComment: "No Netlify deploy preview was found",
+		},
+		{
+			name: "already running preview",
+			deploys: []netlify.Deploy{{
+				ID:           "deploy-123",
+				Context:      "deploy-preview",
+				State:        "building",
+				ReviewID:     5,
+				DeploySSLURL: "https://deploy-preview-5.example.netlify.app",
+				CreatedAt:    time.Now(),
+			}},
+			wantComment: "already in progress",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ghc := &fakeGitHubClient{member: true}
+			netlifyClient := &fakeNetlifyClient{deploys: tc.deploys}
+			cfg := &previewconfig.Config{Repos: map[string]previewconfig.SiteConfig{"kubernetes/website": {SiteID: "site-123"}}}
+			s := newTestServer(ghc, netlifyClient, cfg)
+
+			if err := s.handleIssueComment(logrus.NewEntry(logrus.New()), issueCommentEvent("/netlify-rebuild", "open", true)); err != nil {
+				t.Fatalf("handleIssueComment returned error: %v", err)
+			}
+			if netlifyClient.retryCalled {
+				t.Fatal("expected Netlify retry not to be called")
+			}
+			if len(ghc.comments) != 1 || !strings.Contains(ghc.comments[0], tc.wantComment) {
+				t.Fatalf("unexpected comments: %v", ghc.comments)
+			}
+		})
 	}
 }
 
@@ -188,9 +349,10 @@ type fakeNetlifyClient struct {
 	retryCalled bool
 }
 
-func (f *fakeNetlifyClient) ListDeploys(ctx context.Context, siteID string) ([]netlify.Deploy, error) {
+func (f *fakeNetlifyClient) ForEachDeployPage(ctx context.Context, siteID string, fn func(page []netlify.Deploy) bool) error {
 	f.listCalled = true
-	return f.deploys, nil
+	fn(f.deploys)
+	return nil
 }
 
 func (f *fakeNetlifyClient) RetryDeploy(ctx context.Context, deployID string) error {

--- a/site/content/en/docs/components/external-plugins/netlify-preview.md
+++ b/site/content/en/docs/components/external-plugins/netlify-preview.md
@@ -1,0 +1,62 @@
+---
+title: "netlify-preview"
+weight: 20
+description: >
+  
+---
+
+netlify-preview is an external Prow plugin that retries the latest Netlify
+deploy preview for a pull request in response to a chat command. It is intended
+for repositories whose pull request previews are built by Netlify (for example
+`kubernetes/website` and `kubernetes/contributor-site`).
+
+## Commands
+
+```
+/retest
+```
+
+Retries the latest Netlify deploy preview for the PR **only when that preview
+is in `error` state**. If the preview is `ready`, the plugin posts a comment
+explaining that `/retest` will not retry passing previews and points the user
+to `/rebuild-preview`.
+
+```
+/rebuild-preview
+```
+
+Forces a retry of the latest Netlify deploy preview regardless of its current
+state, with one exception: if a build is already running (`building` or
+`enqueued`), the plugin declines and reports the in-progress preview rather
+than triggering a redundant build.
+
+Both commands require the comment author to be trusted under the same rules
+that Prow's `trigger` plugin applies: org members, configured trusted apps and
+orgs, or PR authors who have received `/ok-to-test`.
+
+## Configuration
+
+The plugin reads a small YAML configuration file that maps each repository to
+a Netlify site. Repositories that are not listed are ignored.
+
+```yaml
+repos:
+  kubernetes/website:
+    site_id: <netlify-site-id>
+  kubernetes/contributor-site:
+    site_id: <netlify-site-id>
+```
+
+Repositories that are listed under `external_plugins:` in the Prow
+configuration but missing from this file will receive a comment explaining
+that no Netlify preview site is configured.
+
+## Required credentials
+
+A Netlify personal access token (or a scoped equivalent) with permission to
+list site deploys and call the deploy retry endpoint. The plugin reads it from
+a file specified at startup. The token never reaches core Prow components.
+
+## Webhook events
+
+The plugin only subscribes to `issue_comment` events.

--- a/site/content/en/docs/components/external-plugins/netlify-preview.md
+++ b/site/content/en/docs/components/external-plugins/netlify-preview.md
@@ -17,18 +17,20 @@ for repositories whose pull request previews are built by Netlify (for example
 ```
 
 Retries the latest Netlify deploy preview for the PR **only when that preview
-is in `error` state**. If the preview is `ready`, the plugin posts a comment
-explaining that `/retest` will not retry passing previews and points the user
-to `/rebuild-preview`.
+is in `error` state**. If the preview is missing, already running, ready, or in
+another unsupported state, the plugin does not post a comment.
 
 ```
-/rebuild-preview
+/netlify-rebuild
 ```
 
 Forces a retry of the latest Netlify deploy preview regardless of its current
 state, with one exception: if a build is already running (`building` or
 `enqueued`), the plugin declines and reports the in-progress preview rather
 than triggering a redundant build.
+
+Both commands look for the PR's preview among the site's newest 1000 deploys;
+older previews are treated as not found.
 
 Both commands require the comment author to be trusted under the same rules
 that Prow's `trigger` plugin applies: org members, configured trusted apps and
@@ -48,8 +50,9 @@ repos:
 ```
 
 Repositories that are listed under `external_plugins:` in the Prow
-configuration but missing from this file will receive a comment explaining
-that no Netlify preview site is configured.
+configuration but missing from this file are ignored for `/retest` comments.
+For `/netlify-rebuild`, the plugin posts a comment explaining that no Netlify
+preview site is configured.
 
 ## Required credentials
 


### PR DESCRIPTION
Adds a new external Prow plugin, `netlify-preview`, that retries the
latest Netlify deploy preview for a pull request in response to chat
commands. Intended for repositories whose PR previews are built by
Netlify (initially `kubernetes/website` and `kubernetes/contributor-site`).

## Design

Two commands (sign-off in #693):

- `/retest` — retries the latest Netlify deploy preview **only when
  that preview is in `error` state**. If it is `ready`, the plugin
  posts a comment pointing the user to `/rebuild-preview` instead.
  Avoids wasteful rebuilds of passing previews on routine `/retest`.
- `/rebuild-preview` — forces a retry regardless of the preview's
  current state, **except** when a build is already running
  (`building` / `enqueued`). The in-flight guard prevents maintainers
  from triggering redundant builds while one is in progress.

## Per-repo site mapping

This PR adds a small configuration package that maps each repository
to a Netlify site ID (This is assuming one Netlify for all related netlify projects, hence a single PAT):

```yaml
repos:
  kubernetes/website:
    site_id: <netlify-site-id>
  kubernetes/contributor-site:
    site_id: <netlify-site-id>
```

Each repo can map to a different Netlify site independently. The
external_plugins: block in Prow configuration is only the enablement
mechanism; site mapping never goes there.

## Trust gating

Retries are gated by the same trust rules Prow's trigger plugin
applies (org membership, configured trusted apps and orgs, or
/ok-to-test on the PR). The gate is a build-minute / abuse
protection rather than a code-execution protection, Netlify has
already built the commit once, so a retry does not grant new code
execution. Wasted Netlify build minutes are the real risk.

Assisted by Claude 


Closes kubernetes-sigs/prow#693.