### PR TITLE
fix(autobumper): use HEAD refspec when pushing in App auth mode

### DIFF
--- a/cmd/generic-autobumper/bumper/bumper.go
+++ b/cmd/generic-autobumper/bumper/bumper.go
@@ -388,7 +388,7 @@ func processGitHubAppAuth(ctx context.Context, o *Options, prh PRHandler) error 
 	}
 
 	logrus.WithField("branch", o.HeadBranchName).Info("Pushing branch directly to upstream repo")
-	if err := repoClient.PushToCentral(o.HeadBranchName, true); err != nil {
+	if err := repoClient.PushToCentral("HEAD:"+o.HeadBranchName, true); err != nil {
 		return fmt.Errorf("push branch %s to %s/%s: %w", o.HeadBranchName, o.GitHubOrg, o.GitHubRepo, err)
 	}
 


### PR DESCRIPTION
## Summary
- `processGitHubAppAuth` commits on the checked-out branch (usually `main`) but `PushToCentral` pushes by local branch name (defaulting to `autobump`)
- Since no local branch `autobump` is created, git fails with `error: src refspec autobump does not match any`
- Fix: push `HEAD:autobump` explicitly so git pushes the current revision to the remote branch without requiring a local branch to exist

Bug introduced in #716.