### PR TITLE
spyglass: validate bucket in ResolveSymlink to prevent SSRF

### DIFF
--- a/pkg/spyglass/spyglass.go
+++ b/pkg/spyglass/spyglass.go
@@ -191,6 +191,10 @@ func (sg *Spyglass) ResolveSymlink(src string) (string, error) {
 		if bucket, exists := sg.cfg().Deck.Spyglass.BucketAliases[potentialAlias]; exists {
 			key = strings.Replace(key, potentialAlias, bucket, 1)
 		}
+		bucket := strings.Split(key, "/")[0]
+		if err := sg.cfg().ValidateStorageBucket(bucket); err != nil {
+			return "", fmt.Errorf("refusing to resolve symlink in disallowed bucket %q: %w", bucket, err)
+		}
 		reader, err := sg.opener.Reader(context.TODO(), fmt.Sprintf("%s://%s.txt", keyType, key))
 		if err != nil {
 			if pkgio.IsNotExist(err) {


### PR DESCRIPTION
# spyglass: validate bucket in ResolveSymlink to prevent SSRF

## What this PR does

Adds a `ValidateStorageBucket` check in `ResolveSymlink` before calling `opener.Reader()`, preventing unauthenticated users from reading arbitrary `.txt` files from any bucket
accessible by Prow's IAM role.

## Why

`ResolveSymlink` takes a user-controlled path from the `/view/` endpoint and directly fetches `<path>.txt` from cloud storage using Prow's credentials — with no bucket validation. Other code paths (e.g., `StorageArtifactFetcher`, other deck handlers) already call `ValidateStorageBucket` or `validateStoragePath`, but this path was missed.

This is a confused deputy / SSRF issue: any unauthenticated user can instruct Prow to call `s3:GetObject` or the GCS equivalent on any `.txt` file in any bucket the IAM role can
access.

Originally reported as kubernetes/test-infra#27333. The initial fix (kubernetes/test-infra#27249) did not address the root cause since validation was not added before or within
`ResolveSymlink`.

## What changed

One-line validation added in `pkg/spyglass/spyglass.go` — after bucket alias resolution, before the `opener.Reader()` call:

```go
bucket := strings.Split(key, "/")[0]
if err := sg.cfg().ValidateStorageBucket(bucket); err != nil {
   return "", fmt.Errorf("refusing to resolve symlink in disallowed bucket %q: %w", bucket, err)
}
```

How to test

1. Configure Prow with a restricted AllKnownStorageBuckets list
2. Request /view/s3/disallowed-bucket/some-path — should now return an error
3. Request /view/s3/allowed-bucket/some-path — should work as before

/area deck
/area spyglass
/kind bug
