### PR TITLE
generic-autobumper: add GitHub App authentication support

### DIFF
--- a/cmd/generic-autobumper/bumper/bumper.go
+++ b/cmd/generic-autobumper/bumper/bumper.go
@@ -32,6 +32,7 @@ import (
 
 	"sigs.k8s.io/prow/cmd/generic-autobumper/updater"
 	"sigs.k8s.io/prow/pkg/config/secret"
+	"sigs.k8s.io/prow/pkg/flagutil"
 	"sigs.k8s.io/prow/pkg/github"
 )
 
@@ -74,6 +75,12 @@ type Options struct {
 	HeadBranchName string `json:"headBranchName"`
 	// Optional list of labels to add to the bump PR
 	Labels []string `json:"labels"`
+	// PRSourceMode controls how the PR branch is pushed: "fork" (PAT, legacy) or "branch" (App auth, push directly to org/repo).
+	// If empty, auto-detected based on available credentials.
+	PRSourceMode string `json:"prSourceMode"`
+	// GitHubOptions provides standard Prow GitHub auth flags. When set and containing app credentials,
+	// takes precedence over GitHubToken. Not serialized from YAML -- populated from CLI flags.
+	GitHubOptions *flagutil.GitHubOptions `json:"-"`
 }
 
 // Information needed for gerrit bump
@@ -146,19 +153,45 @@ func (gc GitCommand) getCommand() string {
 	return fmt.Sprintf("%s %s", gc.baseCommand, strings.Join(gc.buildCommand(), " "))
 }
 
