### PR TITLE
fix(metrics): match GoCollector options with controller-runtime v0.21.0

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/collectors"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/sirupsen/logrus"
 	ctrlruntimemetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
@@ -51,7 +52,9 @@ func ExposeMetricsWithRegistry(component string, pushGateway config.PushGateway,
 	// we can not change it.
 
 	//nolint:staticcheck
-	ctrlruntimemetrics.Registry.Unregister(prometheus.NewGoCollector())
+	ctrlruntimemetrics.Registry.Unregister(
+		collectors.NewGoCollector(collectors.WithGoCollectorRuntimeMetrics(collectors.MetricsAll)),
+	)
 	//nolint:staticcheck
 	ctrlruntimemetrics.Registry.Unregister(prometheus.NewProcessCollector(prometheus.ProcessCollectorOpts{}))
 

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -18,9 +18,14 @@ package metrics
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/collectors"
+	ctrlruntimemetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 
 	"sigs.k8s.io/prow/pkg/config"
 	"sigs.k8s.io/prow/pkg/flagutil"
@@ -59,5 +64,40 @@ func TestExposeMetrics(t *testing.T) {
 	}
 	if resp.StatusCode != http.StatusOK {
 		t.Errorf("response status was not %d but %d", http.StatusOK, resp.StatusCode)
+	}
+}
+
+// TestExposeMetricsWithControllerRuntimeCollectors verifies that the
+// Unregister calls in ExposeMetricsWithRegistry match what controller-runtime
+// v0.21.0 registers via its init in pkg/internal/controller/metrics. The test
+// binary does not trigger that init, so we register the same collectors
+// manually.
+func TestExposeMetricsWithControllerRuntimeCollectors(t *testing.T) {
+	goC := collectors.NewGoCollector(collectors.WithGoCollectorRuntimeMetrics(collectors.MetricsAll))
+	procC := collectors.NewProcessCollector(collectors.ProcessCollectorOpts{})
+	//nolint:staticcheck
+	ctrlruntimemetrics.Registry.MustRegister(goC, procC)
+	t.Cleanup(func() {
+		//nolint:staticcheck
+		ctrlruntimemetrics.Registry.Unregister(goC)
+		//nolint:staticcheck
+		ctrlruntimemetrics.Registry.Unregister(procC)
+	})
+
+	ctx := t.Context()
+	fls := fakeListenAndServer{ctx: ctx}
+	ExposeMetricsWithRegistry("test", config.PushGateway{}, flagutil.DefaultMetricsPort, nil, fls.CreateServer)
+
+	resp, err := http.Get(fls.server.URL + "/metrics")
+	if err != nil {
+		t.Fatalf("failed getting metrics: %v", err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("failed reading body: %v", err)
+	}
+	if strings.Contains(string(body), "collected before with the same name") {
+		t.Fatal("duplicate collector: Unregister options do not match controller-runtime")
 	}
 }


### PR DESCRIPTION
controller-runtime v0.21.0 (pulled in by #713) changed the options used to register its Go collector. Prow unregisters that collector to avoid duplicates when merging registries, but the unregister call still used the old options. Since Prometheus matches by descriptor set, the unregister silently failed, both registries served the same go_* metrics, and /metrics broke for all components that import controller-runtime.

This aligns the unregister options with what controller-runtime now registers and adds a regression test.

Fixes #718