### PR TITLE
feat(peribolos): clean up failed org invitations before re-inviting

### DIFF
--- a/cmd/peribolos/main.go
+++ b/cmd/peribolos/main.go
@@ -44,27 +44,27 @@ const (
 )
 
 type options struct {
-	config            string
-	confirm           bool
-	dump              string
-	dumpFull          bool
-	maximumDelta      float64
-	minAdmins         int
-	requireSelf       bool
-	requiredAdmins    flagutil.Strings
-	fixOrg            bool
-	fixOrgMembers     bool
-	fixTeamMembers    bool
-	fixTeams          bool
-	fixTeamRepos      bool
-	fixRepos          bool
-	fixCollaborators  bool
+	config                string
+	confirm               bool
+	dump                  string
+	dumpFull              bool
+	maximumDelta          float64
+	minAdmins             int
+	requireSelf           bool
+	requiredAdmins        flagutil.Strings
+	fixOrg                bool
+	fixOrgMembers         bool
+	fixTeamMembers        bool
+	fixTeams              bool
+	fixTeamRepos          bool
+	fixRepos              bool
+	fixCollaborators      bool
 	ignoreInvitees        bool
 	ignoreSecretTeams     bool
 	ignoreEnterpriseTeams bool
-	allowRepoArchival bool
-	allowRepoPublish  bool
-	github            flagutil.GitHubOptions
+	allowRepoArchival     bool
+	allowRepoPublish      bool
+	github                flagutil.GitHubOptions
 
 	logLevel string
 }
