### PR TITLE
 mergecommitblocker: allow use of Git subtrees with `excluded_paths` config option

### DIFF
--- a/pkg/git/v2/interactor.go
+++ b/pkg/git/v2/interactor.go
@@ -74,6 +74,10 @@ type Interactor interface {
 	Diff(head, sha string) (changes []string, err error)
 	// MergeCommitsExistBetween determines if merge commits exist between target and HEAD
 	MergeCommitsExistBetween(target, head string) (bool, error)
+	// MergeCommitSHAsBetween returns the SHAs of all merge commits between target and HEAD.
+	MergeCommitSHAsBetween(target, head string) ([]string, error)
+	// CommitChangedFiles returns the list of files changed by a specific commit.
+	CommitChangedFiles(sha string) ([]string, error)
 	// ShowRef returns the commit for a commitlike. Unlike rev-parse it does not require a checkout.
 	ShowRef(commitlike string) (string, error)
 }
@@ -592,6 +596,41 @@ func (i *interactor) MergeCommitsExistBetween(target, head string) (bool, error)
 		return false, fmt.Errorf("error verifying if merge commits exist between %q and %q: %v %s", target, head, err, string(out))
 	}
 	return len(out) != 0, nil
+}
+
+// MergeCommitSHAsBetween returns the SHAs of all merge commits between target and head.
+func (i *interactor) MergeCommitSHAsBetween(target, head string) ([]string, error) {
+	i.logger.Infof("Getting merge commit SHAs between %q and %q", target, head)
+	out, err := i.executor.Run("log", fmt.Sprintf("%s..%s", target, head), "--format=%H", "--merges")
+	if err != nil {
+		return nil, fmt.Errorf("getting merge commits between %q and %q: %w", target, head, err)
+	}
+
+	var shas []string
+	scan := bufio.NewScanner(bytes.NewReader(out))
+	scan.Split(bufio.ScanLines)
+	for scan.Scan() {
+		sha := strings.TrimSpace(scan.Text())
+		if sha != "" {
+			shas = append(shas, sha)
+		}
+	}
+	return shas, nil
+}
+
+// CommitChangedFiles returns the list of files changed by a specific commit.
+func (i *interactor) CommitChangedFiles(sha string) ([]string, error) {
+	i.logger.Infof("Getting files changed by commit %s", sha)
+	out, err := i.executor.Run("diff-tree", "-m", "--no-commit-id", "--name-only", "-r", sha)
+	if err != nil {
+		return nil, fmt.Errorf("getting files changed by commit %s: %w", sha, err)
+	}
+
+	trimmed := strings.TrimSpace(string(out))
+	if trimmed == "" {
+		return nil, nil
+	}
+	return strings.Split(trimmed, "\n"), nil
 }
 
 func (i *interactor) ShowRef(commitlike string) (string, error) {

--- a/pkg/git/v2/interactor_test.go
+++ b/pkg/git/v2/interactor_test.go
@@ -2069,3 +2069,166 @@ func TestInteractor_ShowRef(t *testing.T) {
 		})
 	}
 }
