### PR TITLE
Fix malformed pagination URL when resp.Request.URL differs from paged Path

### DIFF
--- a/pkg/github/client.go
+++ b/pkg/github/client.go
@@ -1989,24 +1989,28 @@ func (c *client) readPaginatedResultsWithValuesWithContext(ctx context.Context, 
 			break
 		}
 
-		// Example for github.com:
-		// * c.bases[0]: api.github.com
-		// * initial call: api.github.com/repos/kubernetes/kubernetes/pulls?per_page=100
-		// * next: api.github.com/repositories/22/pulls?per_page=100&page=2
-		// * in this case prefix will be empty and we're just calling the path returned by next
-		// Example for github enterprise:
-		// * c.bases[0]: <ghe-url>/api/v3
-		// * initial call: <ghe-url>/api/v3/repos/kubernetes/kubernetes/pulls?per_page=100
-		// * next: <ghe-url>/api/v3/repositories/22/pulls?per_page=100&page=2
-		// * in this case prefix will be "/api/v3" and we will strip the prefix. If we don't do that,
-		//   the next call will go to <ghe-url>/api/v3/api/v3/repositories/22/pulls?per_page=100&page=2
-		prefix := strings.TrimSuffix(resp.Request.URL.RequestURI(), pagedPath)
+		// For GitHub Enterprise, c.bases[0] may include a path prefix like /api/v3.
+		// We need to strip that prefix from the Link header URL so that when we
+		// prepend c.bases[hostIndex] we don't duplicate it.
+		// For standard GitHub (with or without ghproxy), there is no path prefix.
+		//
+		// We compare only the Path components (ignoring query strings) to compute
+		// the prefix. The previous approach used the full RequestURI (path+query)
+		// for TrimSuffix, which breaks when resp.Request.URL differs from what we
+		// sent (e.g. due to a redirect): the suffix doesn't match, leaving prefix
+		// set to the entire response URI. A subsequent TrimPrefix then strips too
+		// much from the next-page URL, producing a malformed path like "&page=2".
+		pathOnly := strings.SplitN(pagedPath, "?", 2)[0]
+		prefix := strings.TrimSuffix(resp.Request.URL.Path, pathOnly)
 
 		u, err := url.Parse(link)
 		if err != nil {
 			return fmt.Errorf("failed to parse 'next' link: %w", err)
 		}
 		pagedPath = strings.TrimPrefix(u.RequestURI(), prefix)
+		if len(pagedPath) == 0 || pagedPath[0] != '/' {
+			pagedPath = u.RequestURI()
+		}
 	}
 	return nil
 }

--- a/pkg/github/client_test.go
+++ b/pkg/github/client_test.go
@@ -1373,6 +1373,120 @@ func TestReadPaginatedResults(t *testing.T) {
 	}
 }
 
