### PR TITLE
auxiliary extra_refs

### DIFF
--- a/config/prow/cluster/prowjob-crd/prowjob_customresourcedefinition.yaml
+++ b/config/prow/cluster/prowjob-crd/prowjob_customresourcedefinition.yaml
@@ -1623,6 +1623,18 @@ spec:
                 items:
                   description: Refs describes how the repo was constructed.
                   properties:
+                    auxiliary:
+                      description: |-
+                        Auxiliary indicates that the repository really only provides
+                        auxiliary files for the job and is not the main repository that is
+                        being tested.
+                        This is relevant when determining which version to record in a
+                        periodic job's started.json file: the first repository where
+                        Auxiliary is false or unset is considered the main repository
+                        and determines the version.
+                        In presubmit jobs the version always comes from the repository
+                        for which the job is defined.
+                      type: boolean
                     base_link:
                       description: BaseLink is a link to the commit identified by
                         BaseSHA.
@@ -9730,6 +9742,18 @@ spec:
                   Refs is the code under test, determined at
                   runtime by Prow itself
                 properties:
+                  auxiliary:
+                    description: |-
+                      Auxiliary indicates that the repository really only provides
+                      auxiliary files for the job and is not the main repository that is
+                      being tested.
+                      This is relevant when determining which version to record in a
+                      periodic job's started.json file: the first repository where
+                      Auxiliary is false or unset is considered the main repository
+                      and determines the version.
+                      In presubmit jobs the version always comes from the repository
+                      for which the job is defined.
+                    type: boolean
                   base_link:
                     description: BaseLink is a link to the commit identified by BaseSHA.
                     type: string

--- a/pkg/apis/prowjobs/v1/types.go
+++ b/pkg/apis/prowjobs/v1/types.go
@@ -1222,6 +1222,19 @@ type Refs struct {
 	// directory.
 	WorkDir bool `json:"workdir,omitempty"`
 
+	// Auxiliary indicates that the repository really only provides
+	// auxiliary files for the job and is not the main repository that is
+	// being tested.
+	//
+	// This is relevant when determining which version to record in a
+	// periodic job's started.json file: the first repository where
+	// Auxiliary is false or unset is considered the main repository
+	// and determines the version.
+	//
+	// In presubmit jobs the version always comes from the repository
+	// for which the job is defined.
+	Auxiliary bool `json:"auxiliary,omitempty"`
+
 	// CloneURI is the URI that is used to clone the
 	// repository. If unset, will default to
 	// `https://github.com/org/repo.git`.

--- a/pkg/pod-utils/downwardapi/jobspec.go
+++ b/pkg/pod-utils/downwardapi/jobspec.go
@@ -217,11 +217,14 @@ func getRevisionFromRef(refs *prowapi.Refs) string {
 	return refs.BaseRef
 }
 
-// GetRevisionFromSpec returns a main ref or sha from a spec object
+// GetRevisionFromSpec returns a main ref or sha from a spec object.
+// Auxiliary extra references are ignored.
 func GetRevisionFromSpec(jobSpec *JobSpec) string {
 	return GetRevisionFromRefs(jobSpec.Refs, jobSpec.ExtraRefs)
 }
 
+// GetRevisionFromRefs returns a main ref or sha from main (if available) or extra references.
+// Auxiliary extra references are ignored.
 func GetRevisionFromRefs(refs *prowapi.Refs, extra []prowapi.Refs) string {
 	return getRevisionFromRef(mainRefs(refs, extra))
 }
@@ -230,8 +233,10 @@ func mainRefs(refs *prowapi.Refs, extra []prowapi.Refs) *prowapi.Refs {
 	if refs != nil {
 		return refs
 	}
-	if len(extra) > 0 {
-		return &extra[0]
+	for i := range extra {
+		if !extra[i].Auxiliary {
+			return &extra[i]
+		}
 	}
 	return nil
 }

--- a/pkg/pod-utils/downwardapi/jobspec_test.go
+++ b/pkg/pod-utils/downwardapi/jobspec_test.go
@@ -323,6 +323,35 @@ func TestGetRevisionFromSpec(t *testing.T) {
 			},
 			expected: "master",
 		},
+		{
+			name: "Refs from many extra_refs",
+			spec: JobSpec{
+				ExtraRefs: []prowapi.Refs{
+					{
+						BaseRef: "master",
+					},
+					{
+						BaseRef: "main",
+					},
+				},
+			},
+			expected: "master",
+		},
+		{
+			name: "Skip auxiliary extra ref",
+			spec: JobSpec{
+				ExtraRefs: []prowapi.Refs{
+					{
+						BaseRef:   "master",
+						Auxiliary: true,
+					},
+					{
+						BaseRef: "main",
+					},
+				},
+			},
+			expected: "main",
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Some periodic jobs have to check out repositories via extra_refs although they test something else:
- kops jobs must currently check out the kops repo to build the kops testgrid2 tester.
- Kubernetes E2E node jobs must check out test-infra to get the jobs/e2e_node files.

The kops tester could be built into the test image, but checking out test-infra is likely to be the permanent solution. Marking the kops resp. test-infra repo as "auxiliary" tells Prow that it must ignore them when determining the version for the started.json file. A kubetest2 tester then can set the actual version of what it is testing (typically a pre-built Kubernetes release package) in the metadata.json file.

This approach works with TestGrid's current logic of preferring a version from started.json over a metadata
version (https://github.com/GoogleCloudPlatform/testgrid/blob/d8498c5e9f91d4f8d76f1d62b9f4f7bc32862514/metadata/job.go#L185-L188) because it'll use the metadata version from finished.json when started.json doesn't have one. The metadata.json information gets copied into finished.json by https://github.com/kubernetes-sigs/prow/blob/71428b9c282ee8c9e7e9512068fccce86e7915da/pkg/sidecar/run.go#L127.

Discussion in Slack: https://kubernetes.slack.com/archives/C09QZ4DQB/p1779863293900129