+
+func TestInteractor_MergeCommitSHAsBetween(t *testing.T) {
+	var testCases = []struct {
+		name          string
+		target, head  string
+		responses     map[string]execResponse
+		expectedCalls [][]string
+		expectedOut   []string
+		expectedErr   bool
+	}{
+		{
+			name:   "no merge commits",
+			target: "target",
+			head:   "head",
+			responses: map[string]execResponse{
+				"log target..head --format=%H --merges": {
+					out: []byte(``),
+				},
+			},
+			expectedCalls: [][]string{
+				{"log", "target..head", "--format=%H", "--merges"},
+			},
+			expectedOut: nil,
+			expectedErr: false,
+		},
+		{
+			name:   "one merge commit",
+			target: "target",
+			head:   "head",
+			responses: map[string]execResponse{
+				"log target..head --format=%H --merges": {
+					out: []byte("abc123\n"),
+				},
+			},
+			expectedCalls: [][]string{
+				{"log", "target..head", "--format=%H", "--merges"},
+			},
+			expectedOut: []string{"abc123"},
+			expectedErr: false,
+		},
+		{
+			name:   "multiple merge commits",
+			target: "target",
+			head:   "head",
+			responses: map[string]execResponse{
+				"log target..head --format=%H --merges": {
+					out: []byte("abc123\ndef456\n"),
+				},
+			},
+			expectedCalls: [][]string{
+				{"log", "target..head", "--format=%H", "--merges"},
+			},
+			expectedOut: []string{"abc123", "def456"},
+			expectedErr: false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			e := fakeExecutor{
+				records:   [][]string{},
+				responses: testCase.responses,
+			}
+			i := interactor{
+				executor: &e,
+				logger:   logrus.WithField("test", testCase.name),
+			}
+			actualOut, actualErr := i.MergeCommitSHAsBetween(testCase.target, testCase.head)
+			if testCase.expectedErr && actualErr == nil {
+				t.Errorf("%s: expected an error but got none", testCase.name)
+			}
+			if !testCase.expectedErr && actualErr != nil {
+				t.Errorf("%s: expected no error but got one: %v", testCase.name, actualErr)
+			}
+			if !testCase.expectedErr && !reflect.DeepEqual(actualOut, testCase.expectedOut) {
+				t.Errorf("%s: got incorrect output: %v", testCase.name, diff.ObjectReflectDiff(actualOut, testCase.expectedOut))
+			}
+			if actual, expected := e.records, testCase.expectedCalls; !reflect.DeepEqual(actual, expected) {
+				t.Errorf("%s: got incorrect git calls: %v", testCase.name, diff.ObjectReflectDiff(actual, expected))
+			}
+		})
+	}
+}
+
+func TestInteractor_CommitChangedFiles(t *testing.T) {
+	var testCases = []struct {
+		name          string
+		sha           string
+		responses     map[string]execResponse
+		expectedCalls [][]string
+		expectedOut   []string
+		expectedErr   bool
+	}{
+		{
+			name: "commit with files",
+			sha:  "abc123",
+			responses: map[string]execResponse{
+				"diff-tree -m --no-commit-id --name-only -r abc123": {
+					out: []byte("vendor/lib/a.go\nvendor/lib/b.go\n"),
+				},
+			},
+			expectedCalls: [][]string{
+				{"diff-tree", "-m", "--no-commit-id", "--name-only", "-r", "abc123"},
+			},
+			expectedOut: []string{"vendor/lib/a.go", "vendor/lib/b.go"},
+			expectedErr: false,
+		},
+		{
+			name: "commit with no files",
+			sha:  "abc123",
+			responses: map[string]execResponse{
+				"diff-tree -m --no-commit-id --name-only -r abc123": {
+					out: []byte(``),
+				},
+			},
+			expectedCalls: [][]string{
+				{"diff-tree", "-m", "--no-commit-id", "--name-only", "-r", "abc123"},
+			},
+			expectedOut: nil,
+			expectedErr: false,
+		},
+		{
+			name: "diff-tree command fails",
+			sha:  "abc123",
+			responses: map[string]execResponse{
+				"diff-tree -m --no-commit-id --name-only -r abc123": {
+					err: errors.New("oops"),
+				},
+			},
+			expectedCalls: [][]string{
+				{"diff-tree", "-m", "--no-commit-id", "--name-only", "-r", "abc123"},
+			},
+			expectedOut: nil,
+			expectedErr: true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			e := fakeExecutor{
+				records:   [][]string{},
+				responses: testCase.responses,
+			}
+			i := interactor{
+				executor: &e,
+				logger:   logrus.WithField("test", testCase.name),
+			}
+			actualOut, actualErr := i.CommitChangedFiles(testCase.sha)
+			if testCase.expectedErr && actualErr == nil {
+				t.Errorf("%s: expected an error but got none", testCase.name)
+			}
+			if !testCase.expectedErr && actualErr != nil {
+				t.Errorf("%s: expected no error but got one: %v", testCase.name, actualErr)
+			}
+			if !testCase.expectedErr && !reflect.DeepEqual(actualOut, testCase.expectedOut) {
+				t.Errorf("%s: got incorrect output: %v", testCase.name, diff.ObjectReflectDiff(actualOut, testCase.expectedOut))
+			}
+			if actual, expected := e.records, testCase.expectedCalls; !reflect.DeepEqual(actual, expected) {
+				t.Errorf("%s: got incorrect git calls: %v", testCase.name, diff.ObjectReflectDiff(actual, expected))
+			}
+		})
+	}
+}

