### PR TITLE
chore: upgrade gopkg.in/robfig/cron.v2 to github.com/robfig/cron/v3 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -50,6 +50,7 @@ require (
 	github.com/prometheus/client_golang v1.22.0
 	github.com/prometheus/client_model v0.6.2
 	github.com/prometheus/common v0.62.0
+	github.com/robfig/cron/v3 v3.0.1
 	github.com/shurcooL/githubv4 v0.0.0-20210725200734-83ba7b4c9228
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/pflag v1.0.6
@@ -73,7 +74,6 @@ require (
 	google.golang.org/protobuf v1.36.10
 	gopkg.in/fsnotify.v1 v1.4.7
 	gopkg.in/ini.v1 v1.67.0
-	gopkg.in/robfig/cron.v2 v2.0.0-20150107220207-be2e0b0deed5
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.33.11
 	k8s.io/apimachinery v0.33.11

--- a/go.sum
+++ b/go.sum
@@ -583,6 +583,8 @@ github.com/prometheus/procfs v0.15.1 h1:YagwOFzUgYfKKHX6Dr+sHT7km/hxC76UB0leargg
 github.com/prometheus/procfs v0.15.1/go.mod h1:fB45yRUv8NstnjriLhBQLuOUt+WW4BsoGhij/e3PBqk=
 github.com/prometheus/statsd_exporter v0.22.7 h1:7Pji/i2GuhK6Lu7DHrtTkFmNBCudCPT1pX2CziuyQR0=
 github.com/prometheus/statsd_exporter v0.22.7/go.mod h1:N/TevpjkIh9ccs6nuzY3jQn9dFqnUakOjnEuMPJJJnI=
+github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
+github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
@@ -1116,8 +1118,6 @@ gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
 gopkg.in/ini.v1 v1.67.0 h1:Dgnx+6+nfE+IfzjUEISNeydPJh9AXNNsWbGP9KzCsOA=
 gopkg.in/ini.v1 v1.67.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
-gopkg.in/robfig/cron.v2 v2.0.0-20150107220207-be2e0b0deed5 h1:E846t8CnR+lv5nE+VuiKTDG/v1U2stad0QzddfJC7kY=
-gopkg.in/robfig/cron.v2 v2.0.0-20150107220207-be2e0b0deed5/go.mod h1:hiOFpYm0ZJbusNj2ywpbrXowU3G8U6GIQzqn2mw1UIE=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/warnings.v0 v0.1.2 h1:wFXVbFY8DY5/xOe1ECiWdKCzZlxgshcYVNkBHstARME=
 gopkg.in/warnings.v0 v0.1.2/go.mod h1:jksf8JmL6Qr/oQM2OXTHunEvvTAsrWBLb6OOjuVWRNI=

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -42,9 +42,9 @@ import (
 	gitignore "github.com/denormal/go-gitignore"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/robfig/cron/v3"
 	"github.com/sirupsen/logrus"
 	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
-	"gopkg.in/robfig/cron.v2"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -61,6 +61,10 @@ import (
 	"sigs.k8s.io/prow/pkg/kube"
 	"sigs.k8s.io/prow/pkg/pod-utils/decorate"
 	"sigs.k8s.io/prow/pkg/pod-utils/downwardapi"
+)
+
+var cronParser = cron.NewParser(
+	cron.SecondOptional | cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow | cron.Descriptor,
 )
 
 const (
@@ -2435,7 +2439,7 @@ func (c Config) validatePeriodics(periodics []Periodic) error {
 		}
 
 		if p.Cron != "" {
-			if _, err := cron.Parse(p.Cron); err != nil {
+			if _, err := cronParser.Parse(p.Cron); err != nil {
 				errs = append(errs, fmt.Errorf("invalid cron string %s in periodic %s: %w", p.Cron, p.Name, err))
 			}
 		}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -344,7 +344,6 @@ deck:
 			t.Errorf("%s expected SizeLimit %d, got %d", tc.name, tc.expectedSizeLimit, cfg.Deck.Spyglass.SizeLimit)
 		}
 	}
-
 }
 
 func TestGetGCSBrowserPrefix(t *testing.T) {
@@ -570,7 +569,7 @@ func TestDefaultMatches(t *testing.T) {
 
 func TestDecorationRawYaml(t *testing.T) {
 	t.Parallel()
-	var testCases = []struct {
+	testCases := []struct {
 		name              string
 		expectError       bool
 		expectStrictError bool
@@ -1184,7 +1183,7 @@ periodics:
 
 func TestGerritRawYaml(t *testing.T) {
 	t.Parallel()
-	var testCases = []struct {
+	testCases := []struct {
 		name        string
 		expectError bool
 		rawConfig   string
@@ -1293,7 +1292,7 @@ gerrit:
 
 func TestDisabledClustersRawYaml(t *testing.T) {
 	t.Parallel()
-	var testCases = []struct {
+	testCases := []struct {
 		name        string
 		expectError bool
 		rawConfig   string
@@ -1492,7 +1491,6 @@ func TestValidatePodSpec(t *testing.T) {
 			spec: func(s *v1.PodSpec) {
 				// find a presubmit value
 				for n := range preEnv.Difference(postEnv).Difference(periodEnv) {
-
 					s.Containers[0].Env = append(s.Containers[0].Env, v1.EnvVar{Name: n, Value: "whatever"})
 				}
 				if len(s.Containers[0].Env) == 0 {
@@ -1506,7 +1504,6 @@ func TestValidatePodSpec(t *testing.T) {
 			spec: func(s *v1.PodSpec) {
 				// find a postsubmit value
 				for n := range postEnv.Difference(periodEnv) {
-
 					s.Containers[0].Env = append(s.Containers[0].Env, v1.EnvVar{Name: n, Value: "whatever"})
 				}
 				if len(s.Containers[0].Env) == 0 {
@@ -1520,7 +1517,6 @@ func TestValidatePodSpec(t *testing.T) {
 			spec: func(s *v1.PodSpec) {
 				// find a postsubmit value
 				for n := range periodEnv {
-
 					s.Containers[0].Env = append(s.Containers[0].Env, v1.EnvVar{Name: n, Value: "whatever"})
 				}
 				if len(s.Containers[0].Env) == 0 {
@@ -1696,7 +1692,8 @@ func TestValidatePipelineRunSpec(t *testing.T) {
 			jobType: prowapi.PeriodicJob,
 			spec: func(s *pipelinev1.PipelineRunSpec) {
 				s.PipelineSpec = &pipelinev1.PipelineSpec{
-					Tasks: []pipelinev1.PipelineTask{{Name: "git ref", TaskRef: &pipelinev1.TaskRef{Name: "PROW_IMPLICIT_GIT_REF"}}}}
+					Tasks: []pipelinev1.PipelineTask{{Name: "git ref", TaskRef: &pipelinev1.TaskRef{Name: "PROW_IMPLICIT_GIT_REF"}}},
+				}
 			},
 			pass: false,
 		},
@@ -1705,7 +1702,8 @@ func TestValidatePipelineRunSpec(t *testing.T) {
 			jobType: prowapi.PresubmitJob,
 			spec: func(s *pipelinev1.PipelineRunSpec) {
 				s.PipelineSpec = &pipelinev1.PipelineSpec{
-					Tasks: []pipelinev1.PipelineTask{{Name: "git ref", TaskRef: &pipelinev1.TaskRef{Name: "PROW_IMPLICIT_GIT_REF"}}}}
+					Tasks: []pipelinev1.PipelineTask{{Name: "git ref", TaskRef: &pipelinev1.TaskRef{Name: "PROW_IMPLICIT_GIT_REF"}}},
+				}
 			},
 			pass: true,
 		},
@@ -1714,7 +1712,8 @@ func TestValidatePipelineRunSpec(t *testing.T) {
 			jobType: prowapi.PostsubmitJob,
 			spec: func(s *pipelinev1.PipelineRunSpec) {
 				s.PipelineSpec = &pipelinev1.PipelineSpec{
-					Tasks: []pipelinev1.PipelineTask{{Name: "git ref", TaskRef: &pipelinev1.TaskRef{Name: "PROW_IMPLICIT_GIT_REF"}}}}
+					Tasks: []pipelinev1.PipelineTask{{Name: "git ref", TaskRef: &pipelinev1.TaskRef{Name: "PROW_IMPLICIT_GIT_REF"}}},
+				}
 			},
 			pass: true,
 		},
@@ -1722,7 +1721,8 @@ func TestValidatePipelineRunSpec(t *testing.T) {
 			name: "reject extra refs usage with no extra refs",
 			spec: func(s *pipelinev1.PipelineRunSpec) {
 				s.PipelineSpec = &pipelinev1.PipelineSpec{
-					Tasks: []pipelinev1.PipelineTask{{Name: "git ref", TaskRef: &pipelinev1.TaskRef{Name: "PROW_EXTRA_GIT_REF_0"}}}}
+					Tasks: []pipelinev1.PipelineTask{{Name: "git ref", TaskRef: &pipelinev1.TaskRef{Name: "PROW_EXTRA_GIT_REF_0"}}},
+				}
 			},
 			pass: false,
 		},
@@ -1730,7 +1730,8 @@ func TestValidatePipelineRunSpec(t *testing.T) {
 			name: "allow extra refs usage with extra refs",
 			spec: func(s *pipelinev1.PipelineRunSpec) {
 				s.PipelineSpec = &pipelinev1.PipelineSpec{
-					Tasks: []pipelinev1.PipelineTask{{Name: "git ref", TaskRef: &pipelinev1.TaskRef{Name: "PROW_EXTRA_GIT_REF_0"}}}}
+					Tasks: []pipelinev1.PipelineTask{{Name: "git ref", TaskRef: &pipelinev1.TaskRef{Name: "PROW_EXTRA_GIT_REF_0"}}},
+				}
 			},
 			extraRefs: []prowapi.Refs{{Org: "o", Repo: "r"}},
 			pass:      true,
@@ -1739,7 +1740,8 @@ func TestValidatePipelineRunSpec(t *testing.T) {
 			name: "reject wrong extra refs index usage",
 			spec: func(s *pipelinev1.PipelineRunSpec) {
 				s.PipelineSpec = &pipelinev1.PipelineSpec{
-					Tasks: []pipelinev1.PipelineTask{{Name: "git ref", TaskRef: &pipelinev1.TaskRef{Name: "PROW_EXTRA_GIT_REF_1"}}}}
+					Tasks: []pipelinev1.PipelineTask{{Name: "git ref", TaskRef: &pipelinev1.TaskRef{Name: "PROW_EXTRA_GIT_REF_1"}}},
+				}
 			},
 			extraRefs: []prowapi.Refs{{Org: "o", Repo: "r"}},
 			pass:      false,
@@ -1753,7 +1755,8 @@ func TestValidatePipelineRunSpec(t *testing.T) {
 			name: "allow unrelated resource refs",
 			spec: func(s *pipelinev1.PipelineRunSpec) {
 				s.PipelineSpec = &pipelinev1.PipelineSpec{
-					Tasks: []pipelinev1.PipelineTask{{Name: "git ref", TaskRef: &pipelinev1.TaskRef{Name: "some-other-ref"}}}}
+					Tasks: []pipelinev1.PipelineTask{{Name: "git ref", TaskRef: &pipelinev1.TaskRef{Name: "some-other-ref"}}},
+				}
 			},
 			pass: true,
 		},
@@ -1761,7 +1764,8 @@ func TestValidatePipelineRunSpec(t *testing.T) {
 			name: "reject leading zeros when extra ref usage is otherwise valid",
 			spec: func(s *pipelinev1.PipelineRunSpec) {
 				s.PipelineSpec = &pipelinev1.PipelineSpec{
-					Tasks: []pipelinev1.PipelineTask{{Name: "git ref", TaskRef: &pipelinev1.TaskRef{Name: "PROW_EXTRA_GIT_REF_000"}}}}
+					Tasks: []pipelinev1.PipelineTask{{Name: "git ref", TaskRef: &pipelinev1.TaskRef{Name: "PROW_EXTRA_GIT_REF_000"}}},
+				}
 			},
 			extraRefs: []prowapi.Refs{{Org: "o", Repo: "r"}},
 			pass:      false,
@@ -2518,7 +2522,7 @@ func TestValidConfigLoading(t *testing.T) {
 
 		return "nil"
 	}
-	var testCases = []struct {
+	testCases := []struct {
 		name               string
 		prowConfig         string
 		versionFileContent string
@@ -3065,7 +3069,8 @@ tide:
   queries:
   - repos:
     - stranded/fish`,
-			jobConfigs: []string{`
+			jobConfigs: []string{
+				`
 presubmits:
   k/k:
   - name: my-job
@@ -3462,7 +3467,6 @@ postsubmits:
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-
 			// save the config
 			prowConfigDir := t.TempDir()
 
@@ -3597,7 +3601,7 @@ func TestReadJobConfigProwIgnore(t *testing.T) {
 		"extraneous.md": `I am unrelated.`,
 	}
 
-	var testCases = []struct {
+	testCases := []struct {
 		name   string
 		files  map[string]string
 		verify func(*JobConfig) error
@@ -3880,11 +3884,10 @@ func TestSecretAgentLoading(t *testing.T) {
 	if len(errors) > 0 {
 		t.Fatal(errors)
 	}
-
 }
 
 func TestValidGitHubReportType(t *testing.T) {
-	var testCases = []struct {
+	testCases := []struct {
 		name        string
 		prowConfig  string
 		expectError bool
@@ -3942,7 +3945,7 @@ github_reporter:
 }
 
 func TestRerunAuthConfigsGetRerunAuthConfig(t *testing.T) {
-	var testCases = []struct {
+	testCases := []struct {
 		name     string
 		configs  RerunAuthConfigs
 		jobSpec  *prowapi.ProwJobSpec
@@ -4065,7 +4068,7 @@ func TestRerunAuthConfigsGetRerunAuthConfig(t *testing.T) {
 }
 
 func TestDefaultRerunAuthConfigsGetRerunAuthConfig(t *testing.T) {
-	var testCases = []struct {
+	testCases := []struct {
 		name     string
 		configs  []*DefaultRerunAuthConfigEntry
 		jobSpec  *prowapi.ProwJobSpec
@@ -4354,7 +4357,7 @@ func TestDefaultRerunAuthConfigsGetRerunAuthConfig(t *testing.T) {
 }
 
 func TestMergeCommitTemplateLoading(t *testing.T) {
-	var testCases = []struct {
+	testCases := []struct {
 		name        string
 		prowConfig  string
 		expectError bool
@@ -4599,13 +4602,15 @@ func TestValidateComponentConfig(t *testing.T) {
 		{
 			name: "Valid default URL, no err",
 			config: &Config{ProwConfig: ProwConfig{Plank: Plank{
-				JobURLPrefixConfig: map[string]string{"*": "https://my-prow"}}}},
+				JobURLPrefixConfig: map[string]string{"*": "https://my-prow"},
+			}}},
 			errExpected: false,
 		},
 		{
 			name: "Invalid default URL, err",
 			config: &Config{ProwConfig: ProwConfig{Plank: Plank{
-				JobURLPrefixConfig: map[string]string{"*": "https:// my-prow"}}}},
+				JobURLPrefixConfig: map[string]string{"*": "https:// my-prow"},
+			}}},
 			errExpected: true,
 		},
 		{
@@ -4655,7 +4660,8 @@ func TestValidateComponentConfig(t *testing.T) {
 					"*":              "https://my-prow",
 					"my-org":         "https://my-alternate-prow",
 					"my-org/my-repo": "https://my-third-prow",
-				}}}},
+				},
+			}}},
 			errExpected: false,
 		},
 		{
@@ -4665,7 +4671,8 @@ func TestValidateComponentConfig(t *testing.T) {
 					"*":              "https://my-prow",
 					"my-org":         "https://my-alternate-prow",
 					"my-org/my-repo": "https:// my-third-prow",
-				}}}},
+				},
+			}}},
 			errExpected: true,
 		},
 		{
@@ -4878,6 +4885,7 @@ func TestSlackReporterValidation(t *testing.T) {
 		})
 	}
 }
+
 func TestManagedHmacEntityValidation(t *testing.T) {
 	testCases := []struct {
 		name       string
@@ -4916,15 +4924,14 @@ func TestManagedHmacEntityValidation(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-
 			err := tc.prowConfig.validateComponentConfig()
 			if tc.shouldFail != (err != nil) {
 				t.Errorf("%s: Unexpected outcome. Error expected %v, Error found %s", tc.name, tc.shouldFail, err)
 			}
-
 		})
 	}
 }
+
 func TestValidateTriggering(t *testing.T) {
 	testCases := []struct {
 		name        string
@@ -5043,7 +5050,8 @@ func TestRefGetterForGitHubPullRequest(t *testing.T) {
 			name: "PullRequest is fetched, stored and returned",
 			rg: &RefGetterForGitHubPullRequest{
 				ghc: &fakegithub.FakeClient{
-					PullRequests: map[int]*github.PullRequest{0: {ID: 123456}}},
+					PullRequests: map[int]*github.PullRequest{0: {ID: 123456}},
+				},
 			},
 			verify: func(rg *RefGetterForGitHubPullRequest) error {
 				pr, err := rg.PullRequest()
@@ -7918,7 +7926,6 @@ func TestDefaultAndValidateReportTemplate(t *testing.T) {
 		expected    *Controller
 		expectedErr bool
 	}{
-
 		{
 			id:         "no report_template or report_templates specified, no changes expected",
 			controller: &Controller{},
@@ -8194,7 +8201,7 @@ func TestValidatePeriodics(t *testing.T) {
 			periodics: []Periodic{
 				{JobBase: JobBase{Name: "a"}, Cron: "hello"},
 			},
-			expectedError: "invalid cron string hello in periodic a: Expected 5 or 6 fields, found 1: hello",
+			expectedError: "invalid cron string hello in periodic a: expected 5 to 6 fields, found 1: [hello]",
 		},
 		{
 			name: "Invalid interval",
@@ -8243,6 +8250,20 @@ func TestValidatePeriodics(t *testing.T) {
 			expected: []Periodic{
 				{JobBase: JobBase{Name: "a"}, MinimumInterval: "10ns", minimum_interval: time.Duration(10)},
 			},
+		},
+		{
+			name: "Valid 5-field cron",
+			periodics: []Periodic{
+				{JobBase: JobBase{Name: "a"}, Cron: "05 15 * * 1-5"},
+			},
+			expectedError: "",
+		},
+		{
+			name: "Valid 6-field cron",
+			periodics: []Periodic{
+				{JobBase: JobBase{Name: "a"}, Cron: "0 05 15 * * 1-5"},
+			},
+			expectedError: "",
 		},
 	}
 
@@ -8998,7 +9019,6 @@ func TestHasConfigFor(t *testing.T) {
 					t.Errorf("expected repos differ from actual: %s", diff)
 				}
 			}
-
 		})
 	}
 }
@@ -9186,10 +9206,8 @@ func TestProwConfigMergingProperties(t *testing.T) {
 	// Do not parallelize, the PRNG used by the fuzzer is not threadsafe
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-
 			for _, propertyTest := range expectedProperties {
 				t.Run(propertyTest.name, func(t *testing.T) {
-
 					for range 100 {
 						fuzzedConfig := &ProwConfig{}
 						fuzzedConfig.SlackReporterConfigs = map[string]SlackReporter{}
@@ -9459,7 +9477,8 @@ func TestGetAndCheckRefs(t *testing.T) {
 			baseSHAGetter: goodSHAGetter("ba5e"),
 			headSHAGetters: []RefGetter{
 				goodSHAGetter("abcd"),
-				goodSHAGetter("ef01")},
+				goodSHAGetter("ef01"),
+			},
 			expected: expected{
 				baseSHA:  "ba5e",
 				headSHAs: []string{"abcd", "ef01"},
@@ -9481,7 +9500,8 @@ func TestGetAndCheckRefs(t *testing.T) {
 			baseSHAGetter: badSHAGetter,
 			headSHAGetters: []RefGetter{
 				goodSHAGetter("abcd"),
-				goodSHAGetter("ef01")},
+				goodSHAGetter("ef01"),
+			},
 			expected: expected{
 				baseSHA:  "",
 				headSHAs: nil,
@@ -9493,7 +9513,8 @@ func TestGetAndCheckRefs(t *testing.T) {
 			baseSHAGetter: goodSHAGetter("ba5e"),
 			headSHAGetters: []RefGetter{
 				goodSHAGetter("abcd"),
-				badSHAGetter},
+				badSHAGetter,
+			},
 			expected: expected{
 				baseSHA:  "",
 				headSHAs: nil,

--- a/pkg/cron/cron.go
+++ b/pkg/cron/cron.go
@@ -22,12 +22,16 @@ import (
 	"strings"
 	"sync"
 
+	cron "github.com/robfig/cron/v3"
 	"github.com/sirupsen/logrus"
-	cron "gopkg.in/robfig/cron.v2" // using v2 api, doc at https://godoc.org/gopkg.in/robfig/cron.v2
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	"sigs.k8s.io/prow/pkg/config"
+)
+
+var cronParser = cron.NewParser(
+	cron.SecondOptional | cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow | cron.Descriptor,
 )
 
 // jobStatus is a cache layer for tracking existing cron jobs
@@ -52,7 +56,7 @@ type Cron struct {
 // New makes a new Cron object
 func New() *Cron {
 	return &Cron{
-		cronAgent: cron.New(),
+		cronAgent: cron.New(cron.WithParser(cronParser)),
 		jobs:      map[string]*jobStatus{},
 		logger:    logrus.WithField("client", "cron"),
 	}
@@ -156,7 +160,6 @@ func (c *Cron) addJob(name, cron string) error {
 		c.jobs[name].triggered = true
 		c.logger.Infof("Triggering cron job %s.", name)
 	})
-
 	if err != nil {
 		return fmt.Errorf("cronAgent fails to add job %s with cron %s: %w", name, cron, err)
 	}

--- a/pkg/cron/cron_test.go
+++ b/pkg/cron/cron_test.go
@@ -19,7 +19,7 @@ package cron
 import (
 	"testing"
 
-	cron "gopkg.in/robfig/cron.v2"
+	cron "github.com/robfig/cron/v3"
 	"sigs.k8s.io/prow/pkg/config"
 )
 


### PR DESCRIPTION
Upgrade `gopkg.in/robfig/cron.v2` to `github.com/robfig/cron/v3`.

As mentioned in  https://github.com/robfig/cron#upgrading-to-v3-june-2019, the path of the gomodules has been changed. Hence upgrading the gomodule to the new path.

Reference:
* https://github.com/robfig/cron#upgrading-to-v3-june-2019
* https://pkg.go.dev/github.com/robfig/cron/v3