### PR TITLE
tide: optionally abort superseded batch jobs before retriggering

### DIFF
--- a/pkg/config/prow-config-documented.yaml
+++ b/pkg/config/prow-config-documented.yaml
@@ -1471,6 +1471,12 @@ slack_reporter_configs:
 # is: https://github.com/kubernetes/test-infra/issues.
 status_error_link: ' '
 tide:
+    # AbortSupersededBatchJobsMap configures on org or org/repo level whether Tide
+    # should abort older in-flight batch ProwJobs for the same branch when a new
+    # base SHA requires triggering a new batch.
+    # Use '*' as key to set this globally. Defaults to true.
+    abort_superseded_batch_jobs:
+        "": true
     # BatchSizeLimitMap is a key/value pair of an org or org/repo as the key and
     # integer batch size limit as the value. Use "*" as key to set a global default.
     # Special values:

--- a/pkg/config/tide.go
+++ b/pkg/config/tide.go
@@ -247,6 +247,11 @@ type Tide struct {
 	// starting a new one requires to start new instances of all tests.
 	// Use '*' as key to set this globally. Defaults to true.
 	PrioritizeExistingBatchesMap map[string]bool `json:"prioritize_existing_batches,omitempty"`
+	// AbortSupersededBatchJobsMap configures on org or org/repo level whether Tide
+	// should abort older in-flight batch ProwJobs for the same branch when a new
+	// base SHA requires triggering a new batch.
+	// Use '*' as key to set this globally. Defaults to true.
+	AbortSupersededBatchJobsMap map[string]bool `json:"abort_superseded_batch_jobs,omitempty"`
 	// GitHubMergeBlocksPolicyMap configures on org or org/repo level how Tide should handle
 	// GitHub's mergeStateStatus (BLOCKED state from branch protection rules, rulesets,
 	// required reviews, etc.).
@@ -383,6 +388,22 @@ func (t *Tide) PrioritizeExistingBatches(repo OrgRepo) bool {
 		return val
 	}
 
+	return true
+}
+
+// AbortSupersededBatchJobs returns whether Tide should abort older in-flight
+// batch ProwJobs when a new base SHA triggers a new batch for the given repo.
+// Defaults to true if no config is set.
+func (t *Tide) AbortSupersededBatchJobs(repo OrgRepo) bool {
+	if val, set := t.AbortSupersededBatchJobsMap[repo.String()]; set {
+		return val
+	}
+	if val, set := t.AbortSupersededBatchJobsMap[repo.Org]; set {
+		return val
+	}
+	if val, set := t.AbortSupersededBatchJobsMap["*"]; set {
+		return val
+	}
 	return true
 }
 

--- a/pkg/config/tide_test.go
+++ b/pkg/config/tide_test.go
@@ -457,6 +457,54 @@ tide:
 	}
 }
 
