### PR TITLE
fix(peribolos): skip enterprise teams during reconciliation

### DIFF
--- a/cmd/peribolos/main.go
+++ b/cmd/peribolos/main.go
@@ -59,8 +59,9 @@ type options struct {
 	fixTeamRepos      bool
 	fixRepos          bool
 	fixCollaborators  bool
-	ignoreInvitees    bool
-	ignoreSecretTeams bool
+	ignoreInvitees        bool
+	ignoreSecretTeams     bool
+	ignoreEnterpriseTeams bool
 	allowRepoArchival bool
 	allowRepoPublish  bool
 	github            flagutil.GitHubOptions
@@ -88,6 +89,7 @@ func (o *options) parseArgs(flags *flag.FlagSet, args []string) error {
 	flags.BoolVar(&o.dumpFull, "dump-full", false, "Output current config of the org as a valid input config file instead of a snippet")
 	flags.BoolVar(&o.ignoreInvitees, "ignore-invitees", false, "Do not compare missing members with active invitations (compatibility for GitHub Enterprise)")
 	flags.BoolVar(&o.ignoreSecretTeams, "ignore-secret-teams", false, "Do not dump or update secret teams if set")
+	flags.BoolVar(&o.ignoreEnterpriseTeams, "ignore-enterprise-teams", false, "Skip enterprise teams and their members during reconciliation")
 	flags.BoolVar(&o.fixOrg, "fix-org", false, "Change org metadata if set")
 	flags.BoolVar(&o.fixOrgMembers, "fix-org-members", false, "Add/remove org members if set")
 	flags.BoolVar(&o.fixTeams, "fix-teams", false, "Create/delete/update teams if set")
@@ -162,7 +164,7 @@ func main() {
 	}
 
 	if o.dump != "" {
-		ret, err := dumpOrgConfig(githubClient, o.dump, o.ignoreSecretTeams, o.github.AppID)
+		ret, err := dumpOrgConfig(githubClient, o.dump, o.ignoreSecretTeams, o.ignoreEnterpriseTeams, o.github.AppID)
 		if err != nil {
 			logrus.WithError(err).Fatalf("Dump %s failed to collect current data.", o.dump)
 		}
@@ -213,7 +215,7 @@ type dumpClient interface {
 	BotUser() (*github.UserData, error)
 }
 
-func dumpOrgConfig(client dumpClient, orgName string, ignoreSecretTeams bool, appID string) (*org.Config, error) {
+func dumpOrgConfig(client dumpClient, orgName string, ignoreSecretTeams bool, ignoreEnterpriseTeams bool, appID string) (*org.Config, error) {
 	out := org.Config{}
 	meta, err := client.GetOrg(orgName)
 	if err != nil {
@@ -276,6 +278,10 @@ func dumpOrgConfig(client dumpClient, orgName string, ignoreSecretTeams bool, ap
 
 	for _, t := range teams {
 		logger := logrus.WithFields(logrus.Fields{"id": t.ID, "name": t.Name})
+		if ignoreEnterpriseTeams && t.Type == github.TeamTypeEnterprise {
+			logger.Debug("Skipping enterprise team.")
+			continue
+		}
 		p := org.Privacy(t.Privacy)
 		if ignoreSecretTeams && p == org.Secret {
 			logger.Debug("Ignoring secret team.")
@@ -392,6 +398,8 @@ func dumpOrgConfig(client dumpClient, orgName string, ignoreSecretTeams bool, ap
 type orgClient interface {
 	BotUser() (*github.UserData, error)
 	ListOrgMembers(org, role string) ([]github.TeamMember, error)
+	ListTeams(org string) ([]github.Team, error)
+	ListTeamMembersBySlug(org, teamSlug, role string) ([]github.TeamMember, error)
 	RemoveOrgMembership(org, user string) error
 	UpdateOrgMembership(org, user string, admin bool) (*github.OrgMembership, error)
 }
@@ -443,6 +451,34 @@ func configureOrgMembers(opt options, client orgClient, orgName string, orgConfi
 	want := memberships{members: wantMembers, super: wantAdmins}
 	have.normalize()
 	want.normalize()
+
+	if opt.ignoreEnterpriseTeams {
+		allTeams, err := client.ListTeams(orgName)
+		if err != nil {
+			return fmt.Errorf("failed to list %s teams: %w", orgName, err)
+		}
+		enterpriseMembers := sets.Set[string]{}
+		for _, t := range allTeams {
+			if t.Type != github.TeamTypeEnterprise {
+				continue
+			}
+			members, err := client.ListTeamMembersBySlug(orgName, t.Slug, github.RoleAll)
+			if err != nil {
+				logrus.WithError(err).Warnf("Failed to list enterprise team %s members, skipping", t.Slug)
+				continue
+			}
+			for _, m := range members {
+				enterpriseMembers.Insert(github.NormLogin(m.Login))
+			}
+		}
+		if len(enterpriseMembers) > 0 {
+			logrus.Infof("Excluding %d enterprise team members from org member reconciliation: %s",
+				len(enterpriseMembers), strings.Join(sets.List(enterpriseMembers), ", "))
+			have.super = have.super.Difference(enterpriseMembers)
+			have.members = have.members.Difference(enterpriseMembers)
+		}
+	}
+
 	// Figure out who to remove
 	remove := have.all().Difference(want.all())
 
@@ -666,7 +702,7 @@ type teamClient interface {
 }
 
 // configureTeams returns the ids for all expected team names, creating/deleting teams as necessary.
-func configureTeams(client teamClient, orgName string, orgConfig org.Config, maxDelta float64, ignoreSecretTeams bool) (map[string]github.Team, error) {
+func configureTeams(client teamClient, orgName string, orgConfig org.Config, maxDelta float64, ignoreSecretTeams bool, ignoreEnterpriseTeams bool) (map[string]github.Team, error) {
 	if err := validateTeamNames(orgConfig); err != nil {
 		return nil, err
 	}
@@ -680,6 +716,10 @@ func configureTeams(client teamClient, orgName string, orgConfig org.Config, max
 	}
 	logrus.Debugf("Found %d teams", len(teamList))
 	for _, t := range teamList {
+		if ignoreEnterpriseTeams && t.Type == github.TeamTypeEnterprise {
+			logrus.Infof("Skipping enterprise team %s(%s) — managed at the enterprise level", t.Slug, t.Name)
+			continue
+		}
 		if ignoreSecretTeams && org.Privacy(t.Privacy) == org.Secret {
 			continue
 		}
@@ -914,7 +954,7 @@ func configureOrg(opt options, client github.Client, orgName string, orgConfig o
 	}
 
 	// Find the id and current state of each declared team (create/delete as necessary)
-	githubTeams, err := configureTeams(client, orgName, orgConfig, opt.maximumDelta, opt.ignoreSecretTeams)
+	githubTeams, err := configureTeams(client, orgName, orgConfig, opt.maximumDelta, opt.ignoreSecretTeams, opt.ignoreEnterpriseTeams)
 	if err != nil {
 		return fmt.Errorf("failed to configure %s teams: %w", orgName, err)
 	}

--- a/cmd/peribolos/main_test.go
+++ b/cmd/peribolos/main_test.go
@@ -168,13 +168,15 @@ func TestOptions(t *testing.T) {
 }
 
 type fakeClient struct {
-	orgMembers sets.Set[string]
-	admins     sets.Set[string]
-	invitees   sets.Set[string]
-	members    sets.Set[string]
-	removed    sets.Set[string]
-	newAdmins  sets.Set[string]
-	newMembers sets.Set[string]
+	orgMembers      sets.Set[string]
+	admins          sets.Set[string]
+	invitees        sets.Set[string]
+	members         sets.Set[string]
+	removed         sets.Set[string]
+	newAdmins       sets.Set[string]
+	newMembers      sets.Set[string]
+	teams           []github.Team
+	enterpriseTeams map[string][]github.TeamMember // slug -> members
 }
 
 func (c *fakeClient) BotUser() (*github.UserData, error) {
@@ -254,7 +256,19 @@ func (c *fakeClient) UpdateOrgMembership(org, user string, admin bool) (*github.
 	}, nil
 }
 
+func (c *fakeClient) ListTeams(org string) ([]github.Team, error) {
+	for _, t := range c.teams {
+		if t.Name == "list-teams-fail" {
+			return nil, fmt.Errorf("injected ListTeams error")
+		}
+	}
+	return c.teams, nil
+}
+
 func (c *fakeClient) ListTeamMembersBySlug(org, teamSlug, role string) ([]github.TeamMember, error) {
+	if members, ok := c.enterpriseTeams[teamSlug]; ok {
+		return members, nil
+	}
 	if teamSlug != configuredTeamSlug {
 		return nil, fmt.Errorf("only team: %s supported, not %s", configuredTeamSlug, teamSlug)
 	}
@@ -478,16 +492,18 @@ func TestConfigureMembers(t *testing.T) {
 
 func TestConfigureOrgMembers(t *testing.T) {
 	cases := []struct {
-		name        string
-		opt         options
-		config      org.Config
-		admins      []string
-		members     []string
-		invitations []string
-		err         bool
-		remove      []string
-		addAdmins   []string
-		addMembers  []string
+		name            string
+		opt             options
+		config          org.Config
+		admins          []string
+		members         []string
+		invitations     []string
+		teams           []github.Team
+		enterpriseTeams map[string][]github.TeamMember
+		err             bool
+		remove          []string
+		addAdmins       []string
+		addMembers      []string
 	}{
 		{
 			name: "too few admins",
@@ -652,16 +668,88 @@ func TestConfigureOrgMembers(t *testing.T) {
 			},
 			invitations: []string{"invited-admin", "invited-member"},
 		},
+		{
+			name: "enterprise team members excluded from removal",
+			config: org.Config{
+				Admins:  []string{"keep-admin"},
+				Members: []string{"keep-member"},
+			},
+			opt: options{
+				maximumDelta:          0.5,
+				ignoreEnterpriseTeams: true,
+			},
+			admins:  []string{"keep-admin", "ent-user"},
+			members: []string{"keep-member", "ent-user2"},
+			teams: []github.Team{
+				{Name: "org-team", Slug: "org-team", Type: "organization"},
+				{Name: "ent-security", Slug: "ent-security", Type: github.TeamTypeEnterprise},
+			},
+			enterpriseTeams: map[string][]github.TeamMember{
+				"ent-security": {{Login: "ent-user"}, {Login: "ent-user2"}},
+			},
+		},
+		{
+			name: "enterprise team members not excluded without flag",
+			config: org.Config{
+				Admins:  []string{"keep-admin"},
+				Members: []string{"keep-member"},
+			},
+			opt: options{
+				maximumDelta: 0.5,
+			},
+			admins:  []string{"keep-admin", "ent-user"},
+			members: []string{"keep-member"},
+			remove:  []string{"ent-user"},
+		},
+		{
+			name: "enterprise member also in config is kept with configured role",
+			config: org.Config{
+				Admins:  []string{"keep-admin"},
+				Members: []string{"keep-member", "ent-user"},
+			},
+			opt: options{
+				maximumDelta:          0.5,
+				ignoreEnterpriseTeams: true,
+			},
+			admins:  []string{"keep-admin", "ent-user"},
+			members: []string{"keep-member"},
+			teams: []github.Team{
+				{Name: "ent-security", Slug: "ent-security", Type: github.TeamTypeEnterprise},
+			},
+			enterpriseTeams: map[string][]github.TeamMember{
+				"ent-security": {{Login: "ent-user"}},
+			},
+			addMembers: []string{"ent-user"},
+		},
+		{
+			name: "ListTeams error fails configureOrgMembers",
+			config: org.Config{
+				Admins:  []string{"keep-admin"},
+				Members: []string{"keep-member"},
+			},
+			opt: options{
+				maximumDelta:          0.5,
+				ignoreEnterpriseTeams: true,
+			},
+			admins:  []string{"keep-admin"},
+			members: []string{"keep-member"},
+			teams: []github.Team{
+				{Name: "list-teams-fail"},
+			},
+			err: true,
+		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			fc := &fakeClient{
-				admins:     sets.New[string](tc.admins...),
-				members:    sets.New[string](tc.members...),
-				removed:    sets.Set[string]{},
-				newAdmins:  sets.Set[string]{},
-				newMembers: sets.Set[string]{},
+				admins:          sets.New[string](tc.admins...),
+				members:         sets.New[string](tc.members...),
+				removed:         sets.Set[string]{},
+				newAdmins:       sets.Set[string]{},
+				newMembers:      sets.Set[string]{},
+				teams:           tc.teams,
+				enterpriseTeams: tc.enterpriseTeams,
 			}
 
 			err := configureOrgMembers(tc.opt, fc, fakeOrg, tc.config, sets.New[string](tc.invitations...))
@@ -840,15 +928,16 @@ func TestConfigureTeams(t *testing.T) {
 	desc := "so interesting"
 	priv := org.Secret
 	cases := []struct {
-		name              string
-		err               bool
-		orgNameOverride   string
-		ignoreSecretTeams bool
-		config            org.Config
-		teams             []github.Team
-		expected          map[string]github.Team
-		deleted           []string
-		delta             float64
+		name                  string
+		err                   bool
+		orgNameOverride       string
+		ignoreSecretTeams     bool
+		ignoreEnterpriseTeams bool
+		config                org.Config
+		teams                 []github.Team
+		expected              map[string]github.Team
+		deleted               []string
+		delta                 float64
 	}{
 		{
 			name: "do nothing without error",
@@ -1036,6 +1125,42 @@ func TestConfigureTeams(t *testing.T) {
 			deleted:  []string{"closed"},
 			delta:    1,
 		},
+		{
+			name:                  "skip enterprise teams when flag is set",
+			ignoreEnterpriseTeams: true,
+			teams: []github.Team{
+				{
+					Name: "org-team",
+					Slug: "org-team",
+					ID:   1,
+				},
+				{
+					Name: "ent-security",
+					Slug: "ent-security",
+					ID:   2,
+					Type: github.TeamTypeEnterprise,
+				},
+			},
+			config:   org.Config{Teams: map[string]org.Team{}},
+			expected: map[string]github.Team{},
+			deleted:  []string{"org-team"},
+			delta:    1,
+		},
+		{
+			name: "enterprise teams treated as normal without flag",
+			teams: []github.Team{
+				{
+					Name: "ent-security",
+					Slug: "ent-security",
+					ID:   2,
+					Type: github.TeamTypeEnterprise,
+				},
+			},
+			config:   org.Config{Teams: map[string]org.Team{}},
+			expected: map[string]github.Team{},
+			deleted:  []string{"ent-security"},
+			delta:    1,
+		},
 	}
 
 	for _, tc := range cases {
@@ -1051,7 +1176,7 @@ func TestConfigureTeams(t *testing.T) {
 			if tc.delta == 0 {
 				tc.delta = 1
 			}
-			actual, err := configureTeams(fc, orgName, tc.config, tc.delta, tc.ignoreSecretTeams)
+			actual, err := configureTeams(fc, orgName, tc.config, tc.delta, tc.ignoreSecretTeams, tc.ignoreEnterpriseTeams)
 			switch {
 			case err != nil:
 				if !tc.err {
@@ -1729,14 +1854,15 @@ func TestDumpOrgConfig(t *testing.T) {
 	repoHomepage := "https://www.somewhe.re/something/"
 	master := "master-branch"
 	cases := []struct {
-		name              string
-		orgOverride       string
-		ignoreSecretTeams bool
-		meta              github.Organization
-		members           []string
-		admins            []string
-		teams             []github.Team
-		teamMembers       map[string][]string
+		name                  string
+		orgOverride           string
+		ignoreSecretTeams     bool
+		ignoreEnterpriseTeams bool
+		meta                  github.Organization
+		members               []string
+		admins                []string
+		teams                 []github.Team
+		teamMembers           map[string][]string
 		maintainers       map[string][]string
 		repoPermissions   map[string][]github.Repo
 		repos             []github.FullRepo
@@ -2026,6 +2152,69 @@ func TestDumpOrgConfig(t *testing.T) {
 				Repos:   map[string]org.Repo{},
 			},
 		},
+		{
+			name:                  "skips enterprise teams when flag is set",
+			ignoreEnterpriseTeams: true,
+			meta: github.Organization{
+				Name:                         hello,
+				MembersCanCreateRepositories: yes,
+				DefaultRepositoryPermission:  string(perm),
+			},
+			members: []string{"george"},
+			admins:  []string{"admin"},
+			teams: []github.Team{
+				{
+					ID:          5,
+					Slug:        "team-5",
+					Name:        "friends",
+					Description: details,
+				},
+				{
+					ID:   9,
+					Slug: "ent-security",
+					Name: "ent-security",
+					Type: github.TeamTypeEnterprise,
+				},
+			},
+			teamMembers: map[string][]string{
+				"team-5": {"george"},
+			},
+			maintainers: map[string][]string{
+				"team-5": {},
+			},
+			repoPermissions: map[string][]github.Repo{
+				"team-5": {},
+			},
+			expected: org.Config{
+				Metadata: org.Metadata{
+					Name:                         &hello,
+					BillingEmail:                 &empty,
+					Company:                      &empty,
+					Email:                        &empty,
+					Description:                  &empty,
+					Location:                     &empty,
+					HasOrganizationProjects:      &no,
+					HasRepositoryProjects:        &no,
+					DefaultRepositoryPermission:  &perm,
+					MembersCanCreateRepositories: &yes,
+				},
+				Teams: map[string]org.Team{
+					"friends": {
+						TeamMetadata: org.TeamMetadata{
+							Description: &details,
+							Privacy:     &pub,
+						},
+						Members:     []string{"george"},
+						Maintainers: []string{},
+						Children:    map[string]org.Team{},
+						Repos:       map[string]github.RepoPermissionLevel{},
+					},
+				},
+				Members: []string{"george"},
+				Admins:  []string{"admin"},
+				Repos:   map[string]org.Repo{},
+			},
+		},
 	}
 
 	for _, tc := range cases {
@@ -2045,7 +2234,7 @@ func TestDumpOrgConfig(t *testing.T) {
 				repoPermissions: tc.repoPermissions,
 				repos:           tc.repos,
 			}
-			actual, err := dumpOrgConfig(fc, orgName, tc.ignoreSecretTeams, "")
+			actual, err := dumpOrgConfig(fc, orgName, tc.ignoreSecretTeams, tc.ignoreEnterpriseTeams, "")
 			switch {
 			case err != nil:
 				if !tc.err {

--- a/pkg/github/types.go
+++ b/pkg/github/types.go
@@ -1109,6 +1109,9 @@ const (
 	PrivacySecret = "secret"
 	// PrivacyClosed memberships are visible to org members.
 	PrivacyClosed = "closed"
+
+	// TeamTypeEnterprise identifies teams managed at the enterprise level.
+	TeamTypeEnterprise = "enterprise"
 )
 
 // Team is a github organizational team
@@ -1118,6 +1121,7 @@ type Team struct {
 	Slug         string         `json:"slug"`
 	Description  string         `json:"description,omitempty"`
 	Privacy      string         `json:"privacy,omitempty"`
+	Type         string         `json:"type,omitempty"`
 	Parent       *Team          `json:"parent,omitempty"`         // Only present in responses
 	ParentTeamID *int           `json:"parent_team_id,omitempty"` // Only valid in creates/edits
 	Permission   TeamPermission `json:"permission,omitempty"`


### PR DESCRIPTION
## Summary

GitHub Enterprise Teams (`type: "enterprise"`) are managed at the enterprise level and cannot be modified via the org-level API. When an enterprise team is assigned to an org, peribolos fails in two ways:

1. **Team reconciliation (422):** Peribolos sees the enterprise team in `GET /orgs/{org}/teams`, doesn't find it in the config, and tries to delete it. The API rejects the operation with `422 Unprocessable Entity`.
2. **Member reconciliation (403):** Enterprise team members are injected into the org membership. Peribolos tries to remove them (not in config) and gets `403 Forbidden` because enterprise-granted membership can't be revoked at the org level.

This PR adds an `--ignore-enterprise-teams` flag that filters enterprise teams from all reconciliation paths:

- **`configureTeams`**: Enterprise teams are excluded from the teams map, so they are never deleted or updated
- **`dumpOrgConfig`**: Enterprise teams are excluded from the dumped config
- **`configureOrgMembers`**: Enterprise team members are collected and removed from the `have` set before diffing against `want`, so they never enter the removal set

Uses the `type` field from `GET /orgs/{org}/teams` to identify enterprise teams. The filtering is gated behind the flag to avoid changing default behavior.

## Changes

- `pkg/github/types.go` – Add `TeamTypeEnterprise` constant and `Type` field to `Team` struct
- `cmd/peribolos/main.go` – Add `--ignore-enterprise-teams` flag; filter enterprise teams in `configureTeams`, `dumpOrgConfig`, and `configureOrgMembers`; expand `orgClient` interface with `ListTeams` and `ListTeamMembersBySlug`
- `cmd/peribolos/main_test.go` – Add 7 test cases covering flag-on filtering, flag-off pass-through, role reconciliation for dual members, error propagation, and dump filtering

>*Tests were written with AI assistance (Claude Code), as well as the description summary.*
