### PR TITLE
buildlog: fail gracefully on large build logs

### DIFF
--- a/pkg/spyglass/lenses/buildlog/buildlog.css
+++ b/pkg/spyglass/lenses/buildlog/buildlog.css
@@ -136,6 +136,18 @@ html {
   background: #42425A;
 }
 
+.log-error {
+  color: #c23621;
+  padding: 8px 12px;
+  margin: 4px 0;
+}
+
+.log-warning {
+  color: #adad27;
+  padding: 8px 12px;
+  margin: 4px 0;
+}
+
 /* ansi colors from https://en.wikipedia.org/wiki/ANSI_escape_code#Colors */
 .ansi-0 { color: #000000; }  /* Black */
 .ansi-1 { color: #c23621; }  /* Red */

--- a/pkg/spyglass/lenses/buildlog/lens.go
+++ b/pkg/spyglass/lenses/buildlog/lens.go
@@ -45,6 +45,8 @@ const (
 	priority        = 10
 	neighborLines   = 5 // number of "important" lines to be displayed in either direction
 	minLinesSkipped = 5
+
+	highlightSizeThreshold = 10 * 1024 * 1024 // 10 MiB
 )
 
 var defaultHighlightLineLengthMax = 10000 // Default maximum length of a line worth highlighting
@@ -161,6 +163,8 @@ type LogArtifactView struct {
 	ShowRawLog   bool
 	CanSave      bool
 	CanAnalyze   bool
+	Error        string
+	Warning      string
 }
 
 // buildLogsView holds each log file view
@@ -224,8 +228,24 @@ func (lens Lens) Body(artifacts []api.Artifact, resourceDir string, data string,
 		lines, err := logLinesAll(a)
 		if err != nil {
 			logrus.WithError(err).Info("Error reading log.")
+			av.Error = fmt.Sprintf("Failed to read log: %v", err)
+			buildLogsView.LogViews = append(buildLogsView.LogViews, av)
 			continue
 		}
+
+		// For large logs, skip regex highlighting to avoid excessive CPU usage.
+		// Lines are still rendered and grouped, just without colored highlights.
+		highlightRegex := conf.highlightRegex
+		sz, err := a.Size()
+		if err != nil {
+			logrus.WithError(err).Warn("Could not determine artifact size, disabling highlighting as a precaution.")
+			highlightRegex = nil
+			av.Warning = "Syntax highlighting disabled (unable to determine log size)"
+		} else if sz > highlightSizeThreshold {
+			highlightRegex = nil
+			av.Warning = "Syntax highlighting disabled (log exceeds 10 MiB)"
+		}
+
 		artifact := av.ArtifactName
 		meta, _ := a.Metadata()
 		start, end := -1, -1
@@ -255,7 +275,7 @@ func (lens Lens) Body(artifacts []api.Artifact, resourceDir string, data string,
 				start, end = resp.Min, resp.Max
 			}
 		}
-		av.LineGroups = groupLines(&artifact, start, end, highlightLines(lines, 0, &artifact, conf.highlightRegex, conf.highlightLengthMax)...)
+		av.LineGroups = groupLines(&artifact, start, end, highlightLines(lines, 0, &artifact, highlightRegex, conf.highlightLengthMax)...)
 		av.ViewAll = true
 		av.CanSave = canSave(a.CanonicalLink())
 		av.CanAnalyze = analyze
@@ -505,7 +525,7 @@ func highlightLines(lines []string, startLine int, artifact *string, highlightRe
 	for i, text := range lines {
 		length := len(text)
 		subLines := []SubLine{}
-		if length <= maxLen {
+		if highlightRegex != nil && length <= maxLen {
 			loc := highlightRegex.FindStringIndex(text)
 			for loc != nil {
 				subLines = append(subLines, SubLine{false, text[:loc[0]]})

--- a/pkg/spyglass/lenses/buildlog/lens_test.go
+++ b/pkg/spyglass/lenses/buildlog/lens_test.go
@@ -1133,6 +1133,97 @@ func testHighlighter(t *testing.T, wantReq highlightRequest, code int, response 
 	})
 }
 
+type errArtifact struct {
+	fake.Artifact
+	readAllErr   error
+	sizeOverride *int64
+	sizeErr      error
+}
+
+func (ea *errArtifact) ReadAll() ([]byte, error) {
+	if ea.readAllErr != nil {
+		return nil, ea.readAllErr
+	}
+	return ea.Artifact.ReadAll()
+}
+
+func (ea *errArtifact) Size() (int64, error) {
+	if ea.sizeErr != nil {
+		return 0, ea.sizeErr
+	}
+	if ea.sizeOverride != nil {
+		return *ea.sizeOverride, nil
+	}
+	return ea.Artifact.Size()
+}
+
+func TestBodyReadAllError(t *testing.T) {
+	art := &errArtifact{
+		Artifact: fake.Artifact{
+			Path:    "build-log.txt",
+			Content: []byte("content"),
+		},
+		readAllErr: fmt.Errorf("file size over specified limit"),
+	}
+	got := Lens{}.Body([]api.Artifact{art}, ".", "", nil, prowconfig.Spyglass{})
+	if !strings.Contains(got, "Failed to read log") {
+		t.Errorf("Body() should render an error message when ReadAll fails, got: %s", got[:min(200, len(got))])
+	}
+	if !strings.Contains(got, "file size over specified limit") {
+		t.Errorf("Body() should include the underlying error, got: %s", got[:min(200, len(got))])
+	}
+	if !strings.Contains(got, "build-log.txt") {
+		t.Errorf("Body() should still reference the artifact name, got: %s", got[:min(200, len(got))])
+	}
+}
+
+func TestBodyLargeLogSkipsHighlight(t *testing.T) {
+	largeSize := int64(highlightSizeThreshold + 1)
+	art := &errArtifact{
+		Artifact: fake.Artifact{
+			Path:    "build-log.txt",
+			Content: []byte("line one\nERROR: something failed\nline three\n"),
+		},
+		sizeOverride: &largeSize,
+	}
+	got := Lens{}.Body([]api.Artifact{art}, ".", "", nil, prowconfig.Spyglass{})
+	if strings.Contains(got, "log-error") {
+		t.Error("Body() should not render an error for large but readable logs")
+	}
+	if !strings.Contains(got, "line one") {
+		t.Error("Body() should still render log content for large logs")
+	}
+	if !strings.Contains(got, "log-warning") {
+		t.Error("Body() should render a warning when highlighting is disabled due to size")
+	}
+	if !strings.Contains(got, "Syntax highlighting disabled") {
+		t.Error("Body() warning should mention highlighting is disabled")
+	}
+}
+
+func TestBodySizeErrorDisablesHighlight(t *testing.T) {
+	art := &errArtifact{
+		Artifact: fake.Artifact{
+			Path:    "build-log.txt",
+			Content: []byte("line one\nERROR: something failed\nline three\n"),
+		},
+		sizeErr: fmt.Errorf("network timeout"),
+	}
+	got := Lens{}.Body([]api.Artifact{art}, ".", "", nil, prowconfig.Spyglass{})
+	if strings.Contains(got, "log-error") {
+		t.Error("Body() should not render an error when only Size() fails")
+	}
+	if !strings.Contains(got, "line one") {
+		t.Error("Body() should still render log content when Size() fails")
+	}
+	if !strings.Contains(got, "log-warning") {
+		t.Error("Body() should render a warning when Size() fails")
+	}
+	if !strings.Contains(got, "unable to determine log size") {
+		t.Error("Body() warning should mention inability to determine size")
+	}
+}
+
 func BenchmarkHighlightLines(b *testing.B) {
 	lorem := []string{
 		"Lorem ipsum dolor sit amet",

--- a/pkg/spyglass/lenses/buildlog/template.html
+++ b/pkg/spyglass/lenses/buildlog/template.html
@@ -9,6 +9,8 @@
     {{if .CanAnalyze}}<button class="analyze-button" data-artifact="{{$log.ArtifactName}}" title="Highlight interesting lines identified by prow">Analyze</button>{{end}}
     <button class="show-all-button" data-artifact="{{$log.ArtifactName}}">Show all hidden lines</button>
     {{if .ShowRawLog}}<a href="{{$log.ArtifactLink}}" style="padding-left:15px;">Raw {{$log.ArtifactName}}<i class="material-icons" style="padding-left: 3px;">open_in_new</i></a>{{end}}
+    {{if .Error}}<div class="log-error">{{.Error}}</div>{{end}}
+    {{if .Warning}}<div class="log-warning">{{.Warning}}</div>{{end}}
     <div class="loglines{{if .CanSave}} savable{{end}}" id="{{$log.ArtifactName}}-content">
       {{block "line groups" $log.LineGroups}}
       {{range . }}


### PR DESCRIPTION
Large build logs cause the buildlog lens to hang. ReadAll() succeeds but highlightLines() regex matching is too expensive. The frontend shows a spinner forever. Additionally, when ReadAll() fails, the lens silently skips the artifact with no user-facing output.

Changes:
- Skip regex highlighting for artifacts larger than 10 MiB (lines still render)
- Show errors in the UI when ReadAll() fails instead of silent continue
- Add nil-regex guard in highlightLines()
- Log and disable highlighting when Size() returns an error, as the artifact may be too large to highlight safely
- Show a warning banner in the UI when highlighting is disabled

Fixes #176