+// resolvedPRSourceMode returns the effective PR source mode. If not explicitly
+// set, it auto-detects based on available credentials: "branch" when GitHub App
+// credentials are present, "fork" otherwise.
+func (o *Options) resolvedPRSourceMode() string {
+	if o.PRSourceMode != "" {
+		return o.PRSourceMode
+	}
+	if o.GitHubOptions != nil && o.GitHubOptions.AppID != "" {
+		return "branch"
+	}
+	return "fork"
+}
+
 func validateOptions(o *Options) error {
 	if !o.SkipPullRequest && o.Gerrit == nil {
-		if o.GitHubToken == "" {
-			return fmt.Errorf("gitHubToken is mandatory when skipPullRequest is false or unspecified")
+		mode := o.resolvedPRSourceMode()
+		switch mode {
+		case "branch":
+			if o.GitHubOptions == nil || o.GitHubOptions.AppID == "" {
+				return fmt.Errorf("--pr-source-mode=branch requires --github-app-id and --github-app-private-key-path")
+			}
+			if err := o.GitHubOptions.Validate(false); err != nil {
+				return fmt.Errorf("invalid GitHub options: %w", err)
+			}
+		case "fork":
+			if o.GitHubToken == "" {
+				return fmt.Errorf("gitHubToken is mandatory when skipPullRequest is false or unspecified")
+			}
+			if o.RemoteName == "" {
+				return fmt.Errorf("remoteName is mandatory when skipPullRequest is false or unspecified")
+			}
+		default:
+			return fmt.Errorf("invalid pr-source-mode %q, expected one of: fork, branch", mode)
 		}
 		if (o.GitEmail == "") != (o.GitName == "") {
 			return fmt.Errorf("gitName and gitEmail must be specified together")
 		}
 		if o.GitHubOrg == "" || o.GitHubRepo == "" {
 			return fmt.Errorf("gitHubOrg and gitHubRepo are mandatory when skipPullRequest is false or unspecified")
-		}
-		if o.RemoteName == "" {
-			return fmt.Errorf("remoteName is mandatory when skipPullRequest is false or unspecified")
 		}
 	}
 	if !o.SkipPullRequest && o.Gerrit != nil {
@@ -196,10 +229,13 @@ func Run(ctx context.Context, o *Options, prh PRHandler) error {
 	if o.SkipPullRequest {
 		logrus.Debugf("--skip-pull-request is set to true, won't create a pull request.")
 	}
-	if o.Gerrit == nil {
-		return processGitHub(ctx, o, prh)
+	if o.Gerrit != nil {
+		return processGerrit(ctx, o, prh)
 	}
-	return processGerrit(ctx, o, prh)
+	if o.resolvedPRSourceMode() == "branch" {
+		return processGitHubAppAuth(ctx, o, prh)
+	}
+	return processGitHub(ctx, o, prh)
 }
 
 func processGitHub(ctx context.Context, o *Options, prh PRHandler) error {
@@ -274,6 +310,102 @@ func processGitHub(ctx context.Context, o *Options, prh PRHandler) error {
 		return fmt.Errorf("to create the PR: %w", err)
 	}
 	return nil
+}
+
+// processGitHubAppAuth handles the GitHub App authentication flow. It uses
+// flagutil.GitHubOptions to construct the GitHub API client and GitClientFactory
+// to push branches directly to the upstream repository (no fork needed).
+func processGitHubAppAuth(ctx context.Context, o *Options, prh PRHandler) error {
+	stdout := HideSecretsWriter{Delegate: os.Stdout, Censor: secret.Censor}
+	stderr := HideSecretsWriter{Delegate: os.Stderr, Censor: secret.Censor}
+
+	gc, err := o.GitHubOptions.GitHubClient(false)
+	if err != nil {
+		return fmt.Errorf("construct GitHub client: %w", err)
+	}
+
+	if o.GitName == "" || o.GitEmail == "" {
+		user, err := gc.BotUser()
+		if err != nil {
+			return fmt.Errorf("get bot user: %w", err)
+		}
+		login := user.Login
+		if !strings.HasSuffix(login, "[bot]") {
+			login += "[bot]"
+		}
+		if o.GitName == "" {
+			o.GitName = login
+		}
+		if o.GitEmail == "" {
+			o.GitEmail = login + "@users.noreply.github.com"
+		}
+	}
+
+	var anyChange bool
+	for i, changeFunc := range prh.Changes() {
+		msg, err := changeFunc(ctx)
+		if err != nil {
+			return fmt.Errorf("process function %d: %w", i, err)
+		}
+
+		changed, err := HasChanges()
+		if err != nil {
+			return fmt.Errorf("checking changes: %w", err)
+		}
+
+		if !changed {
+			logrus.WithField("function", i).Info("Nothing changed, skip commit ...")
+			continue
+		}
+
+		anyChange = true
+		if err := gitCommit(o.GitName, o.GitEmail, msg, stdout, stderr, o.Signoff); err != nil {
+			return fmt.Errorf("git commit: %w", err)
+		}
+	}
+	if !anyChange {
+		logrus.Info("Nothing changed from all functions, skip PR ...")
+		return nil
+	}
+
+	gitClientFactory, err := o.GitHubOptions.GitClientFactory("", nil, false, false)
+	if err != nil {
+		return fmt.Errorf("create git client factory: %w", err)
+	}
+	defer func() {
+		if cleanErr := gitClientFactory.Clean(); cleanErr != nil {
+			logrus.WithError(cleanErr).Warn("Failed to clean git client factory")
+		}
+	}()
+
+	repoClient, err := gitClientFactory.ClientFromDir(o.GitHubOrg, o.GitHubRepo, ".")
+	if err != nil {
+		return fmt.Errorf("create repo client for %s/%s: %w", o.GitHubOrg, o.GitHubRepo, err)
+	}
+
+	if o.SkipPullRequest {
+		return nil
+	}
+
+	logrus.WithField("branch", o.HeadBranchName).Info("Pushing branch directly to upstream repo")
+	if err := repoClient.PushToCentral(o.HeadBranchName, true); err != nil {
+		return fmt.Errorf("push branch %s to %s/%s: %w", o.HeadBranchName, o.GitHubOrg, o.GitHubRepo, err)
+	}
+
+	summary, body := prh.PRTitleBody()
+	if o.GitHubBaseBranch == "" {
+		repo, err := gc.GetRepo(o.GitHubOrg, o.GitHubRepo)
+		if err != nil {
+			return fmt.Errorf("detect default remote branch for %s/%s: %w", o.GitHubOrg, o.GitHubRepo, err)
+		}
+		o.GitHubBaseBranch = repo.DefaultBranch
+	}
+
+	orgAwareGC := &OrgAwareClient{Client: gc, Org: o.GitHubOrg, IsAppAuth: true}
+	return UpdatePullRequestWithLabels(orgAwareGC, o.GitHubOrg, o.GitHubRepo,
+		summary, generatePRBody(body, getAssignment(o.AssignTo)),
+		o.HeadBranchName, o.GitHubBaseBranch, o.HeadBranchName,
+		true, o.Labels, false)
 }
 
 func processGerrit(ctx context.Context, o *Options, prh PRHandler) error {

--- a/cmd/generic-autobumper/bumper/bumper_test.go
+++ b/cmd/generic-autobumper/bumper/bumper_test.go
@@ -24,6 +24,8 @@ import (
 	"testing"
 
 	"sigs.k8s.io/prow/pkg/config/secret"
+	"sigs.k8s.io/prow/pkg/flagutil"
+	"sigs.k8s.io/prow/pkg/github"
 )
 
 func TestValidateOptions(t *testing.T) {
@@ -336,4 +338,242 @@ func TestCDToRootDir(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestResolvedPRSourceMode(t *testing.T) {
+	cases := []struct {
+		name     string
+		mode     string
+		appID    string
+		expected string
+	}{
+		{
+			name:     "explicit fork mode",
+			mode:     "fork",
+			expected: "fork",
+		},
+		{
+			name:     "explicit branch mode",
+			mode:     "branch",
+			expected: "branch",
+		},
+		{
+			name:     "auto-detect with app credentials",
+			mode:     "",
+			appID:    "12345",
+			expected: "branch",
+		},
+		{
+			name:     "auto-detect without app credentials",
+			mode:     "",
+			expected: "fork",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			o := &Options{PRSourceMode: tc.mode}
+			if tc.appID != "" {
+				o.GitHubOptions = &flagutil.GitHubOptions{AppID: tc.appID}
+			}
+			if got := o.resolvedPRSourceMode(); got != tc.expected {
+				t.Errorf("expected %q, got %q", tc.expected, got)
+			}
+		})
+	}
+}
+
+func TestValidateOptionsAppAuth(t *testing.T) {
+	cases := []struct {
+		name string
+		opts *Options
+		err  bool
+	}{
+		{
+			name: "branch mode with app credentials is valid",
+			opts: &Options{
+				GitHubOrg:    "org",
+				GitHubRepo:   "repo",
+				PRSourceMode: "branch",
+				GitHubOptions: &flagutil.GitHubOptions{
+					AppID:             "12345",
+					AppPrivateKeyPath: "/etc/github/cert",
+				},
+			},
+			err: false,
+		},
+		{
+			name: "branch mode with app-id but no private key fails",
+			opts: &Options{
+				GitHubOrg:    "org",
+				GitHubRepo:   "repo",
+				PRSourceMode: "branch",
+				GitHubOptions: &flagutil.GitHubOptions{
+					AppID: "12345",
+				},
+			},
+			err: true,
+		},
+		{
+			name: "branch mode without app credentials fails",
+			opts: &Options{
+				GitHubOrg:     "org",
+				GitHubRepo:    "repo",
+				PRSourceMode:  "branch",
+				GitHubOptions: &flagutil.GitHubOptions{},
+			},
+			err: true,
+		},
+		{
+			name: "branch mode without GitHubOptions fails",
+			opts: &Options{
+				GitHubOrg:    "org",
+				GitHubRepo:   "repo",
+				PRSourceMode: "branch",
+			},
+			err: true,
+		},
+		{
+			name: "fork mode without token fails",
+			opts: &Options{
+				GitHubOrg:    "org",
+				GitHubRepo:   "repo",
+				PRSourceMode: "fork",
+				RemoteName:   "remote",
+			},
+			err: true,
+		},
+		{
+			name: "fork mode with token is valid",
+			opts: &Options{
+				GitHubOrg:    "org",
+				GitHubRepo:   "repo",
+				PRSourceMode: "fork",
+				GitHubToken:  "/path/to/token",
+				RemoteName:   "remote",
+			},
+			err: false,
+		},
+		{
+			name: "invalid mode fails",
+			opts: &Options{
+				GitHubOrg:    "org",
+				GitHubRepo:   "repo",
+				PRSourceMode: "invalid",
+			},
+			err: true,
+		},
+		{
+			name: "skip pull request bypasses validation",
+			opts: &Options{
+				SkipPullRequest: true,
+				PRSourceMode:    "branch",
+			},
+			err: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateOptions(tc.opts)
+			if err == nil && tc.err {
+				t.Errorf("expected error but got nil")
+			}
+			if err != nil && !tc.err {
+				t.Errorf("expected no error but got: %v", err)
+			}
+		})
+	}
+}
+
+func TestOrgAwareClientFindIssues(t *testing.T) {
+	expectedOrg := "test-org"
+	expectedQuery := "is:pr author:bot"
+	var calledOrg, calledQuery string
+
+	fake := &fakeGHClient{
+		findIssuesWithOrgFunc: func(org, query, sort string, asc bool) ([]github.Issue, error) {
+			calledOrg = org
+			calledQuery = query
+			return []github.Issue{{Number: 1}}, nil
+		},
+	}
+
+	client := &OrgAwareClient{Client: fake, Org: expectedOrg, IsAppAuth: true}
+	issues, err := client.FindIssues(expectedQuery, "", false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(issues) != 1 || issues[0].Number != 1 {
+		t.Errorf("unexpected issues returned: %v", issues)
+	}
+	if calledOrg != expectedOrg {
+		t.Errorf("expected org %q, got %q", expectedOrg, calledOrg)
+	}
+	if calledQuery != expectedQuery {
+		t.Errorf("expected query %q, got %q", expectedQuery, calledQuery)
+	}
+}
+
+func TestOrgAwareClientBotUser(t *testing.T) {
+	cases := []struct {
+		name          string
+		login         string
+		isAppAuth     bool
+		expectedLogin string
+	}{
+		{
+			name:          "app auth appends [bot]",
+			login:         "my-app",
+			isAppAuth:     true,
+			expectedLogin: "my-app[bot]",
+		},
+		{
+			name:          "app auth does not double-append [bot]",
+			login:         "my-app[bot]",
+			isAppAuth:     true,
+			expectedLogin: "my-app[bot]",
+		},
+		{
+			name:          "PAT auth does not append [bot]",
+			login:         "my-user",
+			isAppAuth:     false,
+			expectedLogin: "my-user",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fake := &fakeGHClient{
+				botUserFunc: func() (*github.UserData, error) {
+					return &github.UserData{Login: tc.login, Name: "Bot"}, nil
+				},
+			}
+			client := &OrgAwareClient{Client: fake, Org: "org", IsAppAuth: tc.isAppAuth}
+			user, err := client.BotUser()
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if user.Login != tc.expectedLogin {
+				t.Errorf("expected login %q, got %q", tc.expectedLogin, user.Login)
+			}
+		})
+	}
+}
+
+type fakeGHClient struct {
+	github.Client
+	findIssuesWithOrgFunc func(org, query, sort string, asc bool) ([]github.Issue, error)
+	botUserFunc           func() (*github.UserData, error)
+}
+
+func (f *fakeGHClient) FindIssuesWithOrg(org, query, sort string, asc bool) ([]github.Issue, error) {
+	if f.findIssuesWithOrgFunc != nil {
+		return f.findIssuesWithOrgFunc(org, query, sort, asc)
+	}
+	return nil, nil
+}
+
+func (f *fakeGHClient) BotUser() (*github.UserData, error) {
+	if f.botUserFunc != nil {
+		return f.botUserFunc()
+	}
+	return &github.UserData{Login: "bot"}, nil
 }

--- a/cmd/generic-autobumper/bumper/orgaware.go
+++ b/cmd/generic-autobumper/bumper/orgaware.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bumper
+
+import (
+	"strings"
+
+	"sigs.k8s.io/prow/pkg/github"
+)
+
+// OrgAwareClient wraps a github.Client so that FindIssues routes through
+// FindIssuesWithOrg. Prow's App auth round-tripper requires the org in
+// the request context to resolve the installation token, but
+// UpdatePullRequestWithLabels internally calls FindIssues which
+// passes an empty org.
+//
+// When IsAppAuth is true, BotUser() appends "[bot]" to the login so that
+// GitHub's search API author: qualifier matches the App's acting identity.
+type OrgAwareClient struct {
+	github.Client
+	Org       string
+	IsAppAuth bool
+}
+
+func (c *OrgAwareClient) FindIssues(query, sort string, asc bool) ([]github.Issue, error) {
+	return c.Client.FindIssuesWithOrg(c.Org, query, sort, asc)
+}
+
+// BotUser returns the bot user data. When the client is using GitHub App auth,
+// it appends the "[bot]" suffix to the login. GitHub Apps act as "slug[bot]"
+// users, but prow's getUserData only stores the bare slug. The search API's
+// author: qualifier requires the full "slug[bot]" form to match PRs created
+// by the App.
+func (c *OrgAwareClient) BotUser() (*github.UserData, error) {
+	user, err := c.Client.BotUser()
+	if err != nil {
+		return nil, err
+	}
+	if !c.IsAppAuth || strings.HasSuffix(user.Login, "[bot]") {
+		return user, nil
+	}
+	return &github.UserData{
+		Name:  user.Name,
+		Login: user.Login + "[bot]",
+		Email: user.Email,
+	}, nil
+}

--- a/cmd/generic-autobumper/main.go
+++ b/cmd/generic-autobumper/main.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	goflag "flag"
 	"fmt"
 	"io"
 	"net/http"
@@ -37,6 +38,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/prow/cmd/generic-autobumper/bumper"
 	"sigs.k8s.io/prow/cmd/generic-autobumper/imagebumper"
+	"sigs.k8s.io/prow/pkg/flagutil"
 
 	"sigs.k8s.io/yaml"
 )
@@ -174,13 +176,19 @@ func parseOptions() (*options, *bumper.Options, error) {
 	var labelsOverride []string
 	var skipPullRequest bool
 	var signoff bool
+	var prSourceMode string
 
 	var o options
+	var githubOpts flagutil.GitHubOptions
+	githubOpts.AddFlags(goflag.CommandLine)
+	flag.CommandLine.AddGoFlagSet(goflag.CommandLine)
+
 	flag.StringVar(&config, "config", "", "The path to the config file for the autobumber.")
 	flag.StringSliceVar(&labelsOverride, "labels-override", nil, "Override labels to be added to PR.")
 	flag.BoolVar(&skipPullRequest, "skip-pullrequest", false, "")
 	flag.BoolVar(&signoff, "signoff", false, "Signoff the commits.")
 	flag.BoolVar(&o.SkipIfNoOncall, "skip-if-no-oncall", false, "Don't run anything if no oncall is discovered")
+	flag.StringVar(&prSourceMode, "pr-source-mode", "", "How to push PR source: fork (PAT, legacy) or branch (App auth, push directly to org/repo).")
 	flag.Parse()
 
 	var pro bumper.Options
@@ -205,6 +213,10 @@ func parseOptions() (*options, *bumper.Options, error) {
 	}
 	pro.SkipPullRequest = skipPullRequest
 	pro.Signoff = signoff
+	pro.GitHubOptions = &githubOpts
+	if prSourceMode != "" {
+		pro.PRSourceMode = prSourceMode
+	}
 	return &o, &pro, nil
 }
 


### PR DESCRIPTION
Add a new --pr-source-mode=branch option that uses GitHub App credentials (via standard flagutil.GitHubOptions CLI flags) to push branches directly to the upstream repository and create same-repo pull requests. This avoids the need for a personal access token and fork-based workflow.

The legacy PAT/fork flow remains the default and is completely untouched. When --github-app-id and --github-app-private-key-path are provided (or auto-detected), the tool uses GitClientFactory + PushToCentral for git operations and OrgAwareClient for PR creation -- the same pattern used by other Prow components.

Co-authored-by Cursor