+func TestReadPaginatedResultsWithValuesSamePathPagination(t *testing.T) {
+	requestCount := 0
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		var labels []Label
+		switch {
+		case r.URL.Query().Get("page") == "":
+			labels = []Label{{Name: "page1"}}
+			w.Header().Set("Link", fmt.Sprintf(
+				`<https://%s%s?per_page=100&page=2>; rel="next"`,
+				r.Host, r.URL.Path))
+		case r.URL.Query().Get("page") == "2":
+			labels = []Label{{Name: "page2"}}
+		default:
+			t.Fatalf("Unexpected request: %s", r.URL.String())
+		}
+		b, err := json.Marshal(labels)
+		if err != nil {
+			t.Fatalf("Failed to marshal: %v", err)
+		}
+		fmt.Fprint(w, string(b))
+	}))
+	defer ts.Close()
+
+	c := getClient(ts.URL)
+	var labels []Label
+	err := c.readPaginatedResultsWithValues(
+		"/repos/org/repo/branches",
+		url.Values{
+			"per_page":  []string{"100"},
+			"protected": []string{"false"},
+		},
+		"",
+		"",
+		func() interface{} {
+			return &[]Label{}
+		},
+		func(obj interface{}) {
+			labels = append(labels, *(obj.(*[]Label))...)
+		},
+	)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	expected := []Label{{Name: "page1"}, {Name: "page2"}}
+	if !reflect.DeepEqual(labels, expected) {
+		t.Errorf("Expected %v, got %v", expected, labels)
+	}
+	if requestCount != 2 {
+		t.Errorf("Expected 2 requests, got %d", requestCount)
+	}
+}
+
+func TestReadPaginatedResultsWithRedirect(t *testing.T) {
+	// Simulates the scenario where a GitHub API request is redirected (e.g.
+	// due to a repo rename/transfer). After the redirect, resp.Request.URL
+	// differs from the original pagedPath. The pagination URL construction
+	// must still produce a valid URL for the next page.
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/old-org/old-repo/branches":
+			newURL := fmt.Sprintf("https://%s/repos/new-org/new-repo/branches", r.Host)
+			if r.URL.RawQuery != "" {
+				newURL += "?" + r.URL.RawQuery
+			}
+			http.Redirect(w, r, newURL, http.StatusMovedPermanently)
+		case "/repos/new-org/new-repo/branches":
+			var labels []Label
+			if r.URL.Query().Get("page") == "" {
+				labels = []Label{{Name: "page1"}}
+				w.Header().Set("Link", fmt.Sprintf(
+					`<https://%s/repos/new-org/new-repo/branches?per_page=100&page=2>; rel="next"`,
+					r.Host))
+			} else {
+				labels = []Label{{Name: "page2"}}
+			}
+			b, err := json.Marshal(labels)
+			if err != nil {
+				t.Fatalf("Failed to marshal: %v", err)
+			}
+			fmt.Fprint(w, string(b))
+		default:
+			t.Errorf("Unexpected request path: %s (full: %s)", r.URL.Path, r.URL.String())
+			http.Error(w, "not found", http.StatusNotFound)
+		}
+	}))
+	defer ts.Close()
+
+	c := getClient(ts.URL)
+	var labels []Label
+	err := c.readPaginatedResultsWithValues(
+		"/repos/old-org/old-repo/branches",
+		url.Values{
+			"per_page":  []string{"100"},
+			"protected": []string{"false"},
+		},
+		"",
+		"",
+		func() interface{} {
+			return &[]Label{}
+		},
+		func(obj interface{}) {
+			labels = append(labels, *(obj.(*[]Label))...)
+		},
+	)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	expected := []Label{{Name: "page1"}, {Name: "page2"}}
+	if !reflect.DeepEqual(labels, expected) {
+		t.Errorf("Expected %v, got %v", expected, labels)
+	}
+}
+
 func TestListPullRequestComments(t *testing.T) {
 	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {


### PR DESCRIPTION
When the GitHub API redirects a request (e.g. repo rename/transfer, org case mismatch), Go's http.Client follows the redirect and sets resp.Request.URL to the final location. The pagination prefix logic used TrimSuffix on the full RequestURI (path+query) to detect a GHE base path like /api/v3. When the response URL differs from what we sent, the suffix doesn't match, leaving prefix set to the entire response URI. The subsequent TrimPrefix then strips too much from the next-page Link URL, producing a bare "&page=2" that gets concatenated with the base host — e.g. "https://api.github.com&page=2" — causing a DNS failure.

Fix:
- Compare only URL.Path (not the full URI with query string) when computing the GHE prefix, making it immune to query param differences.
- Add a safety check: if pagedPath doesn't start with '/' after prefix stripping, fall back to the full Link header RequestURI.

Note: the fallback can re-introduce path duplication on GHE instances that also involve a redirect. This is a known limitation — a 404 from a doubled /api/v3 prefix is strictly better than a fatal DNS crash, and the redirect+GHE combination is extremely rare. A follow-up can address it with host-aware prefix detection.

Made with Cursor