--- a/pkg/plugins/config.go
+++ b/pkg/plugins/config.go
@@ -83,6 +83,7 @@ type Configuration struct {
 	Label                Label                        `json:"label,omitempty"`
 	Lgtm                 []Lgtm                       `json:"lgtm,omitempty"`
 	Jira                 *Jira                        `json:"jira,omitempty"`
+	MergeCommitBlocker   []MergeCommitBlocker         `json:"merge_commit_blocker,omitempty"`
 	MilestoneApplier     map[string]BranchToMilestone `json:"milestone_applier,omitempty"`
 	ReleaseNote          ReleaseNote                  `json:"release_note,omitempty"`
 	RepoMilestone        map[string]Milestone         `json:"repo_milestone,omitempty"`
@@ -389,6 +390,20 @@ type Lgtm struct {
 	// StickyLgtmTeam specifies the GitHub team whose members are trusted with sticky LGTM,
 	// which eliminates the need to re-lgtm minor fixes/updates.
 	StickyLgtmTeam string `json:"trusted_team_for_sticky_lgtm,omitempty"`
+}
+
+// MergeCommitBlocker specifies a configuration for the mergecommitblocker plugin.
+// The configuration for the mergecommitblocker plugin is defined as a list of these structures.
+type MergeCommitBlocker struct {
+	// Repos is either of the form org/repos or just org.
+	Repos []string `json:"repos,omitempty"`
+	// ExcludedPaths is a list of regular expressions matching file paths that should be
+	// excluded from merge commit checks. Merge commits that only touch files matching
+	// these patterns will be allowed. This is useful for workflows like Git subtrees
+	// which inherently require merge commits.
+	ExcludedPaths []string `json:"excluded_paths,omitempty"`
+	// CompiledExcludedPaths is the compiled version of ExcludedPaths. It should not be specified in config.
+	CompiledExcludedPaths []*regexp.Regexp `json:"-"`
 }
 
 // Jira holds the config for the jira plugin.
@@ -1047,6 +1062,26 @@ func (c *Configuration) LgtmFor(org, repo string) *Lgtm {
 	return &Lgtm{}
 }
 
+// MergeCommitBlockerFor finds the MergeCommitBlocker for a repo, if one exists.
+// A configuration can be listed for the repo itself or for the owning organization.
+func (c *Configuration) MergeCommitBlockerFor(org, repo string) *MergeCommitBlocker {
+	fullName := fmt.Sprintf("%s/%s", org, repo)
+	for i := range c.MergeCommitBlocker {
+		if !sets.New(c.MergeCommitBlocker[i].Repos...).Has(fullName) {
+			continue
+		}
+		return &c.MergeCommitBlocker[i]
+	}
+	// If you don't find anything, loop again looking for an org config
+	for i := range c.MergeCommitBlocker {
+		if !sets.New(c.MergeCommitBlocker[i].Repos...).Has(org) {
+			continue
+		}
+		return &c.MergeCommitBlocker[i]
+	}
+	return nil
+}
+
 // TriggerFor finds the Trigger for a repo, if one exists
 // a trigger can be listed for the repo itself or for the
 // owning organization
@@ -1542,6 +1577,17 @@ func compileRegexpsAndDurations(pc *Configuration) error {
 			return fmt.Errorf("failed to compile blunderbuss wait for context description regular expression: %q, error: %w", pc.Blunderbuss.WaitForStatus.Description, err)
 		}
 	}
+
+	for i := range pc.MergeCommitBlocker {
+		for _, pattern := range pc.MergeCommitBlocker[i].ExcludedPaths {
+			re, err := regexp.Compile(pattern)
+			if err != nil {
+				return fmt.Errorf("failed to compile mergecommitblocker excluded_paths pattern: %q, error: %w", pattern, err)
+			}
+			pc.MergeCommitBlocker[i].CompiledExcludedPaths = append(pc.MergeCommitBlocker[i].CompiledExcludedPaths, re)
+		}
+	}
+
 	return nil
 }
 

