### PR TITLE
invalidcommitmsg: add config surface for fixup commit checking

### DIFF
--- a/pkg/plugins/config.go
+++ b/pkg/plugins/config.go
@@ -97,6 +97,7 @@ type Configuration struct {
 	Welcome              []Welcome                    `json:"welcome,omitempty"`
 	Override             Override                     `json:"override,omitempty"`
 	Help                 Help                         `json:"help,omitempty"`
+	InvalidCommitMsg     []InvalidCommitMsg           `json:"invalid_commit_msg,omitempty"`
 }
 
 type Help struct {
@@ -116,6 +117,19 @@ func (h *Help) setDefaults() {
 	if h.HelpGuidelinesURL == "" {
 		h.HelpGuidelinesURL = "https://git.k8s.io/community/contributors/guide/help-wanted.md"
 	}
+}
+
+// InvalidCommitMsg is config for the invalidcommitmsg plugin.
+type InvalidCommitMsg struct {
+	// Repos is either of the form org/repos or just org.
+	Repos []string `json:"repos,omitempty"`
+	// CheckFixupCommits enables checking for fixup!/amend!/squash! commits.
+	// When enabled, PRs with such commits will be labeled with do-not-merge/invalid-commit-message.
+	CheckFixupCommits bool `json:"check_fixup_commits,omitempty"`
+}
+
+func (i InvalidCommitMsg) getRepos() []string {
+	return i.Repos
 }
 
 // Golint holds configuration for the golint plugin
@@ -1094,6 +1108,28 @@ func (c *Configuration) DcoFor(org, repo string) *Dco {
 	return &Dco{}
 }
 
+// InvalidCommitMsgFor finds the InvalidCommitMsg configuration for a repo, if one exists.
+// A configuration can be listed for the repo itself or for the owning organization.
+func (c *Configuration) InvalidCommitMsgFor(org, repo string) *InvalidCommitMsg {
+	fullName := fmt.Sprintf("%s/%s", org, repo)
+	// Prioritize repo level triggers over org level triggers.
+	for _, cfg := range c.InvalidCommitMsg {
+		if !sets.New[string](cfg.Repos...).Has(fullName) {
+			continue
+		}
+		return &cfg
+	}
+	// If you don't find anything, loop again looking for an org config
+	for _, cfg := range c.InvalidCommitMsg {
+		if !sets.New[string](cfg.Repos...).Has(org) {
+			continue
+		}
+		return &cfg
+	}
+
+	return &InvalidCommitMsg{}
+}
+
 func OldToNewPlugins(oldPlugins map[string][]string) Plugins {
 	newPlugins := make(Plugins)
 	for repo, plugins := range oldPlugins {
@@ -1471,6 +1507,18 @@ func validateTrigger(triggers []Trigger) error {
 	}
 	return nil
 }
+func validateInvalidCommitMsg(cfgs []InvalidCommitMsg) error {
+	var errs []error
+	for i, cfg := range cfgs {
+		for _, repo := range cfg.Repos {
+			if strings.TrimSpace(repo) == "" {
+				errs = append(errs, fmt.Errorf(
+					"error validating invalid_commit_msg config #%d: repo %q must be of form org or org/repo", i, repo))
+			}
+		}
+	}
+	return utilerrors.NewAggregate(errs)
+}
 
 var warnRepoMilestone time.Time
 
@@ -1585,6 +1633,12 @@ func (c *Configuration) Validate() error {
 		return err
 	}
 	if err := validateRepoDupes(c.Welcome); err != nil {
+		return err
+	}
+	if err := validateInvalidCommitMsg(c.InvalidCommitMsg); err != nil {
+		return err
+	}
+	if err := validateRepoDupes(c.InvalidCommitMsg); err != nil {
 		return err
 	}
 	validateRepoMilestone(c.RepoMilestone)

--- a/pkg/plugins/config.go
+++ b/pkg/plugins/config.go
@@ -123,13 +123,31 @@ func (h *Help) setDefaults() {
 type InvalidCommitMsg struct {
 	// Repos is either of the form org/repos or just org.
 	Repos []string `json:"repos,omitempty"`
-	// CheckFixupCommits enables checking for fixup!/amend!/squash! commits.
-	// When enabled, PRs with such commits will be labeled with do-not-merge/invalid-commit-message.
-	CheckFixupCommits bool `json:"check_fixup_commits,omitempty"`
+	// Checks is a list of check configurations.
+	// Each check can be individually enabled or disabled.
+	Checks []InvalidCommitMsgCheck `json:"checks,omitempty"`
+}
+
+// InvalidCommitMsgCheck represents a single check configuration.
+type InvalidCommitMsgCheck struct {
+	// Name is the name of the check (e.g., "fixupPrefix", "issueClosingKeywords").
+	Name string `json:"name"`
+	// Disabled indicates whether this check should be skipped.
+	Disabled bool `json:"disabled,omitempty"`
 }
 
 func (i InvalidCommitMsg) getRepos() []string {
 	return i.Repos
+}
+
+// IsCheckDisabled returns true if the named check is disabled in the configuration.
+func (i *InvalidCommitMsg) IsCheckDisabled(checkName string) bool {
+	for _, check := range i.Checks {
+		if check.Name == checkName {
+			return check.Disabled
+		}
+	}
+	return false
 }
 
 // Golint holds configuration for the golint plugin
@@ -1507,6 +1525,9 @@ func validateTrigger(triggers []Trigger) error {
 	}
 	return nil
 }
+
+var validInvalidCommitMsgChecks = sets.New[string]("fixupPrefix", "issueClosingKeywords")
+
 func validateInvalidCommitMsg(cfgs []InvalidCommitMsg) error {
 	var errs []error
 	for i, cfg := range cfgs {
@@ -1514,6 +1535,16 @@ func validateInvalidCommitMsg(cfgs []InvalidCommitMsg) error {
 			if strings.TrimSpace(repo) == "" {
 				errs = append(errs, fmt.Errorf(
 					"error validating invalid_commit_msg config #%d: repo %q must be of form org or org/repo", i, repo))
+			}
+		}
+		for j, check := range cfg.Checks {
+			if strings.TrimSpace(check.Name) == "" {
+				errs = append(errs, fmt.Errorf(
+					"error validating invalid_commit_msg config #%d check #%d: check name cannot be empty", i, j))
+			} else if !validInvalidCommitMsgChecks.Has(check.Name) {
+				errs = append(errs, fmt.Errorf(
+					"error validating invalid_commit_msg config #%d check #%d: unknown check name %q (valid: %v)",
+					i, j, check.Name, sets.List(validInvalidCommitMsgChecks)))
 			}
 		}
 	}

--- a/pkg/plugins/config_test.go
+++ b/pkg/plugins/config_test.go
@@ -2750,8 +2750,10 @@ func TestValidateInvalidCommitMsg(t *testing.T) {
 			name: "valid config",
 			config: []InvalidCommitMsg{
 				{
-					Repos:             []string{"kubernetes/test-infra", "kubernetes"},
-					CheckFixupCommits: true,
+					Repos: []string{"kubernetes/test-infra", "kubernetes"},
+					Checks: []InvalidCommitMsgCheck{
+						{Name: "fixupPrefix", Disabled: false},
+					},
 				},
 			},
 			expectedErr: false,
@@ -2760,8 +2762,10 @@ func TestValidateInvalidCommitMsg(t *testing.T) {
 			name: "empty repo name",
 			config: []InvalidCommitMsg{
 				{
-					Repos:             []string{"kubernetes/test-infra", ""},
-					CheckFixupCommits: true,
+					Repos: []string{"kubernetes/test-infra", ""},
+					Checks: []InvalidCommitMsgCheck{
+						{Name: "fixupPrefix"},
+					},
 				},
 			},
 			expectedErr: true,
@@ -2770,8 +2774,34 @@ func TestValidateInvalidCommitMsg(t *testing.T) {
 			name: "whitespace repo name",
 			config: []InvalidCommitMsg{
 				{
-					Repos:             []string{"kubernetes/test-infra", "  "},
-					CheckFixupCommits: false,
+					Repos: []string{"kubernetes/test-infra", "  "},
+					Checks: []InvalidCommitMsgCheck{
+						{Name: "fixupPrefix", Disabled: true},
+					},
+				},
+			},
+			expectedErr: true,
+		},
+		{
+			name: "invalid check name",
+			config: []InvalidCommitMsg{
+				{
+					Repos: []string{"kubernetes"},
+					Checks: []InvalidCommitMsgCheck{
+						{Name: "invalidCheck"},
+					},
+				},
+			},
+			expectedErr: true,
+		},
+		{
+			name: "empty check name",
+			config: []InvalidCommitMsg{
+				{
+					Repos: []string{"kubernetes"},
+					Checks: []InvalidCommitMsgCheck{
+						{Name: ""},
+					},
 				},
 			},
 			expectedErr: true,
@@ -2804,20 +2834,26 @@ func TestInvalidCommitMsgFor(t *testing.T) {
 			config: Configuration{
 				InvalidCommitMsg: []InvalidCommitMsg{
 					{
-						Repos:             []string{"kubernetes/test-infra"},
-						CheckFixupCommits: true,
+						Repos: []string{"kubernetes/test-infra"},
+						Checks: []InvalidCommitMsgCheck{
+							{Name: "fixupPrefix", Disabled: false},
+						},
 					},
 					{
-						Repos:             []string{"kubernetes"},
-						CheckFixupCommits: false,
+						Repos: []string{"kubernetes"},
+						Checks: []InvalidCommitMsgCheck{
+							{Name: "fixupPrefix", Disabled: true},
+						},
 					},
 				},
 			},
 			org:  "kubernetes",
 			repo: "test-infra",
 			expected: InvalidCommitMsg{
-				Repos:             []string{"kubernetes/test-infra"},
-				CheckFixupCommits: true,
+				Repos: []string{"kubernetes/test-infra"},
+				Checks: []InvalidCommitMsgCheck{
+					{Name: "fixupPrefix", Disabled: false},
+				},
 			},
 		},
 		{
@@ -2825,16 +2861,20 @@ func TestInvalidCommitMsgFor(t *testing.T) {
 			config: Configuration{
 				InvalidCommitMsg: []InvalidCommitMsg{
 					{
-						Repos:             []string{"kubernetes"},
-						CheckFixupCommits: true,
+						Repos: []string{"kubernetes"},
+						Checks: []InvalidCommitMsgCheck{
+							{Name: "fixupPrefix", Disabled: false},
+						},
 					},
 				},
 			},
 			org:  "kubernetes",
 			repo: "community",
 			expected: InvalidCommitMsg{
-				Repos:             []string{"kubernetes"},
-				CheckFixupCommits: true,
+				Repos: []string{"kubernetes"},
+				Checks: []InvalidCommitMsgCheck{
+					{Name: "fixupPrefix", Disabled: false},
+				},
 			},
 		},
 		{
@@ -2842,8 +2882,10 @@ func TestInvalidCommitMsgFor(t *testing.T) {
 			config: Configuration{
 				InvalidCommitMsg: []InvalidCommitMsg{
 					{
-						Repos:             []string{"other-org"},
-						CheckFixupCommits: true,
+						Repos: []string{"other-org"},
+						Checks: []InvalidCommitMsgCheck{
+							{Name: "fixupPrefix", Disabled: false},
+						},
 					},
 				},
 			},
@@ -2856,20 +2898,26 @@ func TestInvalidCommitMsgFor(t *testing.T) {
 			config: Configuration{
 				InvalidCommitMsg: []InvalidCommitMsg{
 					{
-						Repos:             []string{"kubernetes"},
-						CheckFixupCommits: false,
+						Repos: []string{"kubernetes"},
+						Checks: []InvalidCommitMsgCheck{
+							{Name: "fixupPrefix", Disabled: true},
+						},
 					},
 					{
-						Repos:             []string{"kubernetes/test-infra"},
-						CheckFixupCommits: true,
+						Repos: []string{"kubernetes/test-infra"},
+						Checks: []InvalidCommitMsgCheck{
+							{Name: "fixupPrefix", Disabled: false},
+						},
 					},
 				},
 			},
 			org:  "kubernetes",
 			repo: "test-infra",
 			expected: InvalidCommitMsg{
-				Repos:             []string{"kubernetes/test-infra"},
-				CheckFixupCommits: true,
+				Repos: []string{"kubernetes/test-infra"},
+				Checks: []InvalidCommitMsgCheck{
+					{Name: "fixupPrefix", Disabled: false},
+				},
 			},
 		},
 	}

--- a/pkg/plugins/config_test.go
+++ b/pkg/plugins/config_test.go
@@ -2739,3 +2739,147 @@ func TestConfigMapSpecIsAllowed(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateInvalidCommitMsg(t *testing.T) {
+	tests := []struct {
+		name        string
+		config      []InvalidCommitMsg
+		expectedErr bool
+	}{
+		{
+			name: "valid config",
+			config: []InvalidCommitMsg{
+				{
+					Repos:             []string{"kubernetes/test-infra", "kubernetes"},
+					CheckFixupCommits: true,
+				},
+			},
+			expectedErr: false,
+		},
+		{
+			name: "empty repo name",
+			config: []InvalidCommitMsg{
+				{
+					Repos:             []string{"kubernetes/test-infra", ""},
+					CheckFixupCommits: true,
+				},
+			},
+			expectedErr: true,
+		},
+		{
+			name: "whitespace repo name",
+			config: []InvalidCommitMsg{
+				{
+					Repos:             []string{"kubernetes/test-infra", "  "},
+					CheckFixupCommits: false,
+				},
+			},
+			expectedErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := validateInvalidCommitMsg(test.config)
+			if test.expectedErr && err == nil {
+				t.Errorf("expected error but got none")
+			}
+			if !test.expectedErr && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestInvalidCommitMsgFor(t *testing.T) {
+	tests := []struct {
+		name     string
+		config   Configuration
+		org      string
+		repo     string
+		expected InvalidCommitMsg
+	}{
+		{
+			name: "repo level config",
+			config: Configuration{
+				InvalidCommitMsg: []InvalidCommitMsg{
+					{
+						Repos:             []string{"kubernetes/test-infra"},
+						CheckFixupCommits: true,
+					},
+					{
+						Repos:             []string{"kubernetes"},
+						CheckFixupCommits: false,
+					},
+				},
+			},
+			org:  "kubernetes",
+			repo: "test-infra",
+			expected: InvalidCommitMsg{
+				Repos:             []string{"kubernetes/test-infra"},
+				CheckFixupCommits: true,
+			},
+		},
+		{
+			name: "org level config",
+			config: Configuration{
+				InvalidCommitMsg: []InvalidCommitMsg{
+					{
+						Repos:             []string{"kubernetes"},
+						CheckFixupCommits: true,
+					},
+				},
+			},
+			org:  "kubernetes",
+			repo: "community",
+			expected: InvalidCommitMsg{
+				Repos:             []string{"kubernetes"},
+				CheckFixupCommits: true,
+			},
+		},
+		{
+			name: "no config",
+			config: Configuration{
+				InvalidCommitMsg: []InvalidCommitMsg{
+					{
+						Repos:             []string{"other-org"},
+						CheckFixupCommits: true,
+					},
+				},
+			},
+			org:      "kubernetes",
+			repo:     "test-infra",
+			expected: InvalidCommitMsg{},
+		},
+		{
+			name: "repo config takes precedence over org config",
+			config: Configuration{
+				InvalidCommitMsg: []InvalidCommitMsg{
+					{
+						Repos:             []string{"kubernetes"},
+						CheckFixupCommits: false,
+					},
+					{
+						Repos:             []string{"kubernetes/test-infra"},
+						CheckFixupCommits: true,
+					},
+				},
+			},
+			org:  "kubernetes",
+			repo: "test-infra",
+			expected: InvalidCommitMsg{
+				Repos:             []string{"kubernetes/test-infra"},
+				CheckFixupCommits: true,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result := test.config.InvalidCommitMsgFor(test.org, test.repo)
+			if !reflect.DeepEqual(*result, test.expected) {
+				t.Errorf("expected %+v, got %+v", test.expected, *result)
+			}
+		})
+	}
+}

--- a/pkg/plugins/invalidcommitmsg/invalidcommitmsg.go
+++ b/pkg/plugins/invalidcommitmsg/invalidcommitmsg.go
@@ -20,7 +20,6 @@ package invalidcommitmsg
 
 import (
 	"fmt"
-	"os"
 	"regexp"
 	"strings"
 
@@ -47,11 +46,14 @@ func init() {
 }
 
 func helpProvider(config *plugins.Configuration, _ []config.OrgRepo) (*pluginhelp.PluginHelp, error) {
-	// Only the Description field is specified because this plugin is not triggered with commands and is not configurable.
-	return &pluginhelp.PluginHelp{
-			Description: "The invalidcommitmsg plugin applies the '" + invalidCommitMsgLabel + "' label to pull requests whose commit messages and titles contain keywords which can automatically close issues or contain temporary commits such as fixup!, amend!, or squash!",
-		},
-		nil
+	// The plugin is configurable via the invalid_commit_msg section in plugins.yaml.
+	pluginHelp := &pluginhelp.PluginHelp{
+		Description: "The invalidcommitmsg plugin applies the '" + invalidCommitMsgLabel + "' label to pull requests whose commit messages and titles contain keywords which can automatically close issues or contain temporary commits such as fixup!, amend!, or squash!",
+	}
+	pluginHelp.Config = map[string]string{
+		"": "The plugin can be configured to check for fixup/amend/squash commits by setting 'check_fixup_commits: true' in the invalid_commit_msg configuration for specific repos or orgs.",
+	}
+	return pluginHelp, nil
 }
 
 type githubClient interface {
@@ -71,10 +73,10 @@ func handlePullRequest(pc plugins.Agent, pr github.PullRequestEvent) error {
 	if err != nil {
 		return err
 	}
-	return handle(pc.GitHubClient, pc.Logger, pr, cp)
+	return handle(pc.GitHubClient, pc.Logger, pc.PluginConfig, pr, cp)
 }
 
-func handle(gc githubClient, log *logrus.Entry, pr github.PullRequestEvent, cp commentPruner) error {
+func handle(gc githubClient, log *logrus.Entry, config *plugins.Configuration, pr github.PullRequestEvent, cp commentPruner) error {
 	// Only consider actions indicating that the code diffs may have changed.
 	if !hasPRChanged(pr) {
 		return nil
@@ -87,7 +89,8 @@ func handle(gc githubClient, log *logrus.Entry, pr github.PullRequestEvent, cp c
 		title  = pr.PullRequest.Title
 	)
 
-	checkFixup := os.Getenv("ENABLE_FIXUP_CHECK") == "true"
+	cfg := config.InvalidCommitMsgFor(org, repo)
+	checkFixup := cfg.CheckFixupCommits
 
 	labels, err := gc.GetIssueLabels(org, repo, number)
 	if err != nil {

--- a/pkg/plugins/invalidcommitmsg/invalidcommitmsg.go
+++ b/pkg/plugins/invalidcommitmsg/invalidcommitmsg.go
@@ -51,7 +51,7 @@ func helpProvider(config *plugins.Configuration, _ []config.OrgRepo) (*pluginhel
 		Description: "The invalidcommitmsg plugin applies the '" + invalidCommitMsgLabel + "' label to pull requests whose commit messages and titles contain keywords which can automatically close issues or contain temporary commits such as fixup!, amend!, or squash!",
 	}
 	pluginHelp.Config = map[string]string{
-		"": "The plugin can be configured to check for fixup/amend/squash commits by setting 'check_fixup_commits: true' in the invalid_commit_msg configuration for specific repos or orgs.",
+		"": "The plugin can be configured per-check using the 'checks' field. Each check can be individually disabled by setting 'disabled: true'. Available checks: 'fixupPrefix' (for fixup!/amend!/squash! commits) and 'issueClosingKeywords' (for issue-closing keywords in titles/commits).",
 	}
 	return pluginHelp, nil
 }

--- a/pkg/plugins/invalidcommitmsg/invalidcommitmsg.go
+++ b/pkg/plugins/invalidcommitmsg/invalidcommitmsg.go
@@ -91,6 +91,7 @@ func handle(gc githubClient, log *logrus.Entry, config *plugins.Configuration, p
 
 	cfg := config.InvalidCommitMsgFor(org, repo)
 	checkFixup := !cfg.IsCheckDisabled("fixupPrefix")
+	checkIssueClosing := !cfg.IsCheckDisabled("issueClosingKeywords")
 
 	labels, err := gc.GetIssueLabels(org, repo, number)
 	if err != nil {
@@ -112,7 +113,7 @@ func handle(gc githubClient, log *logrus.Entry, config *plugins.Configuration, p
 		msg := commit.Commit.Message
 		subject := strings.Split(msg, "\n")[0]
 
-		if CloseIssueRegex.MatchString(msg) {
+		if checkIssueClosing && CloseIssueRegex.MatchString(msg) {
 			invalidCommits = append(invalidCommits, commit)
 		}
 
@@ -121,7 +122,7 @@ func handle(gc githubClient, log *logrus.Entry, config *plugins.Configuration, p
 		}
 	}
 
-	invalidPRTitle := CloseIssueRegex.MatchString(title)
+	invalidPRTitle := checkIssueClosing && CloseIssueRegex.MatchString(title)
 
 	// Determine if any check failed
 	hasIssues := len(invalidCommits) != 0 || invalidPRTitle || (checkFixup && len(fixupCommits) != 0)

--- a/pkg/plugins/invalidcommitmsg/invalidcommitmsg.go
+++ b/pkg/plugins/invalidcommitmsg/invalidcommitmsg.go
@@ -90,7 +90,7 @@ func handle(gc githubClient, log *logrus.Entry, config *plugins.Configuration, p
 	)
 
 	cfg := config.InvalidCommitMsgFor(org, repo)
-	checkFixup := cfg.CheckFixupCommits
+	checkFixup := !cfg.IsCheckDisabled("fixupPrefix")
 
 	labels, err := gc.GetIssueLabels(org, repo, number)
 	if err != nil {

--- a/pkg/plugins/invalidcommitmsg/invalidcommitmsg_test.go
+++ b/pkg/plugins/invalidcommitmsg/invalidcommitmsg_test.go
@@ -26,6 +26,7 @@ import (
 
 	"sigs.k8s.io/prow/pkg/github"
 	"sigs.k8s.io/prow/pkg/github/fakegithub"
+	"sigs.k8s.io/prow/pkg/plugins"
 )
 
 type fakePruner struct{}
@@ -57,7 +58,7 @@ func TestHandlePullRequest(t *testing.T) {
 		commits                      []github.RepositoryCommit
 		title                        string
 		hasInvalidCommitMessageLabel bool
-		enableFixupEnv               bool
+		checkFixupCommits            bool
 
 		// expectations
 		addedLabel   string
@@ -166,7 +167,7 @@ func TestHandlePullRequest(t *testing.T) {
 				{SHA: "sha1", Commit: github.GitCommit{Message: "fixup! update tests"}},
 			},
 			hasInvalidCommitMessageLabel: false,
-			enableFixupEnv:               true,
+			checkFixupCommits:            true,
 			addedLabel:                   fmt.Sprintf("k/k#3:%s", invalidCommitMsgLabel),
 		},
 		{
@@ -176,7 +177,7 @@ func TestHandlePullRequest(t *testing.T) {
 				{SHA: "sha1", Commit: github.GitCommit{Message: "amend! update tests"}},
 			},
 			hasInvalidCommitMessageLabel: false,
-			enableFixupEnv:               true,
+			checkFixupCommits:            true,
 			addedLabel:                   fmt.Sprintf("k/k#3:%s", invalidCommitMsgLabel),
 		},
 		{
@@ -186,7 +187,7 @@ func TestHandlePullRequest(t *testing.T) {
 				{SHA: "sha1", Commit: github.GitCommit{Message: "squash! update tests"}},
 			},
 			hasInvalidCommitMessageLabel: false,
-			enableFixupEnv:               true,
+			checkFixupCommits:            true,
 			addedLabel:                   fmt.Sprintf("k/k#3:%s", invalidCommitMsgLabel),
 		},
 		{
@@ -195,7 +196,7 @@ func TestHandlePullRequest(t *testing.T) {
 			commits: []github.RepositoryCommit{
 				{SHA: "sha1", Commit: github.GitCommit{Message: "fixup! update tests"}},
 			},
-			enableFixupEnv: false,
+			checkFixupCommits: false,
 		},
 		{
 			name:   "fixup commit detected when feature flag enabled",
@@ -203,8 +204,8 @@ func TestHandlePullRequest(t *testing.T) {
 			commits: []github.RepositoryCommit{
 				{SHA: "sha1", Commit: github.GitCommit{Message: "fixup! update tests"}},
 			},
-			addedLabel:     fmt.Sprintf("k/k#3:%s", invalidCommitMsgLabel),
-			enableFixupEnv: true,
+			addedLabel:        fmt.Sprintf("k/k#3:%s", invalidCommitMsgLabel),
+			checkFixupCommits: true,
 		},
 		{
 			name:   "commit with fixup and close keyword",
@@ -212,8 +213,8 @@ func TestHandlePullRequest(t *testing.T) {
 			commits: []github.RepositoryCommit{
 				{SHA: "sha1", Commit: github.GitCommit{Message: "fixup! fixes #123"}},
 			},
-			enableFixupEnv: true,
-			addedLabel:     fmt.Sprintf("k/k#3:%s", invalidCommitMsgLabel),
+			checkFixupCommits: true,
+			addedLabel:        fmt.Sprintf("k/k#3:%s", invalidCommitMsgLabel),
 		},
 		{
 			name:   "fixup commits removed -> remove label",
@@ -222,7 +223,7 @@ func TestHandlePullRequest(t *testing.T) {
 				{SHA: "sha1", Commit: github.GitCommit{Message: "normal commit"}},
 			},
 			hasInvalidCommitMessageLabel: true,
-			enableFixupEnv:               true,
+			checkFixupCommits:            true,
 			removedLabel:                 fmt.Sprintf("k/k#3:%s", invalidCommitMsgLabel),
 		},
 	}
@@ -246,13 +247,16 @@ func TestHandlePullRequest(t *testing.T) {
 				fc.IssueLabelsAdded = append(fc.IssueLabelsAdded, fmt.Sprintf("k/k#3:%s", invalidCommitMsgLabel))
 			}
 
-			if tc.enableFixupEnv {
-				t.Setenv("ENABLE_FIXUP_CHECK", "true")
-			} else {
-				t.Setenv("ENABLE_FIXUP_CHECK", "false")
+			config := &plugins.Configuration{
+				InvalidCommitMsg: []plugins.InvalidCommitMsg{
+					{
+						Repos:             []string{"k"},
+						CheckFixupCommits: tc.checkFixupCommits,
+					},
+				},
 			}
 
-			if err := handle(fc, logrus.WithField("plugin", pluginName), event, &fakePruner{}); err != nil {
+			if err := handle(fc, logrus.WithField("plugin", pluginName), config, event, &fakePruner{}); err != nil {
 				t.Errorf("For case %s, didn't expect error from invalidcommitmsg plugin: %v", tc.name, err)
 			}
 

--- a/pkg/plugins/invalidcommitmsg/invalidcommitmsg_test.go
+++ b/pkg/plugins/invalidcommitmsg/invalidcommitmsg_test.go
@@ -247,11 +247,22 @@ func TestHandlePullRequest(t *testing.T) {
 				fc.IssueLabelsAdded = append(fc.IssueLabelsAdded, fmt.Sprintf("k/k#3:%s", invalidCommitMsgLabel))
 			}
 
+			var checks []plugins.InvalidCommitMsgCheck
+			if tc.checkFixupCommits {
+				checks = []plugins.InvalidCommitMsgCheck{
+					{Name: "fixupPrefix", Disabled: false},
+				}
+			} else {
+				checks = []plugins.InvalidCommitMsgCheck{
+					{Name: "fixupPrefix", Disabled: true},
+				}
+			}
+
 			config := &plugins.Configuration{
 				InvalidCommitMsg: []plugins.InvalidCommitMsg{
 					{
-						Repos:             []string{"k"},
-						CheckFixupCommits: tc.checkFixupCommits,
+						Repos:  []string{"k"},
+						Checks: checks,
 					},
 				},
 			}
@@ -288,7 +299,7 @@ func TestHandlePullRequest(t *testing.T) {
 
 			comments := fc.IssueCommentsAdded
 
-			if hasIssues(tc.commits, tc.title, tc.enableFixupEnv) {
+			if hasIssues(tc.commits, tc.title, tc.checkFixupCommits) {
 				if len(comments) != 1 {
 					t.Errorf("Expected 1 comment, got %d", len(comments))
 					return
@@ -306,7 +317,7 @@ func TestHandlePullRequest(t *testing.T) {
 					}
 				}
 
-				if tc.enableFixupEnv && containsFixup(tc.commits) {
+				if tc.checkFixupCommits && containsFixup(tc.commits) {
 					if !strings.Contains(comment, "Fixup/amend/squash commits") {
 						t.Errorf("Missing fixup section")
 					}

--- a/pkg/plugins/invalidcommitmsg/invalidcommitmsg_test.go
+++ b/pkg/plugins/invalidcommitmsg/invalidcommitmsg_test.go
@@ -59,6 +59,7 @@ func TestHandlePullRequest(t *testing.T) {
 		title                        string
 		hasInvalidCommitMessageLabel bool
 		checkFixupCommits            bool
+		checkIssueClosing            bool
 
 		// expectations
 		addedLabel   string
@@ -86,8 +87,8 @@ func TestHandlePullRequest(t *testing.T) {
 				{SHA: "sha3", Commit: github.GitCommit{Message: "resolved k/k#9999"}},
 			},
 			hasInvalidCommitMessageLabel: false,
-
-			addedLabel: fmt.Sprintf("k/k#3:%s", invalidCommitMsgLabel),
+			checkIssueClosing:            true,
+			addedLabel:                   fmt.Sprintf("k/k#3:%s", invalidCommitMsgLabel),
 		},
 		{
 			name:   "msg does not contain invalid keywords but has label -> remove label",
@@ -96,8 +97,8 @@ func TestHandlePullRequest(t *testing.T) {
 				{SHA: "sha", Commit: github.GitCommit{Message: "this is a valid message"}},
 			},
 			hasInvalidCommitMessageLabel: true,
-
-			removedLabel: fmt.Sprintf("k/k#3:%s", invalidCommitMsgLabel),
+			checkIssueClosing:            true,
+			removedLabel:                 fmt.Sprintf("k/k#3:%s", invalidCommitMsgLabel),
 		},
 		{
 			name:   "contains valid title -> no-op",
@@ -107,6 +108,7 @@ func TestHandlePullRequest(t *testing.T) {
 			},
 			title:                        "valid title",
 			hasInvalidCommitMessageLabel: false,
+			checkIssueClosing:            true,
 		},
 		{
 			name:   "contains invalid title with fixes keyword -> add label and comment",
@@ -116,6 +118,7 @@ func TestHandlePullRequest(t *testing.T) {
 			},
 			title:                        "fixes #9999",
 			hasInvalidCommitMessageLabel: false,
+			checkIssueClosing:            true,
 			addedLabel:                   fmt.Sprintf("k/k#3:%s", invalidCommitMsgLabel),
 		},
 		{
@@ -128,6 +131,7 @@ func TestHandlePullRequest(t *testing.T) {
 			},
 			title:                        "fixes #9999",
 			hasInvalidCommitMessageLabel: false,
+			checkIssueClosing:            true,
 			addedLabel:                   fmt.Sprintf("k/k#3:%s", invalidCommitMsgLabel),
 		},
 		{
@@ -138,6 +142,7 @@ func TestHandlePullRequest(t *testing.T) {
 			},
 			title:                        "fixes #9999",
 			hasInvalidCommitMessageLabel: true,
+			checkIssueClosing:            true,
 		},
 		{
 			name:   "invalid commits and valid title, and has label -> keep label and add comment",
@@ -149,6 +154,7 @@ func TestHandlePullRequest(t *testing.T) {
 			},
 			title:                        "valid title",
 			hasInvalidCommitMessageLabel: true,
+			checkIssueClosing:            true,
 		},
 		{
 			name:   "valid title and valid commits, and has label -> remove label",
@@ -158,6 +164,7 @@ func TestHandlePullRequest(t *testing.T) {
 			},
 			title:                        "valid title",
 			hasInvalidCommitMessageLabel: true,
+			checkIssueClosing:            true,
 			removedLabel:                 fmt.Sprintf("k/k#3:%s", invalidCommitMsgLabel),
 		},
 		{
@@ -214,6 +221,7 @@ func TestHandlePullRequest(t *testing.T) {
 				{SHA: "sha1", Commit: github.GitCommit{Message: "fixup! fixes #123"}},
 			},
 			checkFixupCommits: true,
+			checkIssueClosing: true,
 			addedLabel:        fmt.Sprintf("k/k#3:%s", invalidCommitMsgLabel),
 		},
 		{
@@ -224,7 +232,27 @@ func TestHandlePullRequest(t *testing.T) {
 			},
 			hasInvalidCommitMessageLabel: true,
 			checkFixupCommits:            true,
+			checkIssueClosing:            true,
 			removedLabel:                 fmt.Sprintf("k/k#3:%s", invalidCommitMsgLabel),
+		},
+		{
+			name:   "issue closing keywords ignored when check disabled",
+			action: github.PullRequestActionOpened,
+			commits: []github.RepositoryCommit{
+				{SHA: "sha1", Commit: github.GitCommit{Message: "fixes k/k#9999"}},
+			},
+			title:                        "fixes #9999",
+			checkIssueClosing:            false,
+			hasInvalidCommitMessageLabel: false,
+		},
+		{
+			name:   "issue closing keywords detected when check enabled",
+			action: github.PullRequestActionOpened,
+			commits: []github.RepositoryCommit{
+				{SHA: "sha1", Commit: github.GitCommit{Message: "fixes k/k#9999"}},
+			},
+			checkIssueClosing: true,
+			addedLabel:        fmt.Sprintf("k/k#3:%s", invalidCommitMsgLabel),
 		},
 	}
 
@@ -248,15 +276,14 @@ func TestHandlePullRequest(t *testing.T) {
 			}
 
 			var checks []plugins.InvalidCommitMsgCheck
-			if tc.checkFixupCommits {
-				checks = []plugins.InvalidCommitMsgCheck{
-					{Name: "fixupPrefix", Disabled: false},
-				}
-			} else {
-				checks = []plugins.InvalidCommitMsgCheck{
-					{Name: "fixupPrefix", Disabled: true},
-				}
-			}
+			checks = append(checks, plugins.InvalidCommitMsgCheck{
+				Name:     "fixupPrefix",
+				Disabled: !tc.checkFixupCommits,
+			})
+			checks = append(checks, plugins.InvalidCommitMsgCheck{
+				Name:     "issueClosingKeywords",
+				Disabled: !tc.checkIssueClosing,
+			})
 
 			config := &plugins.Configuration{
 				InvalidCommitMsg: []plugins.InvalidCommitMsg{
@@ -299,7 +326,7 @@ func TestHandlePullRequest(t *testing.T) {
 
 			comments := fc.IssueCommentsAdded
 
-			if hasIssues(tc.commits, tc.title, tc.checkFixupCommits) {
+			if hasIssues(tc.commits, tc.title, tc.checkFixupCommits, tc.checkIssueClosing) {
 				if len(comments) != 1 {
 					t.Errorf("Expected 1 comment, got %d", len(comments))
 					return
@@ -359,8 +386,8 @@ func isInvalidTitle(title string) bool {
 	return CloseIssueRegex.MatchString(title)
 }
 
-func hasIssues(commits []github.RepositoryCommit, title string, fixupEnabled bool) bool {
-	return containsInvalidCommits(commits) ||
-		isInvalidTitle(title) ||
+func hasIssues(commits []github.RepositoryCommit, title string, fixupEnabled bool, issueClosingEnabled bool) bool {
+	return (issueClosingEnabled && containsInvalidCommits(commits)) ||
+		(issueClosingEnabled && isInvalidTitle(title)) ||
 		(fixupEnabled && containsFixup(commits))
 }


### PR DESCRIPTION
## invalidcommitmsg: add config surface for fixup commit checking

Part of #641

This PR adds the configuration surface for the `invalidcommitmsg` plugin, enabling control of fixup/amend/squash commit checking through `plugins.yaml`.

Replaces the `ENABLE_FIXUP_CHECK` environment variable with proper plugin configuration following standard Prow patterns.

### Configuration

```yaml
invalid_commit_msg:
  - repos:
      - org/repo
    checks:
      - name: fixupPrefix
        disabled: false  # Enable checking for fixup!/amend!/squash! commits
      - name: issueClosingKeywords
        disabled: false  # Always enabled by default
```

### Implementation Details

- **Extensible per-check configuration**: Uses `checks` array instead of boolean fields to avoid proliferation as new checks are added
- **Two-pass lookup**: Implements `InvalidCommitMsgFor(org, repo)` with repo-level config taking precedence over org-level config (consistent with `TriggerFor`, `LgtmFor`, `ApproveFor`)
- **Check name validation**: Validates check names against whitelist (`fixupPrefix`, `issueClosingKeywords`) to prevent typos
- **Updated help text**: Reflects new configuration format in plugin help


**Depends on:** #656  
**Fixes:** #617

---