@@ -397,6 +397,7 @@ func dumpOrgConfig(client dumpClient, orgName string, ignoreSecretTeams bool, ig
 
 type orgClient interface {
 	BotUser() (*github.UserData, error)
+	DeleteOrgInvitation(org string, invitationID int) error
 	ListOrgMembers(org, role string) ([]github.TeamMember, error)
 	ListTeams(org string) ([]github.Team, error)
 	ListTeamMembersBySlug(org, teamSlug, role string) ([]github.TeamMember, error)
@@ -404,7 +405,7 @@ type orgClient interface {
 	UpdateOrgMembership(org, user string, admin bool) (*github.OrgMembership, error)
 }
 
-func configureOrgMembers(opt options, client orgClient, orgName string, orgConfig org.Config, invitees sets.Set[string]) error {
+func configureOrgMembers(opt options, client orgClient, orgName string, orgConfig org.Config, invitees sets.Set[string], failedInvites map[string][]int) error {
 	// Get desired state
 	wantAdmins := sets.New[string](orgConfig.Admins...)
 	wantMembers := sets.New[string](orgConfig.Members...)
@@ -518,6 +519,13 @@ func configureOrgMembers(opt options, client orgClient, orgName string, orgConfi
 		if invitees.Has(user) { // Do not add them, as this causes another invite.
 			logrus.Infof("Waiting for %s to accept invitation to %s", user, orgName)
 			return nil
+		}
+		for _, invID := range failedInvites[user] {
+			if err := client.DeleteOrgInvitation(orgName, invID); err != nil {
+				logrus.WithError(err).Warnf("DeleteOrgInvitation(%s, %d) failed", orgName, invID)
+			} else {
+				logrus.Infof("Cleared failed invitation %d for %s in %s", invID, user, orgName)
+			}
 		}
 		role := github.RoleMember
 		if super {
@@ -910,6 +918,32 @@ func orgInvitations(opt options, client inviteClient, orgName string) (sets.Set[
 	return invitees, nil
 }
 
+type failedInviteClient interface {
+	ListFailedOrgInvitations(org string) ([]github.OrgInvitation, error)
+}
+
+func orgFailedInvitations(opt options, client failedInviteClient, orgName string) (map[string][]int, error) {
+	// Unlike orgInvitations, this only considers fixOrgMembers — failed invitation cleanup
+	// is irrelevant to team member sync, which has no equivalent delete-then-reinvite flow.
+	if !opt.fixOrgMembers || opt.ignoreInvitees {
+		return nil, nil
+	}
+	is, err := client.ListFailedOrgInvitations(orgName)
+	if err != nil {
+		return nil, err
+	}
+	result := make(map[string][]int)
+	for _, i := range is {
+		if i.Login == "" {
+			continue
+		}
+		login := github.NormLogin(i.Login)
+		logrus.Infof("Found failed invitation for %s in %s (reason: %s, at: %s)", login, orgName, i.FailedReason, i.FailedAt)
+		result[login] = append(result[login], i.ID)
+	}
+	return result, nil
+}
+
 func configureOrg(opt options, client github.Client, orgName string, orgConfig org.Config) error {
 	// Ensure that metadata is configured correctly.
 	if !opt.fixOrg {
@@ -923,10 +957,15 @@ func configureOrg(opt options, client github.Client, orgName string, orgConfig o
 		return fmt.Errorf("failed to list %s invitations: %w", orgName, err)
 	}
 
+	failedInvites, err := orgFailedInvitations(opt, client, orgName)
+	if err != nil {
+		return fmt.Errorf("failed to list %s failed invitations: %w", orgName, err)
+	}
+
 	// Invite/remove/update members to the org.
 	if !opt.fixOrgMembers {
 		logrus.Infof("Skipping org member configuration")
-	} else if err := configureOrgMembers(opt, client, orgName, orgConfig, invitees); err != nil {
+	} else if err := configureOrgMembers(opt, client, orgName, orgConfig, invitees, failedInvites); err != nil {
 		return fmt.Errorf("failed to configure %s members: %w", orgName, err)
 	}
 

--- a/cmd/peribolos/main_test.go
+++ b/cmd/peribolos/main_test.go
@@ -171,6 +171,8 @@ type fakeClient struct {
 	orgMembers      sets.Set[string]
 	admins          sets.Set[string]
 	invitees        sets.Set[string]
+	failedInvites   map[string][]int // login -> invitation IDs
+	deletedInvites  []int
 	members         sets.Set[string]
 	removed         sets.Set[string]
 	newAdmins       sets.Set[string]
@@ -216,6 +218,31 @@ func (c *fakeClient) ListOrgInvitations(org string) ([]github.OrgInvitation, err
 		})
 	}
 	return ret, nil
+}
+
+func (c *fakeClient) ListFailedOrgInvitations(org string) ([]github.OrgInvitation, error) {
+	var ret []github.OrgInvitation
+	for login, ids := range c.failedInvites {
+		if login == "fail-list" {
+			return nil, errors.New("injected list failed org invitations failure")
+		}
+		for _, id := range ids {
+			ret = append(ret, github.OrgInvitation{
+				TeamMember:   github.TeamMember{Login: login},
+				ID:           id,
+				FailedReason: "2fa_required",
+			})
+		}
+	}
+	return ret, nil
+}
+
+func (c *fakeClient) DeleteOrgInvitation(org string, invitationID int) error {
+	if invitationID == -1 {
+		return errors.New("injected delete org invitation failure")
+	}
+	c.deletedInvites = append(c.deletedInvites, invitationID)
+	return nil
 }
 
 func (c *fakeClient) RemoveOrgMembership(org, user string) error {
@@ -498,12 +525,14 @@ func TestConfigureOrgMembers(t *testing.T) {
 		admins          []string
 		members         []string
 		invitations     []string
+		failedInvites   map[string][]int
 		teams           []github.Team
 		enterpriseTeams map[string][]github.TeamMember
 		err             bool
 		remove          []string
 		addAdmins       []string
 		addMembers      []string
+		deletedInvites  []int
 	}{
 		{
 			name: "too few admins",
@@ -738,6 +767,49 @@ func TestConfigureOrgMembers(t *testing.T) {
 			},
 			err: true,
 		},
+		{
+			name: "delete failed invite then re-invite",
+			config: org.Config{
+				Members: []string{"reinvite-me"},
+			},
+			failedInvites:  map[string][]int{"reinvite-me": {42}},
+			addMembers:     []string{"reinvite-me"},
+			deletedInvites: []int{42},
+		},
+		{
+			name: "delete all failed invites for same user then re-invite",
+			config: org.Config{
+				Members: []string{"reinvite-me"},
+			},
+			failedInvites:  map[string][]int{"reinvite-me": {42, 43}},
+			addMembers:     []string{"reinvite-me"},
+			deletedInvites: []int{42, 43},
+		},
+		{
+			name: "delete failed invite for admin role",
+			config: org.Config{
+				Admins: []string{"reinvite-admin"},
+			},
+			failedInvites:  map[string][]int{"reinvite-admin": {55}},
+			addAdmins:      []string{"reinvite-admin"},
+			deletedInvites: []int{55},
+		},
+		{
+			name: "delete failed invite failure still re-invites user",
+			config: org.Config{
+				Members: []string{"bad-delete"},
+			},
+			failedInvites: map[string][]int{"bad-delete": {-1}},
+			addMembers:    []string{"bad-delete"},
+		},
+		{
+			name: "pending invite takes precedence over failed invite",
+			config: org.Config{
+				Members: []string{"pending-and-failed"},
+			},
+			invitations:   []string{"pending-and-failed"},
+			failedInvites: map[string][]int{"pending-and-failed": {99}},
+		},
 	}
 
 	for _, tc := range cases {
@@ -750,9 +822,10 @@ func TestConfigureOrgMembers(t *testing.T) {
 				newMembers:      sets.Set[string]{},
 				teams:           tc.teams,
 				enterpriseTeams: tc.enterpriseTeams,
+				failedInvites:   tc.failedInvites,
 			}
 
-			err := configureOrgMembers(tc.opt, fc, fakeOrg, tc.config, sets.New[string](tc.invitations...))
+			err := configureOrgMembers(tc.opt, fc, fakeOrg, tc.config, sets.New[string](tc.invitations...), tc.failedInvites)
 			switch {
 			case err != nil:
 				if !tc.err {
@@ -767,10 +840,21 @@ func TestConfigureOrgMembers(t *testing.T) {
 					t.Errorf("Wrong members added: %v", err)
 				} else if err := cmpLists(tc.addAdmins, sets.List(fc.newAdmins)); err != nil {
 					t.Errorf("Wrong admins added: %v", err)
+				} else if err := cmpLists(intSliceToString(tc.deletedInvites), intSliceToString(fc.deletedInvites)); err != nil {
+					t.Errorf("Wrong invitations deleted: %v", err)
 				}
 			}
 		})
 	}
+}
+
+func intSliceToString(ints []int) []string {
+	var out []string
+	for _, i := range ints {
+		out = append(out, fmt.Sprintf("%d", i))
+	}
+	sort.Strings(out)
+	return out
 }
 
 type fakeTeamClient struct {
@@ -1863,11 +1947,11 @@ func TestDumpOrgConfig(t *testing.T) {
 		admins                []string
 		teams                 []github.Team
 		teamMembers           map[string][]string
-		maintainers       map[string][]string
-		repoPermissions   map[string][]github.Repo
-		repos             []github.FullRepo
-		expected          org.Config
-		err               bool
+		maintainers           map[string][]string
+		repoPermissions       map[string][]github.Repo
+		repos                 []github.FullRepo
+		expected              org.Config
+		err                   bool
 	}{
 		{
 			name:        "fails if GetOrg fails",
@@ -2454,6 +2538,82 @@ func TestOrgInvitations(t *testing.T) {
 				invitees: tc.invitees,
 			}
 			actual, err := orgInvitations(tc.opt, fc, "random-org")
+			switch {
+			case err != nil:
+				if !tc.err {
+					t.Errorf("unexpected error: %v", err)
+				}
+			case tc.err:
+				t.Errorf("failed to receive an error")
+			case !reflect.DeepEqual(actual, tc.expected):
+				t.Errorf("%#v != expected %#v", actual, tc.expected)
+			}
+		})
+	}
+}
+
+func TestOrgFailedInvitations(t *testing.T) {
+	cases := []struct {
+		name          string
+		opt           options
+		failedInvites map[string][]int
+		expected      map[string][]int
+		err           bool
+	}{
+		{
+			name:          "skip when fixOrgMembers is false",
+			failedInvites: map[string][]int{"him": {1}, "her": {2}},
+			expected:      nil,
+		},
+		{
+			name: "skip when ignoreInvitees is set",
+			opt: options{
+				fixOrgMembers:  true,
+				ignoreInvitees: true,
+			},
+			failedInvites: map[string][]int{"him": {1}},
+			expected:      nil,
+		},
+		{
+			name: "returns failed invitations when fixOrgMembers",
+			opt: options{
+				fixOrgMembers: true,
+			},
+			failedInvites: map[string][]int{"him": {1}, "her": {2}},
+			expected:      map[string][]int{"him": {1}, "her": {2}},
+		},
+		{
+			name: "collects multiple failed invitations for same user",
+			opt: options{
+				fixOrgMembers: true,
+			},
+			failedInvites: map[string][]int{"him": {1, 2}},
+			expected:      map[string][]int{"him": {1, 2}},
+		},
+		{
+			name: "normalizes login case",
+			opt: options{
+				fixOrgMembers: true,
+			},
+			failedInvites: map[string][]int{"MiXeD": {3}, "UPPER": {4}},
+			expected:      map[string][]int{"mixed": {3}, "upper": {4}},
+		},
+		{
+			name: "error if list fails",
+			opt: options{
+				fixOrgMembers: true,
+			},
+			failedInvites: map[string][]int{"fail-list": {0}},
+			err:           true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fc := &fakeClient{
+				failedInvites: tc.failedInvites,
+			}
+			actual, err := orgFailedInvitations(tc.opt, fc, "random-org")
 			switch {
 			case err != nil:
 				if !tc.err {

--- a/pkg/github/client.go
+++ b/pkg/github/client.go
@@ -67,6 +67,8 @@ type OrganizationClient interface {
 	GetOrg(name string) (*Organization, error)
 	EditOrg(name string, config Organization) (*Organization, error)
 	ListOrgInvitations(org string) ([]OrgInvitation, error)
+	ListFailedOrgInvitations(org string) ([]OrgInvitation, error)
+	DeleteOrgInvitation(org string, invitationID int) error
 	ListOrgMembers(org, role string) ([]TeamMember, error)
 	HasPermission(org, repo, user string, roles ...string) (bool, error)
 	GetUserPermission(org, repo, user string) (string, error)
@@ -1520,6 +1522,50 @@ func (c *client) ListOrgInvitations(org string) ([]OrgInvitation, error) {
 		return nil, err
 	}
 	return ret, nil
+}
+
+// ListFailedOrgInvitations lists failed invitations to the org.
+//
+// https://docs.github.com/en/rest/orgs/members#list-failed-organization-invitations
+func (c *client) ListFailedOrgInvitations(org string) ([]OrgInvitation, error) {
+	c.log("ListFailedOrgInvitations", org)
+	if c.fake {
+		return nil, nil
+	}
+	path := fmt.Sprintf("/orgs/%s/failed_invitations", org)
+	var ret []OrgInvitation
+	err := c.readPaginatedResults(
+		path,
+		acceptNone,
+		org,
+		func() interface{} {
+			return &[]OrgInvitation{}
+		},
+		func(obj interface{}) {
+			ret = append(ret, *(obj.(*[]OrgInvitation))...)
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+	return ret, nil
+}
+
+// DeleteOrgInvitation deletes a pending or failed organization invitation.
+//
+// https://docs.github.com/en/rest/orgs/members#cancel-an-organization-invitation
+func (c *client) DeleteOrgInvitation(org string, invitationID int) error {
+	c.log("DeleteOrgInvitation", org, invitationID)
+	if c.dry {
+		return nil
+	}
+	_, err := c.request(&request{
+		method:    http.MethodDelete,
+		path:      fmt.Sprintf("/orgs/%s/invitations/%d", org, invitationID),
+		org:       org,
+		exitCodes: []int{204, 404},
+	}, nil)
+	return err
 }
 
 // ListCurrentUserRepoInvitations lists pending invitations for the authenticated user.

--- a/pkg/github/types.go
+++ b/pkg/github/types.go
@@ -1195,8 +1195,11 @@ type TeamMembership struct {
 // OrgInvitation contains Login and other details about the invitation.
 type OrgInvitation struct {
 	TeamMember
-	Email   string     `json:"email"`
-	Inviter TeamMember `json:"inviter"`
+	ID           int        `json:"id"`
+	Email        string     `json:"email"`
+	Inviter      TeamMember `json:"inviter"`
+	FailedAt     time.Time  `json:"failed_at,omitempty"`
+	FailedReason string     `json:"failed_reason,omitempty"`
 }
 
 // UserRepoInvitation is returned by repo invitation obtained by user.


### PR DESCRIPTION
## Summary

- Adds `ListFailedOrgInvitations` and `DeleteOrgInvitation` to the `OrganizationClient` interface and implementation, using GitHub's `GET /orgs/{org}/failed_invitations` and `DELETE /orgs/{org}/invitations/{id}` endpoints
- Peribolos now fetches all failed invitations once per org run and, when about to re-invite a user, clears all their failed invitation records first so the new invite isn't immediately blocked
- Delete failures warn but do not abort the sync or prevent the re-invite — the user gets a fresh invitation regardless

## Test plan

- [x] `go build ./cmd/peribolos/... ./pkg/github/...` passes
- [x] `go test ./cmd/peribolos/... ./pkg/github/...` passes — includes `TestOrgFailedInvitations` (6 cases) and 5 new cases in `TestConfigureOrgMembers` covering single/multiple failed invites, admin role, delete failure, and pending-takes-precedence
- [x] `go vet ./cmd/peribolos/... ./pkg/github/...` passes