+func TestAbortSupersededBatchJobs(t *testing.T) {
+	testcases := []struct {
+		name     string
+		config   map[string]bool
+		repo     OrgRepo
+		expected bool
+	}{
+		{
+			name:     "defaults to true when unset",
+			config:   nil,
+			repo:     OrgRepo{Org: "org", Repo: "repo"},
+			expected: true,
+		},
+		{
+			name:     "global wildcard enables",
+			config:   map[string]bool{"*": true},
+			repo:     OrgRepo{Org: "org", Repo: "repo"},
+			expected: true,
+		},
+		{
+			name:     "org-level override",
+			config:   map[string]bool{"*": false, "myorg": true},
+			repo:     OrgRepo{Org: "myorg", Repo: "repo"},
+			expected: true,
+		},
+		{
+			name:     "repo-level override",
+			config:   map[string]bool{"*": true, "myorg": true, "myorg/myrepo": false},
+			repo:     OrgRepo{Org: "myorg", Repo: "myrepo"},
+			expected: false,
+		},
+		{
+			name:     "unmatched org falls through to global",
+			config:   map[string]bool{"*": true, "other": false},
+			repo:     OrgRepo{Org: "myorg", Repo: "repo"},
+			expected: true,
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			tide := &Tide{AbortSupersededBatchJobsMap: tc.config}
+			if got := tide.AbortSupersededBatchJobs(tc.repo); got != tc.expected {
+				t.Errorf("expected %v, got %v", tc.expected, got)
+			}
+		})
+	}
+}
+
 func TestTideQuery(t *testing.T) {
 	q := " " + testQuery.Query() + " "
 	checkTok := checkTok(t, q)

--- a/pkg/tide/tide.go
+++ b/pkg/tide/tide.go
@@ -1539,6 +1539,39 @@ func (c *syncController) nonFailedBatchForJobAndRefsExists(jobName string, refs 
 	return len(pjs.Items) > 0
 }
 
+func (c *syncController) abortSupersededBatchJobs(sp subpool) error {
+	pjs := &prowapi.ProwJobList{}
+	labels := map[string]string{
+		kube.CreatedByTideLabel: "true",
+		kube.ProwJobTypeLabel:   string(prowapi.BatchJob),
+		kube.OrgLabel:           sp.org,
+		kube.RepoLabel:          sp.repo,
+		kube.BaseRefLabel:       sp.branch,
+	}
+	if err := c.prowJobClient.List(
+		c.ctx,
+		pjs,
+		ctrlruntimeclient.InNamespace(c.config().ProwJobNamespace),
+		ctrlruntimeclient.MatchingLabels(labels),
+	); err != nil {
+		return fmt.Errorf("failed listing existing tide batch jobs: %w", err)
+	}
+	const supersededDescriptionPrefix = "Aborted as superseded by batch for base SHA "
+	var errs []error
+	for _, pj := range pjs.Items {
+		if pj.Spec.Refs == nil || pj.Spec.Refs.BaseSHA == sp.sha || pj.Complete() {
+			continue
+		}
+		prev := pj.DeepCopy()
+		pj.Status.State = prowapi.AbortedState
+		pj.Status.Description = supersededDescriptionPrefix + sp.sha
+		if err := c.prowJobClient.Patch(c.ctx, &pj, ctrlruntimeclient.MergeFrom(prev)); err != nil {
+			errs = append(errs, fmt.Errorf("failed to abort superseded batch prowjob %s: %w", pj.Name, err))
+		}
+	}
+	return utilerrors.NewAggregate(errs)
+}
+
 func (c *syncController) takeAction(sp subpool, batchPending, successes, pendings, missings, batchMerges []CodeReviewCommon, missingSerialTests map[int][]config.Presubmit) (Action, []CodeReviewCommon, error) {
 	var merged []CodeReviewCommon
 	var err error
@@ -1567,6 +1600,11 @@ func (c *syncController) takeAction(sp subpool, batchPending, successes, pending
 	}
 	// If we have no batch, trigger one.
 	if len(sp.prs) > 1 && len(batchPending) == 0 {
+		if c.config().Tide.AbortSupersededBatchJobs(config.OrgRepo{Org: sp.org, Repo: sp.repo}) {
+			if err := c.abortSupersededBatchJobs(sp); err != nil {
+				sp.log.WithError(err).Error("Failed aborting superseded batch jobs.")
+			}
+		}
 		batch, presubmits, err := c.pickBatch(sp, sp.cc, c.pickNewBatch)
 		if err != nil {
 			return Wait, nil, err

--- a/pkg/tide/tide_test.go
+++ b/pkg/tide/tide_test.go
@@ -1609,7 +1609,7 @@ func TestIsAllowedToMerge_ReviewDecision(t *testing.T) {
 			name:             "BLOCKED status - repo config overrides org config (ignore)",
 			mergeStateStatus: "BLOCKED",
 			policyConfig: map[string]config.GitHubMergeBlocksPolicy{
-				orgName: config.GitHubMergeBlocksBlock,
+				orgName:                                 config.GitHubMergeBlocksBlock,
 				fmt.Sprintf("%s/%s", orgName, repoName): config.GitHubMergeBlocksIgnore,
 			},
 			expectedMergeOutput:  "",
@@ -1619,7 +1619,7 @@ func TestIsAllowedToMerge_ReviewDecision(t *testing.T) {
 			name:             "BLOCKED status - repo config overrides org config (block)",
 			mergeStateStatus: "BLOCKED",
 			policyConfig: map[string]config.GitHubMergeBlocksPolicy{
-				orgName: config.GitHubMergeBlocksPermit,
+				orgName:                                 config.GitHubMergeBlocksPermit,
 				fmt.Sprintf("%s/%s", orgName, repoName): config.GitHubMergeBlocksBlock,
 			},
 			expectedMergeOutput:  "PR is blocked from merging by GitHub (check branch protection, required reviews, or rulesets)",
@@ -1715,15 +1715,17 @@ func testTakeAction(clients localgit.Clients, t *testing.T) {
 	testcases := []struct {
 		name string
 
-		batchPending     bool
-		successes        []int
-		pendings         []int
-		nones            []int
-		batchMerges      []int
-		presubmits       map[int][]config.Presubmit
-		preExistingJobs  []runtime.Object
-		mergeErrs        map[int]error
-		enableScheduling bool
+		batchPending                   bool
+		successes                      []int
+		pendings                       []int
+		nones                          []int
+		batchMerges                    []int
+		presubmits                     map[int][]config.Presubmit
+		preExistingJobs                []runtime.Object
+		abortedPreExistingJobs         []string
+		mergeErrs                      map[int]error
+		enableScheduling               bool
+		enableAbortSupersededBatchJobs bool
 
 		merged           int
 		triggered        int
@@ -2059,6 +2061,77 @@ func testTakeAction(clients localgit.Clients, t *testing.T) {
 			action:           TriggerBatch,
 		},
 		{
+			name: "superseded batches are aborted before triggering new batch",
+
+			batchPending: false,
+			successes:    []int{},
+			pendings:     []int{},
+			nones:        []int{1, 2, 3},
+			batchMerges:  []int{},
+			presubmits: map[int][]config.Presubmit{
+				100: {
+					{Reporter: config.Reporter{Context: "foo"}},
+					{Reporter: config.Reporter{Context: "if-changed"}},
+				},
+			},
+			preExistingJobs: []runtime.Object{
+				&prowapi.ProwJob{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "old-batch",
+						Namespace: "pj-ns",
+						Labels: map[string]string{
+							kube.CreatedByTideLabel: "true",
+							kube.ProwJobTypeLabel:   string(prowapi.BatchJob),
+							kube.OrgLabel:           "o",
+							kube.RepoLabel:          "r",
+							kube.BaseRefLabel:       defaultBranch,
+						},
+					},
+					Spec: prowapi.ProwJobSpec{
+						Type: prowapi.BatchJob,
+						Refs: &prowapi.Refs{
+							Org:     "o",
+							Repo:    "r",
+							BaseRef: defaultBranch,
+							BaseSHA: "old-sha",
+							Pulls:   []prowapi.Pull{{Number: 90, SHA: "origin/pr-90"}, {Number: 91, SHA: "origin/pr-91"}},
+						},
+					},
+					Status: prowapi.ProwJobStatus{State: prowapi.PendingState},
+				},
+				&prowapi.ProwJob{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "current-batch",
+						Namespace: "pj-ns",
+						Labels: map[string]string{
+							kube.CreatedByTideLabel: "true",
+							kube.ProwJobTypeLabel:   string(prowapi.BatchJob),
+							kube.OrgLabel:           "o",
+							kube.RepoLabel:          "r",
+							kube.BaseRefLabel:       defaultBranch,
+						},
+					},
+					Spec: prowapi.ProwJobSpec{
+						Type: prowapi.BatchJob,
+						Refs: &prowapi.Refs{
+							Org:     "o",
+							Repo:    "r",
+							BaseRef: defaultBranch,
+							BaseSHA: defaultBranch,
+							Pulls:   []prowapi.Pull{{Number: 92, SHA: "origin/pr-92"}, {Number: 93, SHA: "origin/pr-93"}},
+						},
+					},
+					Status: prowapi.ProwJobStatus{State: prowapi.PendingState},
+				},
+			},
+			abortedPreExistingJobs:         []string{"old-batch"},
+			enableAbortSupersededBatchJobs: true,
+			merged:                         0,
+			triggered:                      2,
+			triggeredBatches:               2,
+			action:                         TriggerBatch,
+		},
+		{
 			name: "pending batch, no serial, should trigger serial",
 
 			batchPending: true,
@@ -2156,6 +2229,9 @@ func testTakeAction(clients localgit.Clients, t *testing.T) {
 					ProwJobNamespace: pjNamespace,
 					Scheduler:        config.Scheduler{Enabled: tc.enableScheduling},
 				},
+			}
+			if tc.enableAbortSupersededBatchJobs {
+				cfg.Tide.AbortSupersededBatchJobsMap = map[string]bool{"*": true}
 			}
 			if err := cfg.SetPresubmits(
 				map[string][]config.Presubmit{
@@ -2321,16 +2397,25 @@ func testTakeAction(clients localgit.Clients, t *testing.T) {
 			if err := c.prowJobClient.List(ctx, prowJobs); err != nil {
 				t.Fatalf("failed to list ProwJobs: %v", err)
 			}
+			preExistingNames := sets.Set[string]{}
+			for _, preExistingJob := range tc.preExistingJobs {
+				preExistingNames.Insert(preExistingJob.(*prowapi.ProwJob).Name)
+			}
+			expectedAbortedPreExistingJobs := sets.New[string](tc.abortedPreExistingJobs...)
+			for _, job := range prowJobs.Items {
+				if !preExistingNames.Has(job.Name) {
+					continue
+				}
+				shouldBeAborted := expectedAbortedPreExistingJobs.Has(job.Name)
+				isAborted := job.Status.State == prowapi.AbortedState
+				if isAborted != shouldBeAborted {
+					t.Errorf("job %s aborted=%t, expected %t", job.Name, isAborted, shouldBeAborted)
+				}
+			}
 			var filteredProwJobs []prowapi.ProwJob
 			// Filter out the ones we passed in
 			for _, job := range prowJobs.Items {
-				var preExists bool
-				for _, preExistingJob := range tc.preExistingJobs {
-					if reflect.DeepEqual(*preExistingJob.(*prowapi.ProwJob), job) {
-						preExists = true
-					}
-				}
-				if !preExists {
+				if !preExistingNames.Has(job.Name) {
 					filteredProwJobs = append(filteredProwJobs, job)
 				}
 


### PR DESCRIPTION
## Summary

When the base branch SHA advances (from a tide merge or manual merge), dividePool() filters ProwJobs by the new baseSHA, making old batch jobs invisible. Tide sees batchPending == 0 and triggers a fresh batch while the stale one runs to completion, wasting compute.

This adds abort of superseded batch ProwJobs just before triggering a new batch. Enabled by default, with opt-out per org/repo.

### Configuration

```yaml
tide:
  abort_superseded_batch_jobs:
    myorg/myrepo: false  # opt out for a specific repo
```

Defaults to true (enabled). Uses the standard per-org/repo map pattern (consistent with `prioritize_existing_batches`, `batch_size_limit`). Set to false to disable.

### How it works

- New method `abortSupersededBatchJobs(sp subpool)` lists all Tide-created batch ProwJobs for the same org/repo/branch regardless of baseSHA, then patches any with a stale baseSHA to AbortedState
- Called in `takeAction` right before `pickBatch`, only when the config is enabled
- Abort failures are non-fatal (logged, then new batch proceeds normally)
- Completed jobs and jobs matching the current baseSHA are skipped

Fixes #650