### PR TITLE
trigger: add /test-manual-required command

### DIFF
--- a/pkg/pjutil/filter.go
+++ b/pkg/pjutil/filter.go
@@ -35,6 +35,9 @@ var RetestRe = regexp.MustCompile(`(?m)^/retest\s*$`)
 // RetestRe provides the regex for `/retest-required`
 var RetestRequiredRe = regexp.MustCompile(`(?m)^/retest-required\s*$`)
 
+// TestRequiredRe provides the regex for `/test-required`
+var TestRequiredRe = regexp.MustCompile(`(?m)^/test-required\s*$`)
+
 var OkToTestRe = regexp.MustCompile(`(?m)^/ok-to-test\s*$`)
 
 // OkToTestCancelRe checks for cancellation of the `/ok-to-test` approval
@@ -263,6 +266,27 @@ func (rrf *RetestRequiredFilter) Name() string {
 	return "retest-required-filter"
 }
 
+type TestRequiredFilter struct {
+	allContexts sets.Set[string]
+}
+
+func NewTestRequiredFilter(allContexts sets.Set[string]) *TestRequiredFilter {
+	return &TestRequiredFilter{
+		allContexts: allContexts,
+	}
+}
+
+func (trf *TestRequiredFilter) ShouldRun(ps config.Presubmit) (bool, bool, bool) {
+	if ps.Optional {
+		return false, false, false
+	}
+	return !trf.allContexts.Has(ps.Context), ps.NeedsExplicitTrigger(), false
+}
+
+func (trf *TestRequiredFilter) Name() string {
+	return "test-required-filter"
+}
+
 type contextGetter func() (sets.Set[string], sets.Set[string], error)
 
 // PresubmitFilter creates a filter for presubmits
@@ -290,6 +314,14 @@ func PresubmitFilter(honorOkToTest bool, contextGetter contextGetter, body strin
 			return nil, err
 		}
 		filters = append(filters, NewRetestRequiredFilter(failedContexts, allContexts))
