### PR TITLE
fix(pipeline): reject duplicate cluster endpoints at startup

### DIFF
--- a/cmd/pipeline/main.go
+++ b/cmd/pipeline/main.go
@@ -21,6 +21,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"sort"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -103,6 +104,22 @@ func newPipelineConfig(cfg rest.Config, stop <-chan struct{}) (*pipelineConfig, 
 	}, nil
 }
 
+// validateUniqueClusters returns an error if multiple contexts resolve to the same API server endpoint.
+// Duplicate endpoints cause the controller to set up redundant informers, leading to incorrect PipelineRun deletions.
+func validateUniqueClusters(configs map[string]rest.Config) error {
+	hostToCtxs := make(map[string][]string, len(configs))
+	for ctx, cfg := range configs {
+		hostToCtxs[cfg.Host] = append(hostToCtxs[cfg.Host], ctx)
+	}
+	for host, ctxs := range hostToCtxs {
+		if len(ctxs) > 1 {
+			sort.Strings(ctxs)
+			return fmt.Errorf("contexts %v resolve to the same cluster endpoint %s; deduplicate them in the kubeconfig", ctxs, host)
+		}
+	}
+	return nil
+}
+
 func main() {
 	logrusutil.ComponentInit()
 
@@ -133,6 +150,10 @@ func main() {
 	} else {
 		// the InClusterContext is always mapped to DefaultClusterAlias in the controller, so there is no need to watch for this config.
 		delete(configs, kube.InClusterContext)
+	}
+
+	if err := validateUniqueClusters(configs); err != nil {
+		logrus.WithError(err).Fatal("Invalid cluster configs")
 	}
 
 	kc, err := kubernetes.NewForConfig(&local)

--- a/cmd/pipeline/main_test.go
+++ b/cmd/pipeline/main_test.go
@@ -21,6 +21,7 @@ import (
 	"reflect"
 	"testing"
 
+	"k8s.io/client-go/rest"
 	prowflagutil "sigs.k8s.io/prow/pkg/flagutil"
 	configflagutil "sigs.k8s.io/prow/pkg/flagutil/config"
 )
@@ -81,6 +82,48 @@ func TestOptions(t *testing.T) {
 				t.Error("failed to received expected error")
 			case !reflect.DeepEqual(&actual, tc.expected):
 				t.Errorf("actual %#v != expected %#v", actual, *tc.expected)
+			}
+		})
+	}
+}
+
+func TestValidateUniqueClusters(t *testing.T) {
+	cases := []struct {
+		name    string
+		configs map[string]rest.Config
+		wantErr bool
+	}{
+		{
+			name: "unique hosts pass",
+			configs: map[string]rest.Config{
+				"ctx-a": {Host: "https://a.example.com"},
+				"ctx-b": {Host: "https://b.example.com"},
+			},
+		},
+		{
+			name: "duplicate hosts fail",
+			configs: map[string]rest.Config{
+				"ctx-a": {Host: "https://a.example.com"},
+				"ctx-b": {Host: "https://a.example.com"},
+			},
+			wantErr: true,
+		},
+		{
+			name:    "empty configs pass",
+			configs: map[string]rest.Config{},
+		},
+		{
+			name: "single config passes",
+			configs: map[string]rest.Config{
+				"ctx-a": {Host: "https://a.example.com"},
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateUniqueClusters(tc.configs)
+			if (err != nil) != tc.wantErr {
+				t.Errorf("validateUniqueClusters() error = %v, wantErr %v", err, tc.wantErr)
 			}
 		})
 	}


### PR DESCRIPTION
What this PR does : 

When an operator configures multiple kubeconfig context names pointing at the same physical cluster (e.g. "default" and "cluster-a" both targeting the same API server), the pipeline controller creates a separate informer per context. Both informers watch the same PipelineRun resources. When a PipelineRun event arrives through the "other" context's informer, the reconcile logic at controller.go:462 sees a context mismatch (ClusterToCtx(pj.Spec.Cluster) != ctx), concludes the PipelineRun doesn't belong, and deletes it. This is a data-loss bug: valid, running PipelineRuns get deleted silently. 

This PR adds a startup validation function (validateUniqueClusters) that detects when multiple contexts share the same API server endpoint and exits with a clear error telling the operator which contexts collide and what to fix. Only affects the pipeline (Tekton) controller running with --all-contexts. Pod-backed ProwJobs and single-context mode are not affected.

Fixes: #609 