--- a/pkg/plugins/mergecommitblocker/mergecommitblocker.go
+++ b/pkg/plugins/mergecommitblocker/mergecommitblocker.go
@@ -18,6 +18,8 @@ package mergecommitblocker
 
 import (
 	"fmt"
+	"regexp"
+	"slices"
 	"strings"
 
 	"github.com/sirupsen/logrus"
@@ -46,10 +48,22 @@ func init() {
 
 // helpProvider provides information on the plugin
 func helpProvider(config *plugins.Configuration, _ []config.OrgRepo) (*pluginhelp.PluginHelp, error) {
-	// Only the Description field is specified because this plugin is not triggered with commands and is not configurable.
-	return &pluginhelp.PluginHelp{
-		Description: fmt.Sprintf("The merge commit blocker plugin adds the %s label to pull requests that contain merge commits", labels.MergeCommits),
-	}, nil
+	pluginHelp := &pluginhelp.PluginHelp{
+		Description: fmt.Sprintf("The merge commit blocker plugin adds the %s label to pull requests that contain merge commits. "+
+			"Merge commits may be excluded from this check if they only modify files matching configured path patterns, "+
+			"which is useful for workflows like Git subtrees.", labels.MergeCommits),
+		Config: map[string]string{},
+	}
+	for _, mcb := range config.MergeCommitBlocker {
+		for _, repo := range mcb.Repos {
+			if len(mcb.ExcludedPaths) > 0 {
+				pluginHelp.Config[repo] = fmt.Sprintf("Excluded paths: %v", mcb.ExcludedPaths)
+			} else {
+				pluginHelp.Config[repo] = "No excluded paths configured."
+			}
+		}
+	}
+	return pluginHelp, nil
 }
 
 type githubClient interface {
@@ -73,10 +87,13 @@ func handlePullRequest(pc plugins.Agent, pre github.PullRequestEvent) error {
 	if err != nil {
 		return err
 	}
-	return handle(pc.GitHubClient, pc.GitClient, cp, pc.Logger, &pre)
+	org := pre.PullRequest.Base.Repo.Owner.Login
+	repo := pre.PullRequest.Base.Repo.Name
+	cfg := pc.PluginConfig.MergeCommitBlockerFor(org, repo)
+	return handle(pc.GitHubClient, pc.GitClient, cp, pc.Logger, &pre, cfg)
 }
 
-func handle(ghc githubClient, gc git.ClientFactory, cp pruneClient, log *logrus.Entry, pre *github.PullRequestEvent) error {
+func handle(ghc githubClient, gc git.ClientFactory, cp pruneClient, log *logrus.Entry, pre *github.PullRequestEvent, cfg *plugins.MergeCommitBlocker) error {
 	var (
 		org  = pre.PullRequest.Base.Repo.Owner.Login
 		repo = pre.PullRequest.Base.Repo.Name
@@ -98,16 +115,19 @@ func handle(ghc githubClient, gc git.ClientFactory, cp pruneClient, log *logrus.
 	}
 	// We are guaranteed to have both Base.SHA and Head.SHA
 	target, head := pre.PullRequest.Base.SHA, pre.PullRequest.Head.SHA
-	existMergeCommits, err := r.MergeCommitsExistBetween(target, head)
+
+	// Determine if there are any disallowed merge commits
+	hasDisallowedMergeCommits, err := hasDisallowedMergeCommits(r, log, target, head, cfg)
 	if err != nil {
 		return err
 	}
+
 	issueLabels, err := ghc.GetIssueLabels(org, repo, num)
 	if err != nil {
 		return err
 	}
 	hasLabel := github.HasLabel(labels.MergeCommits, issueLabels)
-	if hasLabel && !existMergeCommits {
+	if hasLabel && !hasDisallowedMergeCommits {
 		log.Infof("Removing %q Label for %s/%s#%d", labels.MergeCommits, org, repo, num)
 		if err := ghc.RemoveLabel(org, repo, num, labels.MergeCommits); err != nil {
 			return err
@@ -115,7 +135,7 @@ func handle(ghc githubClient, gc git.ClientFactory, cp pruneClient, log *logrus.
 		cp.PruneComments(func(ic github.IssueComment) bool {
 			return strings.Contains(ic.Body, commentBody)
 		})
-	} else if !hasLabel && existMergeCommits {
+	} else if !hasLabel && hasDisallowedMergeCommits {
 		log.Infof("Adding %q Label for %s/%s#%d", labels.MergeCommits, org, repo, num)
 		if err := ghc.AddLabel(org, repo, num, labels.MergeCommits); err != nil {
 			return err
@@ -124,4 +144,51 @@ func handle(ghc githubClient, gc git.ClientFactory, cp pruneClient, log *logrus.
 		return ghc.CreateComment(org, repo, num, msg)
 	}
 	return nil
+}
+
+// hasDisallowedMergeCommits checks if there are any merge commits in the PR that are not allowed
+func hasDisallowedMergeCommits(r git.RepoClient, log *logrus.Entry, target, head string, cfg *plugins.MergeCommitBlocker) (bool, error) {
+	if cfg == nil || len(cfg.CompiledExcludedPaths) == 0 {
+		return r.MergeCommitsExistBetween(target, head)
+	}
+
+	shas, err := r.MergeCommitSHAsBetween(target, head)
+	if err != nil {
+		return false, err
+	}
+
+	if len(shas) == 0 {
+		return false, nil
+	}
+
+	for _, sha := range shas {
+		files, err := r.CommitChangedFiles(sha)
+		if err != nil {
+			return false, err
+		}
+
+		if !isMergeCommitAllowed(files, cfg.CompiledExcludedPaths) {
+			log.Infof("Merge commit %s is not allowed because it modifies files outside excluded paths", sha)
+			return true, nil
+		}
+		log.Debugf("Merge commit %s is allowed because changed files match excluded patterns", sha)
+	}
+
+	return false, nil
+}
+
+// isMergeCommitAllowed returns true if all files changed by the merge commit match at least one excluded pattern.
+func isMergeCommitAllowed(files []string, excludedPatterns []*regexp.Regexp) bool {
+	if len(files) == 0 {
+		return true
+	}
+
+	for _, file := range files {
+		if !slices.ContainsFunc(excludedPatterns, func(p *regexp.Regexp) bool {
+			return p.MatchString(file)
+		}) {
+			return false
+		}
+	}
+	return true
 }

--- a/pkg/plugins/mergecommitblocker/mergecommitblocker_test.go
+++ b/pkg/plugins/mergecommitblocker/mergecommitblocker_test.go
@@ -18,6 +18,7 @@ package mergecommitblocker
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/sirupsen/logrus"
@@ -25,6 +26,7 @@ import (
 	"sigs.k8s.io/prow/pkg/git/localgit"
 	"sigs.k8s.io/prow/pkg/github"
 	"sigs.k8s.io/prow/pkg/labels"
+	"sigs.k8s.io/prow/pkg/plugins"
 )
 
 var defaultBranch = localgit.DefaultBranch("")
@@ -236,7 +238,7 @@ func testHandle(clients localgit.Clients, t *testing.T) {
 		}
 		log := logrus.NewEntry(logrus.New())
 		fakePruner := commentpruner.NewEventClient(tt.fakeGHClient, log, "foo", "bar", tt.prNum)
-		if err := handle(tt.fakeGHClient, c, fakePruner, log, pre); err != nil {
+		if err := handle(tt.fakeGHClient, c, fakePruner, log, pre, nil); err != nil {
 			t.Errorf("Expect err is nil, but got %v", err)
 		}
 		// verify if MergeCommits label as expected
@@ -247,5 +249,247 @@ func testHandle(clients localgit.Clients, t *testing.T) {
 		if _, got := tt.fakeGHClient.comments[tt.prNum]; got != tt.wantComment {
 			t.Errorf("Case: %v. Expect wantComment=%v, but got %v", tt.name, tt.wantComment, got)
 		}
+	}
+}
+
+func TestHandleWithExcludedPathsV2(t *testing.T) {
+	testHandleWithExcludedPaths(localgit.NewV2, t)
+}
+
+func testHandleWithExcludedPaths(clients localgit.Clients, t *testing.T) {
+	lg, c, err := clients()
+	if err != nil {
+		t.Fatalf("Making localgit: %v", err)
+	}
+	defer func() {
+		if err := lg.Clean(); err != nil {
+			t.Errorf("Cleaning up localgit: %v", err)
+		}
+		if err := c.Clean(); err != nil {
+			t.Errorf("Cleaning up client: %v", err)
+		}
+	}()
+	if err := lg.MakeFakeRepo("foo", "bar"); err != nil {
+		t.Fatalf("Making fake repo: %v", err)
+	}
+	var (
+		checkoutPR = func(prNum int) {
+			if err := lg.CheckoutNewBranch("foo", "bar", fmt.Sprintf("pull/%d/head", prNum)); err != nil {
+				t.Fatalf("Creating & checking out pull branch pull/%d/head: %v", prNum, err)
+			}
+		}
+		checkoutBranch = func(branch string) {
+			if err := lg.Checkout("foo", "bar", branch); err != nil {
+				t.Fatalf("Checking out branch %s: %v", branch, err)
+			}
+		}
+		addCommit = func(files map[string][]byte) {
+			if err := lg.AddCommit("foo", "bar", files); err != nil {
+				t.Fatalf("Adding commit: %v", err)
+			}
+		}
+		mergeMaster = func() {
+			if _, err := lg.Merge("foo", "bar", defaultBranch); err != nil {
+				t.Fatalf("Merging master: %v", err)
+			}
+		}
+	)
+
+	type testCase struct {
+		name         string
+		fakeGHClient *fakeGHClient
+		prNum        int
+		config       *plugins.MergeCommitBlocker
+		setupPR      func() // function to set up the PR branch
+		wantLabel    bool
+		wantComment  bool
+	}
+
+	// Set up the initial repo state
+	addCommit(map[string][]byte{"README.md": []byte("initial")})
+
+	// Create PR branches for tests
+	// PR 21: merge commit with files in excluded path only
+	checkoutPR(21)
+	// PR 22: merge commit with files outside excluded path
+	checkoutPR(22)
+	// PR 23: merge commit with files both inside and outside excluded path
+	checkoutPR(23)
+
+	// add another commit
+	checkoutBranch(defaultBranch)
+	addCommit(map[string][]byte{"vendor/lib/file.go": []byte("vendor content")})
+	masterSHA, err := lg.RevParse("foo", "bar", "HEAD")
+	if err != nil {
+		t.Fatalf("Fetching SHA: %v", err)
+	}
+
+	testcases := []testCase{
+		{
+			name: "merge commit with files only in excluded path - no label",
+			fakeGHClient: &fakeGHClient{
+				labels:   strSet{},
+				comments: make(map[int]string),
+			},
+			prNum:  21,
+			config: newMergeCommitBlockerConfig([]string{`^vendor/`}),
+			setupPR: func() {
+				checkoutBranch("pull/21/head")
+				// Add a commit with files in vendor/ before merge
+				addCommit(map[string][]byte{"vendor/other/file.go": []byte("content")})
+				mergeMaster()
+			},
+			wantLabel:   false,
+			wantComment: false,
+		},
+		{
+			name: "merge commit with files outside excluded path - add label",
+			fakeGHClient: &fakeGHClient{
+				labels:   strSet{},
+				comments: make(map[int]string),
+			},
+			prNum:  22,
+			config: newMergeCommitBlockerConfig([]string{`^vendor/`}),
+			setupPR: func() {
+				checkoutBranch("pull/22/head")
+				// Add a commit with files outside vendor/
+				addCommit(map[string][]byte{"src/main.go": []byte("content")})
+				mergeMaster()
+			},
+			wantLabel:   true,
+			wantComment: true,
+		},
+		{
+			name: "merge commit with mixed files - add label",
+			fakeGHClient: &fakeGHClient{
+				labels:   strSet{},
+				comments: make(map[int]string),
+			},
+			prNum:  23,
+			config: newMergeCommitBlockerConfig([]string{`^vendor/`}),
+			setupPR: func() {
+				checkoutBranch("pull/23/head")
+				// Add commits with files both inside and outside vendor/
+				addCommit(map[string][]byte{
+					"vendor/pkg/file.go": []byte("vendor"),
+					"src/app.go":         []byte("app"),
+				})
+				mergeMaster()
+			},
+			wantLabel:   true,
+			wantComment: true,
+		},
+	}
+
+	for _, tt := range testcases {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.setupPR()
+			prSHA, err := lg.RevParse("foo", "bar", "HEAD")
+			if err != nil {
+				t.Fatalf("Fetching SHA: %v", err)
+			}
+			pre := &github.PullRequestEvent{
+				Action: github.PullRequestActionOpened,
+				PullRequest: github.PullRequest{
+					Number: tt.prNum,
+					Base: github.PullRequestBranch{
+						Repo: github.Repo{
+							Owner: github.User{Login: "foo"},
+							Name:  "bar",
+						},
+						SHA: masterSHA,
+					},
+					Head: github.PullRequestBranch{
+						Repo: github.Repo{
+							Owner: github.User{Login: "foo"},
+							Name:  "bar",
+						},
+						SHA: prSHA,
+					},
+				},
+			}
+			log := logrus.NewEntry(logrus.New())
+			fakePruner := commentpruner.NewEventClient(tt.fakeGHClient, log, "foo", "bar", tt.prNum)
+			if err := handle(tt.fakeGHClient, c, fakePruner, log, pre, tt.config); err != nil {
+				t.Errorf("Expect err is nil, but got %v", err)
+			}
+			if _, got := tt.fakeGHClient.labels[labels.MergeCommits]; got != tt.wantLabel {
+				t.Errorf("Case: %v. Expect MergeCommits=%v, but got %v", tt.name, tt.wantLabel, got)
+			}
+			if _, got := tt.fakeGHClient.comments[tt.prNum]; got != tt.wantComment {
+				t.Errorf("Case: %v. Expect wantComment=%v, but got %v", tt.name, tt.wantComment, got)
+			}
+		})
+	}
+}
+
+func TestIsMergeCommitAllowed(t *testing.T) {
+	testcases := []struct {
+		name     string
+		files    []string
+		patterns []string
+		expected bool
+	}{
+		{
+			name:     "all files match pattern",
+			files:    []string{"vendor/lib/a.go", "vendor/lib/b.go"},
+			patterns: []string{`^vendor/`},
+			expected: true,
+		},
+		{
+			name:     "no files match pattern",
+			files:    []string{"src/main.go", "pkg/utils.go"},
+			patterns: []string{`^vendor/`},
+			expected: false,
+		},
+		{
+			name:     "some files match pattern",
+			files:    []string{"vendor/lib/a.go", "src/main.go"},
+			patterns: []string{`^vendor/`},
+			expected: false,
+		},
+		{
+			name:     "empty files list",
+			files:    []string{},
+			patterns: []string{`^vendor/`},
+			expected: true,
+		},
+		{
+			name:     "empty patterns list",
+			files:    []string{"src/main.go"},
+			patterns: []string{},
+			expected: false,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			patterns := compilePatterns(tc.patterns)
+			if got := isMergeCommitAllowed(tc.files, patterns); got != tc.expected {
+				t.Errorf("isMergeCommitAllowed(%v, %v) = %v, want %v", tc.files, tc.patterns, got, tc.expected)
+			}
+		})
+	}
+}
+
+// compilePatterns is a helper function to compile regex patterns for testing
+func compilePatterns(patterns []string) []*regexp.Regexp {
+	var result []*regexp.Regexp
+	for _, p := range patterns {
+		re, err := regexp.Compile(p)
+		if err != nil {
+			continue
+		}
+		result = append(result, re)
+	}
+	return result
+}
+
+// newMergeCommitBlockerConfig creates a MergeCommitBlocker with both
+// ExcludedPaths and CompiledExcludedPaths properly set.
+func newMergeCommitBlockerConfig(excludedPaths []string) *plugins.MergeCommitBlocker {
+	return &plugins.MergeCommitBlocker{
+		ExcludedPaths:         excludedPaths,
+		CompiledExcludedPaths: compilePatterns(excludedPaths),
 	}
 }


### PR DESCRIPTION
Up until now the `mergecommitblocker` plugin has had no configuration options. Hence, when the it was enabled, it would prevent workflows that rely on Git subtrees from functioning as intended. Git subtrees inherently depend on merge commits (e.g., those created by git subtree pull). These merge commits are required for the subtree mechanism to track history correctly. 

This PR allows configuring path patterns (e.g., `^tools/`) so that merge commits changing only those paths are permitted. 
Fixes https://github.com/kubernetes-sigs/prow/issues/666

I've chosen to do both the config introduction and the "business" logic in one PR, since the introduction of the config is a relatively minimal change and it may be easier to follow alongside the introduction of the `excluded_paths` field's logic. 

Example usage:
```yaml
merge_commit_blocker:
  - repos:
      - kubernetes/test-infra
    excluded_paths:
      - ^tools/
      - ^vendor/
```