+	}
+	if TestRequiredRe.MatchString(body) {
+		logger.Info("Using test-required filter")
+		_, allContexts, err := contextGetter()
+		if err != nil {
+			return nil, err
+		}
+		filters = append(filters, NewTestRequiredFilter(allContexts))
 	}
 	if (honorOkToTest && OkToTestRe.MatchString(body)) || TestAllRe.MatchString(body) {
 		logger.Debug("Using test-all filter.")

--- a/pkg/pjutil/filter.go
+++ b/pkg/pjutil/filter.go
@@ -35,6 +35,9 @@ var RetestRe = regexp.MustCompile(`(?m)^/retest\s*$`)
 // RetestRe provides the regex for `/retest-required`
 var RetestRequiredRe = regexp.MustCompile(`(?m)^/retest-required\s*$`)
 
+// TestManualRequiredRe provides the regex for `/test-manual-required`
+var TestManualRequiredRe = regexp.MustCompile(`(?m)^/test-manual-required\s*$`)
+
 var OkToTestRe = regexp.MustCompile(`(?m)^/ok-to-test\s*$`)
 
 // OkToTestCancelRe checks for cancellation of the `/ok-to-test` approval
@@ -263,6 +266,23 @@ func (rrf *RetestRequiredFilter) Name() string {
 	return "retest-required-filter"
 }
 
+type TestManualRequiredFilter struct{}
+
+func NewTestManualRequiredFilter() *TestManualRequiredFilter {
+	return &TestManualRequiredFilter{}
+}
+
+func (tmrf *TestManualRequiredFilter) ShouldRun(ps config.Presubmit) (bool, bool, bool) {
+	if ps.Optional || !ps.NeedsExplicitTrigger() || ps.RunIfChanged != "" || ps.SkipIfOnlyChanged != "" {
+		return false, false, false
+	}
+	return true, true, false
+}
+
+func (tmrf *TestManualRequiredFilter) Name() string {
+	return "test-manual-required-filter"
+}
+
 type contextGetter func() (sets.Set[string], sets.Set[string], error)
 
 // PresubmitFilter creates a filter for presubmits
@@ -290,6 +310,10 @@ func PresubmitFilter(honorOkToTest bool, contextGetter contextGetter, body strin
 			return nil, err
 		}
 		filters = append(filters, NewRetestRequiredFilter(failedContexts, allContexts))
+	}
+	if TestManualRequiredRe.MatchString(body) {
+		logger.Info("Using test-manual-required filter")
+		filters = append(filters, NewTestManualRequiredFilter())
 	}
 	if (honorOkToTest && OkToTestRe.MatchString(body)) || TestAllRe.MatchString(body) {
 		logger.Debug("Using test-all filter.")

--- a/pkg/pjutil/filter_test.go
+++ b/pkg/pjutil/filter_test.go
@@ -753,6 +753,85 @@ func TestPresubmitFilter(t *testing.T) {
 			expected: [][]bool{{false, false, false}, {false, false, false}, {false, false, false}, {true, false, true}, {true, false, false}},
 		},
 		{
+			name: "test-required command selects required contexts that have not run yet",
+			body: "/test-required",
+			org:  "org",
+			repo: "repo",
+			ref:  "ref",
+			presubmits: []config.Presubmit{
+				{
+					JobBase: config.JobBase{
+						Name: "successful-job",
+					},
+					Reporter: config.Reporter{
+						Context: "existing-successful",
+					},
+				},
+				{
+					JobBase: config.JobBase{
+						Name: "pending-job",
+					},
+					Reporter: config.Reporter{
+						Context: "existing-pending",
+					},
+				},
+				{
+					JobBase: config.JobBase{
+						Name: "failure-job",
+					},
+					Reporter: config.Reporter{
+						Context: "existing-failure",
+					},
+				},
+				{
+					JobBase: config.JobBase{
+						Name: "error-job",
+					},
+					Reporter: config.Reporter{
+						Context: "existing-error",
+					},
+				},
+				{
+					JobBase: config.JobBase{
+						Name: "missing-required",
+					},
+					AlwaysRun: true,
+					Reporter: config.Reporter{
+						Context: "missing-required",
+					},
+				},
+				{
+					JobBase: config.JobBase{
+						Name: "missing-optional",
+					},
+					AlwaysRun: true,
+					Optional:  true,
+					Reporter: config.Reporter{
+						Context: "missing-optional",
+					},
+				},
+				{
+					JobBase: config.JobBase{
+						Name: "missing-explicit",
+					},
+					Reporter: config.Reporter{
+						Context: "missing-explicit",
+					},
+					Trigger:      `(?m)^/test (?:.*? )?explicit(?: .*?)?$`,
+					RerunCommand: "/test explicit",
+				},
+			},
+			expected: [][]bool{
+				{false, false, false},
+				{false, false, false},
+				{false, false, false},
+				{false, false, false},
+				{true, false, false},
+				{false, false, false},
+				{true, true, false},
+			},
+		},
+		{
 			name: "explicit test command filters for jobs that match",
 			body: "/test trigger",
 			org:  "org",

--- a/pkg/pjutil/filter_test.go
+++ b/pkg/pjutil/filter_test.go
@@ -465,12 +465,12 @@ func TestPresubmitFilter(t *testing.T) {
 		},
 	}}
 	var testCases = []struct {
-		name                 string
-		honorOkToTest        bool
-		body, org, repo, ref string
-		presubmits           []config.Presubmit
-		expected             [][]bool
-		statusErr, expectErr bool
+		name                  string
+		honorOkToTest         bool
+		body, org, repo, ref  string
+		presubmits            []config.Presubmit
+		expected              [][]bool
+		statusErr, expectErr  bool
 	}{
 		{
 			name: "test all comment selects all tests that don't need an explicit trigger",
@@ -751,6 +751,58 @@ func TestPresubmitFilter(t *testing.T) {
 				},
 			},
 			expected: [][]bool{{false, false, false}, {false, false, false}, {false, false, false}, {true, false, true}, {true, false, false}},
+		},
+		{
+			name: "test-manual-required triggers only required manual jobs without file conditions",
+			body: "/test-manual-required",
+			org:  "org",
+			repo: "repo",
+			ref:  "ref",
+			presubmits: []config.Presubmit{
+				{
+					JobBase:      config.JobBase{Name: "manual-required"},
+					Reporter:     config.Reporter{Context: "manual-required"},
+					Trigger:      `(?m)^/test (?:.*? )?manual(?: .*?)?$`,
+					RerunCommand: "/test manual",
+				},
+				{
+					JobBase:      config.JobBase{Name: "manual-optional"},
+					Optional:     true,
+					Reporter:     config.Reporter{Context: "manual-optional"},
+					Trigger:      `(?m)^/test (?:.*? )?manual-optional(?: .*?)?$`,
+					RerunCommand: "/test manual-optional",
+				},
+				{
+					JobBase:   config.JobBase{Name: "always-runs"},
+					AlwaysRun: true,
+					Reporter:  config.Reporter{Context: "always-runs"},
+				},
+				{
+					JobBase:      config.JobBase{Name: "run-if-changed"},
+					Reporter:     config.Reporter{Context: "run-if-changed"},
+					Trigger:      `(?m)^/test (?:.*? )?conditional(?: .*?)?$`,
+					RerunCommand: "/test conditional",
+					RegexpChangeMatcher: config.RegexpChangeMatcher{
+						RunIfChanged: "sometimes",
+					},
+				},
+				{
+					JobBase:      config.JobBase{Name: "skip-if-only-changed"},
+					Reporter:     config.Reporter{Context: "skip-if-only-changed"},
+					Trigger:      `(?m)^/test (?:.*? )?skip(?: .*?)?$`,
+					RerunCommand: "/test skip",
+					RegexpChangeMatcher: config.RegexpChangeMatcher{
+						SkipIfOnlyChanged: "sometimes",
+					},
+				},
+			},
+			expected: [][]bool{
+				{true, true, false},
+				{false, false, false},
+				{false, false, false},
+				{false, false, false},
+				{false, false, false},
+			},
 		},
 		{
 			name: "explicit test command filters for jobs that match",

--- a/pkg/plugins/trigger/generic-comment.go
+++ b/pkg/plugins/trigger/generic-comment.go
@@ -216,6 +216,7 @@ func HonorOkToTest(trigger plugins.Trigger) bool {
 func commentMatchesTrigger(text string, presubmits []config.Presubmit) bool {
 	if pjutil.RetestRe.MatchString(text) ||
 		pjutil.RetestRequiredRe.MatchString(text) ||
+		pjutil.TestRequiredRe.MatchString(text) ||
 		pjutil.OkToTestRe.MatchString(text) ||
 		pjutil.OkToTestCancelRe.MatchString(text) ||
 		pjutil.TestAllRe.MatchString(text) ||

--- a/pkg/plugins/trigger/generic-comment.go
+++ b/pkg/plugins/trigger/generic-comment.go
@@ -216,6 +216,7 @@ func HonorOkToTest(trigger plugins.Trigger) bool {
 func commentMatchesTrigger(text string, presubmits []config.Presubmit) bool {
 	if pjutil.RetestRe.MatchString(text) ||
 		pjutil.RetestRequiredRe.MatchString(text) ||
+		pjutil.TestManualRequiredRe.MatchString(text) ||
 		pjutil.OkToTestRe.MatchString(text) ||
 		pjutil.OkToTestCancelRe.MatchString(text) ||
 		pjutil.TestAllRe.MatchString(text) ||
@@ -247,6 +248,9 @@ type GitHubClient interface {
 //   - if we got a /test all or an /ok-to-test, we want to consider any job
 //     that doesn't explicitly require a human trigger comment; jobs will
 //     default to not run unless we can determine that they should
+//   - if we got a /test-manual-required, we trigger all required manually
+//     triggered jobs unconditionally. This only includes jobs that need an
+//     explicit trigger and do not use run_if_changed or skip_if_only_changed.
 //
 // If a comment that we get matches more than one of the above patterns, we
 // consider the set of matching presubmits the union of the results from the

--- a/pkg/plugins/trigger/generic-comment_test.go
+++ b/pkg/plugins/trigger/generic-comment_test.go
@@ -596,6 +596,79 @@ func TestHandleGenericComment(t *testing.T) {
 			PruneHelp: true,
 		},
 		{
+			name:   "Test-Required triggers missing required job",
+			Author: "trusted-member",
+			Body:   "/test-required",
+			State:  "open",
+			IsPR:   true,
+			Presubmits: map[string][]config.Presubmit{
+				"org/repo": {
+					{
+						JobBase: config.JobBase{
+							Name: "jab",
+						},
+						AlwaysRun: true,
+						Reporter: config.Reporter{
+							Context: "pull-jab",
+						},
+						Trigger:      `(?m)^/test (?:.*? )?jab(?: .*?)?$`,
+						RerunCommand: `/test jab`,
+					},
+				},
+			},
+			ShouldBuild:   true,
+			StartsExactly: "pull-jab",
+			PruneHelp:     true,
+		},
+		{
+			name:   "Test-Required doesn't trigger missing optional job",
+			Author: "trusted-member",
+			Body:   "/test-required",
+			State:  "open",
+			IsPR:   true,
+			Presubmits: map[string][]config.Presubmit{
+				"org/repo": {
+					{
+						JobBase: config.JobBase{
+							Name: "jab",
+						},
+						AlwaysRun: true,
+						Optional:  true,
+						Reporter: config.Reporter{
+							Context: "pull-jab",
+						},
+						Trigger:      `(?m)^/test (?:.*? )?jab(?: .*?)?$`,
+						RerunCommand: `/test jab`,
+					},
+				},
+			},
+			PruneHelp: true,
+		},
+		{
+			name:   "Test-Required triggers missing required explicit job",
+			Author: "trusted-member",
+			Body:   "/test-required",
+			State:  "open",
+			IsPR:   true,
+			Presubmits: map[string][]config.Presubmit{
+				"org/repo": {
+					{
+						JobBase: config.JobBase{
+							Name: "jab",
+						},
+						Reporter: config.Reporter{
+							Context: "pull-jab",
+						},
+						Trigger:      `(?m)^/test (?:.*? )?jab(?: .*?)?$`,
+						RerunCommand: `/test jab`,
+					},
+				},
+			},
+			ShouldBuild:   true,
+			StartsExactly: "pull-jab",
+			PruneHelp:     true,
+		},
+		{
 			name:   "Retest of run_if_changed job that failed. Changes do not require the job",
 			Author: "trusted-member",
 			Body:   "/retest",

--- a/pkg/plugins/trigger/generic-comment_test.go
+++ b/pkg/plugins/trigger/generic-comment_test.go
@@ -596,6 +596,88 @@ func TestHandleGenericComment(t *testing.T) {
 			PruneHelp: true,
 		},
 		{
+			name:   "Test-Manual-Required triggers missing required manual job",
+			Author: "trusted-member",
+			Body:   "/test-manual-required",
+			State:  "open",
+			IsPR:   true,
+			Presubmits: map[string][]config.Presubmit{
+				"org/repo": {
+					{
+						JobBase: config.JobBase{
+							Name: "jab",
+						},
+						Reporter: config.Reporter{
+							Context: "pull-jab",
+						},
+						Trigger:      `(?m)^/test (?:.*? )?jab(?: .*?)?$`,
+						RerunCommand: `/test jab`,
+					},
+				},
+			},
+			ShouldBuild:   true,
+			StartsExactly: "pull-jab",
+			PruneHelp:     true,
+		},
+		{
+			name:   "Test-Manual-Required doesn't trigger missing optional job",
+			Author: "trusted-member",
+			Body:   "/test-manual-required",
+			State:  "open",
+			IsPR:   true,
+			Presubmits: map[string][]config.Presubmit{
+				"org/repo": {
+					{
+						JobBase: config.JobBase{
+							Name: "jab",
+						},
+						Optional: true,
+						Reporter: config.Reporter{
+							Context: "pull-jab",
+						},
+						Trigger:      `(?m)^/test (?:.*? )?jab(?: .*?)?$`,
+						RerunCommand: `/test jab`,
+					},
+				},
+			},
+			PruneHelp: true,
+		},
+		{
+			name:   "Test-Manual-Required does not trigger always_run or conditional jobs",
+			Author: "trusted-member",
+			Body:   "/test-manual-required",
+			State:  "open",
+			IsPR:   true,
+			Presubmits: map[string][]config.Presubmit{
+				"org/repo": {
+					{
+						JobBase: config.JobBase{
+							Name: "always-run",
+						},
+						AlwaysRun: true,
+						Reporter: config.Reporter{
+							Context: "pull-always-run",
+						},
+						Trigger:      `(?m)^/test (?:.*? )?always-run(?: .*?)?$`,
+						RerunCommand: `/test always-run`,
+					},
+					{
+						JobBase: config.JobBase{
+							Name: "conditional",
+						},
+						RegexpChangeMatcher: config.RegexpChangeMatcher{RunIfChanged: "CHANGED"},
+						Reporter: config.Reporter{
+							Context: "pull-conditional",
+						},
+						Trigger:      `(?m)^/test (?:.*? )?conditional(?: .*?)?$`,
+						RerunCommand: `/test conditional`,
+					},
+				},
+			},
+			ShouldBuild: false,
+			PruneHelp:   true,
+		},
+		{
 			name:   "Retest of run_if_changed job that failed. Changes do not require the job",
 			Author: "trusted-member",
 			Body:   "/retest",

--- a/pkg/plugins/trigger/trigger.go
+++ b/pkg/plugins/trigger/trigger.go
@@ -111,6 +111,7 @@ func helpProvider(config *plugins.Configuration, enabledRepos []config.OrgRepo) 
 <br>Trigger will not automatically start jobs for a PR in draft state, and if a PR is changed to draft it cancels pending jobs.
 <br>If jobs are not run automatically for a PR because it is not trusted or is in draft state, a trusted user can still start jobs manually via the '/test' command.
 <br>The '/retest' command can be used to rerun jobs that have reported failure.
+<br>The '/test-required' command can be used to start required presubmit jobs that have not run yet.
 <br>Trigger starts postsubmit jobs when commits are pushed if the filters on the job match files and branches affected by that push.`,
 		Config:  configInfo,
 		Snippet: yamlSnippet,
@@ -142,6 +143,13 @@ func helpProvider(config *plugins.Configuration, enabledRepos []config.OrgRepo) 
 		Featured:    true,
 		WhoCanUse:   "Anyone can trigger this command on a trusted PR.",
 		Examples:    []string{"/retest"},
+	})
+	pluginHelp.AddCommand(pluginhelp.Command{
+		Usage:       "/test-required",
+		Description: "Manually starts required presubmit jobs that have not run yet.",
+		Featured:    true,
+		WhoCanUse:   "Anyone can trigger this command on a trusted PR.",
+		Examples:    []string{"/test-required"},
 	})
 	pluginHelp.AddCommand(pluginhelp.Command{
 		Usage:       "/test ?",

--- a/pkg/plugins/trigger/trigger.go
+++ b/pkg/plugins/trigger/trigger.go
@@ -111,6 +111,7 @@ func helpProvider(config *plugins.Configuration, enabledRepos []config.OrgRepo) 
 <br>Trigger will not automatically start jobs for a PR in draft state, and if a PR is changed to draft it cancels pending jobs.
 <br>If jobs are not run automatically for a PR because it is not trusted or is in draft state, a trusted user can still start jobs manually via the '/test' command.
 <br>The '/retest' command can be used to rerun jobs that have reported failure.
+<br>The '/test-manual-required' command can be used to start required manually triggered presubmit jobs.
 <br>Trigger starts postsubmit jobs when commits are pushed if the filters on the job match files and branches affected by that push.`,
 		Config:  configInfo,
 		Snippet: yamlSnippet,
@@ -142,6 +143,13 @@ func helpProvider(config *plugins.Configuration, enabledRepos []config.OrgRepo) 
 		Featured:    true,
 		WhoCanUse:   "Anyone can trigger this command on a trusted PR.",
 		Examples:    []string{"/retest"},
+	})
+	pluginHelp.AddCommand(pluginhelp.Command{
+		Usage:       "/test-manual-required",
+		Description: "Manually starts required presubmit jobs that require an explicit trigger and do not use file change conditions.",
+		Featured:    true,
+		WhoCanUse:   "Anyone can trigger this command on a trusted PR.",
+		Examples:    []string{"/test-manual-required"},
 	})
 	pluginHelp.AddCommand(pluginhelp.Command{
 		Usage:       "/test ?",


### PR DESCRIPTION
This PR adds `/test-manual-required command` to trigger required presubmits that need an explicit trigger and have no file-based conditions.

Fixes: #729 