### PR TITLE
.*: add `delete-spam-issue` prow plugin

### DIFF
--- a/cmd/hook/plugin-imports/plugin-imports.go
+++ b/cmd/hook/plugin-imports/plugin-imports.go
@@ -31,6 +31,7 @@ import (
 	_ "sigs.k8s.io/prow/pkg/plugins/cherrypickunapproved"
 	_ "sigs.k8s.io/prow/pkg/plugins/cla"
 	_ "sigs.k8s.io/prow/pkg/plugins/dco"
+	_ "sigs.k8s.io/prow/pkg/plugins/delete-spam-issue"
 	_ "sigs.k8s.io/prow/pkg/plugins/dog"
 	_ "sigs.k8s.io/prow/pkg/plugins/golint"
 	_ "sigs.k8s.io/prow/pkg/plugins/goose"

--- a/pkg/hook/plugin-imports/plugin-imports.go
+++ b/pkg/hook/plugin-imports/plugin-imports.go
@@ -31,6 +31,7 @@ import (
 	_ "sigs.k8s.io/prow/pkg/plugins/cherrypickunapproved"
 	_ "sigs.k8s.io/prow/pkg/plugins/cla"
 	_ "sigs.k8s.io/prow/pkg/plugins/dco"
+	_ "sigs.k8s.io/prow/pkg/plugins/delete-spam-issue"
 	_ "sigs.k8s.io/prow/pkg/plugins/dog"
 	_ "sigs.k8s.io/prow/pkg/plugins/golint"
 	_ "sigs.k8s.io/prow/pkg/plugins/goose"

--- a/pkg/plugins/config.go
+++ b/pkg/plugins/config.go
@@ -77,6 +77,7 @@ type Configuration struct {
 	CherryPickUnapproved CherryPickUnapproved         `json:"cherry_pick_unapproved,omitempty"`
 	ConfigUpdater        ConfigUpdater                `json:"config_updater,omitempty"`
 	Dco                  map[string]*Dco              `json:"dco,omitempty"`
+	DeleteSpamIssue      DeleteSpamIssue              `json:"delete_spam_issue,omitempty"`
 	Golint               Golint                       `json:"golint,omitempty"`
 	Goose                Goose                        `json:"goose,omitempty"`
 	Heart                Heart                        `json:"heart,omitempty"`
@@ -295,6 +296,16 @@ func (c *Configuration) SkipCollaborators(org, repo string) bool {
 		}
 	}
 	return false
+}
+
+// DeleteSpamIssue specifies configuration for the delete-spam-issue plugin.
+type DeleteSpamIssue struct {
+	// AllowedTeams is a list of GitHub team slugs whose members are authorized
+	// to delete spam issues with the /delete-spam-issue command.
+	AllowedTeams []string `json:"allowed_teams,omitempty"`
+	// AllowedUsers is a list of GitHub logins that are authorized to
+	// delete spam issues with the /delete-spam-issue command.
+	AllowedUsers []string `json:"allowed_users,omitempty"`
 }
 
 // Retitle specifies configuration for the retitle plugin.

--- a/pkg/plugins/config.go
+++ b/pkg/plugins/config.go
@@ -300,12 +300,25 @@ func (c *Configuration) SkipCollaborators(org, repo string) bool {
 
 // DeleteSpamIssue specifies configuration for the delete-spam-issue plugin.
 type DeleteSpamIssue struct {
+	// AllowTopLevelApprovers allows approvers from the top-level OWNERS file
+	// of the repository to delete spam issues with the /delete-spam-issue command.
+	// Defaults to true.
+	AllowTopLevelApprovers *bool `json:"allow_top_level_approvers,omitempty"`
 	// AllowedTeams is a list of GitHub team slugs whose members are authorized
 	// to delete spam issues with the /delete-spam-issue command.
 	AllowedTeams []string `json:"allowed_teams,omitempty"`
 	// AllowedUsers is a list of GitHub logins that are authorized to
 	// delete spam issues with the /delete-spam-issue command.
 	AllowedUsers []string `json:"allowed_users,omitempty"`
+}
+
+// TopLevelApproversAllowed returns whether approvers from the top-level OWNERS
+// file of the repository may delete spam issues, defaulting to true when unset.
+func (d DeleteSpamIssue) TopLevelApproversAllowed() bool {
+	if d.AllowTopLevelApprovers != nil {
+		return *d.AllowTopLevelApprovers
+	}
+	return true
 }
 
 // Retitle specifies configuration for the retitle plugin.

--- a/pkg/plugins/config_test.go
+++ b/pkg/plugins/config_test.go
@@ -1071,6 +1071,37 @@ orgs:
 	}
 }
 
+func TestTopLevelApproversAllowed(t *testing.T) {
+	testCases := []struct {
+		name     string
+		config   DeleteSpamIssue
+		expected bool
+	}{
+		{
+			name:     "unset defaults to true",
+			config:   DeleteSpamIssue{},
+			expected: true,
+		},
+		{
+			name:     "explicitly enabled",
+			config:   DeleteSpamIssue{AllowTopLevelApprovers: ptr.To(true)},
+			expected: true,
+		},
+		{
+			name:     "explicitly disabled",
+			config:   DeleteSpamIssue{AllowTopLevelApprovers: ptr.To(false)},
+			expected: false,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if actual := tc.config.TopLevelApproversAllowed(); actual != tc.expected {
+				t.Errorf("expected: %t, got: %t", tc.expected, actual)
+			}
+		})
+	}
+}
+
 func TestBugzillaBugState_String(t *testing.T) {
 	testCases := []struct {
 		name     string

--- a/pkg/plugins/delete-spam-issue/delete-spam-issue.go
+++ b/pkg/plugins/delete-spam-issue/delete-spam-issue.go
@@ -1,0 +1,160 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package deletespamissue implements the delete-spam-issue plugin.
+package deletespamissue
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+
+	githubql "github.com/shurcooL/githubv4"
+	"github.com/sirupsen/logrus"
+
+	"sigs.k8s.io/prow/pkg/config"
+	"sigs.k8s.io/prow/pkg/github"
+	"sigs.k8s.io/prow/pkg/pluginhelp"
+	"sigs.k8s.io/prow/pkg/plugins"
+)
+
+const pluginName = "delete-spam-issue"
+
+var deleteSpamIssueRe = regexp.MustCompile(`(?mi)^/delete-spam-issue\s*$`)
+
+type githubClient interface {
+	CreateComment(org, repo string, number int, comment string) error
+	TeamBySlugHasMember(org string, teamSlug string, memberLogin string) (bool, error)
+	MutateWithGitHubAppsSupport(context.Context, any, githubql.Input, map[string]any, string) error
+}
+
+func init() {
+	plugins.RegisterGenericCommentHandler(pluginName, handleGenericCommentEvent, helpProvider)
+}
+
+func helpProvider(_ *plugins.Configuration, _ []config.OrgRepo) (*pluginhelp.PluginHelp, error) {
+	yamlSnippet, err := plugins.CommentMap.GenYaml(&plugins.Configuration{
+		DeleteSpamIssue: plugins.DeleteSpamIssue{
+			AllowedTeams: []string{"spam-fighters"},
+			AllowedUsers: []string{"alice", "bob"},
+		},
+	})
+	if err != nil {
+		logrus.WithError(err).Warnf("cannot generate comments for %s plugin", pluginName)
+	}
+	pluginHelp := &pluginhelp.PluginHelp{
+		Description: "The delete-spam-issue plugin allows a configured list of users to delete issues that are deemed spam.",
+		Snippet:     yamlSnippet,
+	}
+	pluginHelp.AddCommand(pluginhelp.Command{
+		Usage:       "/delete-spam-issue",
+		Description: "Deletes the issue because it is deemed spam.",
+		WhoCanUse:   "Users listed under the plugin's allowed_users configuration and members of teams listed under allowed_teams.",
+		Examples:    []string{"/delete-spam-issue"},
+	})
+	return pluginHelp, nil
+}
+
+func handleGenericCommentEvent(pc plugins.Agent, e github.GenericCommentEvent) error {
+	return handleGenericComment(pc.GitHubClient, pc.PluginConfig.DeleteSpamIssue, pc.Logger, e)
+}
+
+func handleGenericComment(gc githubClient, config plugins.DeleteSpamIssue, log *logrus.Entry, e github.GenericCommentEvent) error {
+	if e.Action != github.GenericCommentActionCreated {
+		return nil
+	}
+
+	if !deleteSpamIssueRe.MatchString(e.Body) {
+		return nil
+	}
+
+	org := e.Repo.Owner.Login
+	repo := e.Repo.Name
+	number := e.Number
+	user := e.User.Login
+
+	if e.IsPR {
+		return gc.CreateComment(org, repo, number, plugins.FormatResponseRaw(e.Body, e.HTMLURL, user, "`/delete-spam-issue` can only be used on GitHub issues."))
+	}
+
+	canDelete, canNotDeleteReason, err := canUserDeleteIssue(gc, org, user, config)
+	if err != nil {
+		return fmt.Errorf("failed to check if user can delete issue: %w", err)
+	}
+	if !canDelete {
+		return gc.CreateComment(org, repo, number, plugins.FormatResponseRaw(e.Body, e.HTMLURL, user, canNotDeleteReason))
+	}
+
+	// Although the issue is being deleted, still leave a comment for an email trail just in case.
+	if err := gc.CreateComment(org, repo, number, plugins.FormatResponseRaw(e.Body, e.HTMLURL, user, "This issue is being deleted because it has been deemed spam. If you believe this is a mistake, please reach out in the [#github-management](https://kubernetes.slack.com/messages/github-management) Slack channel.")); err != nil {
+		return fmt.Errorf("failed to comment on issue: %w", err)
+	}
+
+	if err := deleteIssue(gc, org, e.NodeID); err != nil {
+		log.WithError(err).Error("Failed to delete issue.")
+		return gc.CreateComment(org, repo, number, plugins.FormatResponseRaw(e.Body, e.HTMLURL, user, fmt.Sprintf("Unable to delete issue #%d. Please try again later.", number)))
+	}
+
+	return nil
+}
+
+func canUserDeleteIssue(gc githubClient, org string, user string, config plugins.DeleteSpamIssue) (canDelete bool, canNotDeleteReason string, err error) {
+	for _, allowedUser := range config.AllowedUsers {
+		if strings.EqualFold(allowedUser, user) {
+			return true, "", nil
+		}
+	}
+
+	for _, team := range config.AllowedTeams {
+		isMember, err := gc.TeamBySlugHasMember(org, team, user)
+		if err != nil {
+			return false, "", err
+		}
+		if isMember {
+			return true, "", nil
+		}
+	}
+
+	msg := "This issue cannot be deleted, because you are not in one of the allowed teams and are not an allowed user."
+	if len(config.AllowedTeams) > 0 {
+		msg += fmt.Sprintf(" Must be a member of one of these teams: %s", strings.Join(config.AllowedTeams, ", "))
+	}
+	return false, msg, nil
+}
+
+// deleteIssueMutation is a GraphQL mutation struct compatible with shurcooL/githubql's client
+//
+// See https://docs.github.com/en/graphql/reference/input-objects#deleteissueinput
+type deleteIssueMutation struct {
+	DeleteIssue struct {
+		Repository struct {
+			Name githubql.String
+		}
+	} `graphql:"deleteIssue(input: $input)"`
+}
+
+// deleteIssue deletes an issue. Deleting issues is only available via
+// GitHub's GraphQL API.
+//
+// See https://docs.github.com/en/graphql/reference/mutations#deleteissue
+func deleteIssue(gc githubClient, org, issueNodeID string) error {
+	m := &deleteIssueMutation{}
+	input := githubql.DeleteIssueInput{
+		IssueID: githubql.ID(issueNodeID),
+	}
+	return gc.MutateWithGitHubAppsSupport(context.Background(), m, input, nil, org)
+}

--- a/pkg/plugins/delete-spam-issue/delete-spam-issue.go
+++ b/pkg/plugins/delete-spam-issue/delete-spam-issue.go
@@ -25,11 +25,13 @@ import (
 
 	githubql "github.com/shurcooL/githubv4"
 	"github.com/sirupsen/logrus"
+	"k8s.io/utils/ptr"
 
 	"sigs.k8s.io/prow/pkg/config"
 	"sigs.k8s.io/prow/pkg/github"
 	"sigs.k8s.io/prow/pkg/pluginhelp"
 	"sigs.k8s.io/prow/pkg/plugins"
+	"sigs.k8s.io/prow/pkg/repoowners"
 )
 
 const pluginName = "delete-spam-issue"
@@ -42,6 +44,10 @@ type githubClient interface {
 	MutateWithGitHubAppsSupport(context.Context, any, githubql.Input, map[string]any, string) error
 }
 
+type ownersClient interface {
+	LoadRepoOwners(org, repo, base string) (repoowners.RepoOwner, error)
+}
+
 func init() {
 	plugins.RegisterGenericCommentHandler(pluginName, handleGenericCommentEvent, helpProvider)
 }
@@ -49,8 +55,9 @@ func init() {
 func helpProvider(_ *plugins.Configuration, _ []config.OrgRepo) (*pluginhelp.PluginHelp, error) {
 	yamlSnippet, err := plugins.CommentMap.GenYaml(&plugins.Configuration{
 		DeleteSpamIssue: plugins.DeleteSpamIssue{
-			AllowedTeams: []string{"spam-fighters"},
-			AllowedUsers: []string{"alice", "bob"},
+			AllowTopLevelApprovers: ptr.To(true),
+			AllowedTeams:           []string{"spam-fighters"},
+			AllowedUsers:           []string{"alice", "bob"},
 		},
 	})
 	if err != nil {
@@ -63,17 +70,17 @@ func helpProvider(_ *plugins.Configuration, _ []config.OrgRepo) (*pluginhelp.Plu
 	pluginHelp.AddCommand(pluginhelp.Command{
 		Usage:       "/delete-spam-issue",
 		Description: "Deletes the issue because it is deemed spam.",
-		WhoCanUse:   "Users listed under the plugin's allowed_users configuration and members of teams listed under allowed_teams.",
+		WhoCanUse:   "Users listed under the plugin's allowed_users configuration, members of teams listed under allowed_teams, and, unless allow_top_level_approvers is disabled, approvers from the top-level OWNERS file of the repository.",
 		Examples:    []string{"/delete-spam-issue"},
 	})
 	return pluginHelp, nil
 }
 
 func handleGenericCommentEvent(pc plugins.Agent, e github.GenericCommentEvent) error {
-	return handleGenericComment(pc.GitHubClient, pc.PluginConfig.DeleteSpamIssue, pc.Logger, e)
+	return handleGenericComment(pc.GitHubClient, pc.OwnersClient, pc.PluginConfig.DeleteSpamIssue, pc.Logger, e)
 }
 
-func handleGenericComment(gc githubClient, config plugins.DeleteSpamIssue, log *logrus.Entry, e github.GenericCommentEvent) error {
+func handleGenericComment(gc githubClient, oc ownersClient, config plugins.DeleteSpamIssue, log *logrus.Entry, e github.GenericCommentEvent) error {
 	if e.Action != github.GenericCommentActionCreated {
 		return nil
 	}
@@ -91,7 +98,7 @@ func handleGenericComment(gc githubClient, config plugins.DeleteSpamIssue, log *
 		return gc.CreateComment(org, repo, number, plugins.FormatResponseRaw(e.Body, e.HTMLURL, user, "`/delete-spam-issue` can only be used on GitHub issues."))
 	}
 
-	canDelete, canNotDeleteReason, err := canUserDeleteIssue(gc, org, user, config)
+	canDelete, canNotDeleteReason, err := canUserDeleteIssue(gc, oc, org, repo, e.Repo.DefaultBranch, user, config)
 	if err != nil {
 		return fmt.Errorf("failed to check if user can delete issue: %w", err)
 	}
@@ -112,7 +119,7 @@ func handleGenericComment(gc githubClient, config plugins.DeleteSpamIssue, log *
 	return nil
 }
 
-func canUserDeleteIssue(gc githubClient, org string, user string, config plugins.DeleteSpamIssue) (canDelete bool, canNotDeleteReason string, err error) {
+func canUserDeleteIssue(gc githubClient, oc ownersClient, org, repo, defaultBranch, user string, config plugins.DeleteSpamIssue) (canDelete bool, canNotDeleteReason string, err error) {
 	for _, allowedUser := range config.AllowedUsers {
 		if strings.EqualFold(allowedUser, user) {
 			return true, "", nil
@@ -129,9 +136,22 @@ func canUserDeleteIssue(gc githubClient, org string, user string, config plugins
 		}
 	}
 
+	if config.TopLevelApproversAllowed() {
+		owners, err := oc.LoadRepoOwners(org, repo, defaultBranch)
+		if err != nil {
+			return false, "", err
+		}
+		if owners.TopLevelApprovers().Has(github.NormLogin(user)) {
+			return true, "", nil
+		}
+	}
+
 	msg := "This issue cannot be deleted, because you are not in one of the allowed teams and are not an allowed user."
 	if len(config.AllowedTeams) > 0 {
 		msg += fmt.Sprintf(" Must be a member of one of these teams: %s", strings.Join(config.AllowedTeams, ", "))
+	}
+	if config.TopLevelApproversAllowed() {
+		msg += " Approvers from the top-level OWNERS file can also use this command."
 	}
 	return false, msg, nil
 }

--- a/pkg/plugins/delete-spam-issue/delete-spam-issue_test.go
+++ b/pkg/plugins/delete-spam-issue/delete-spam-issue_test.go
@@ -1,0 +1,213 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deletespamissue
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	githubql "github.com/shurcooL/githubv4"
+	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	"sigs.k8s.io/prow/pkg/github"
+	"sigs.k8s.io/prow/pkg/github/fakegithub"
+	"sigs.k8s.io/prow/pkg/plugins"
+)
+
+// fakeClient wraps fakegithub.FakeClient and adds MutateWithGitHubAppsSupport,
+// which is required by the githubClient interface for the delete mutation.
+// It also allows injecting a TeamBySlugHasMember error.
+type fakeClient struct {
+	*fakegithub.FakeClient
+	mutateInput   githubql.Input
+	mutateErr     error
+	teamMemberErr error
+}
+
+func (c *fakeClient) MutateWithGitHubAppsSupport(_ context.Context, _ any, input githubql.Input, _ map[string]any, _ string) error {
+	c.mutateInput = input
+	return c.mutateErr
+}
+
+func (c *fakeClient) TeamBySlugHasMember(org string, teamSlug string, memberLogin string) (bool, error) {
+	if c.teamMemberErr != nil {
+		return false, c.teamMemberErr
+	}
+	return c.FakeClient.TeamBySlugHasMember(org, teamSlug, memberLogin)
+}
+
+func TestDeleteSpamIssue(t *testing.T) {
+	validEvent := github.GenericCommentEvent{
+		Action: github.GenericCommentActionCreated,
+		Repo:   github.Repo{Owner: github.User{Login: "kubernetes"}, Name: "test-repo"},
+		Number: 101,
+		NodeID: "fakeIssueNodeID",
+		User:   github.User{Login: "allowed-user"},
+		Body:   "/delete-spam-issue",
+		IsPR:   false,
+	}
+
+	testCases := []struct {
+		name           string
+		event          github.GenericCommentEvent
+		allowedUsers   []string
+		allowedTeams   []string
+		teamMembers    []string
+		mutateErr      error
+		teamMemberErr  error
+		wantErr        bool
+		expectComments []string
+		expectDeleted  bool
+	}{
+		{
+			name:           "allowed user deletes issue",
+			event:          validEvent,
+			allowedUsers:   []string{"allowed-user"},
+			expectComments: []string{"This issue is being deleted because it has been deemed spam"},
+			expectDeleted:  true,
+		},
+		{
+			name:           "allowed user match is case-insensitive",
+			event:          validEvent,
+			allowedUsers:   []string{"Allowed-User"},
+			expectComments: []string{"This issue is being deleted because it has been deemed spam"},
+			expectDeleted:  true,
+		},
+		{
+			name:           "allowed team member deletes issue",
+			event:          validEvent,
+			allowedTeams:   []string{"spam-fighters"},
+			teamMembers:    []string{"allowed-user"},
+			expectComments: []string{"This issue is being deleted because it has been deemed spam"},
+			expectDeleted:  true,
+		},
+		{
+			name:           "user not in allowed team posts error comment with teams",
+			event:          validEvent,
+			allowedTeams:   []string{"spam-fighters"},
+			teamMembers:    []string{"other-user"},
+			expectComments: []string{"not in one of the allowed teams and are not an allowed user. Must be a member of one of these teams: spam-fighters"},
+		},
+		{
+			name:           "unauthorized user posts error comment",
+			event:          validEvent,
+			allowedUsers:   []string{"other-user"},
+			expectComments: []string{"not in one of the allowed teams and are not an allowed user"},
+		},
+		{
+			name:           "no allowed users or teams configured rejects everyone",
+			event:          validEvent,
+			expectComments: []string{"not in one of the allowed teams and are not an allowed user"},
+		},
+		{
+			name: "command on pull request posts error comment",
+			event: func() github.GenericCommentEvent {
+				e := validEvent
+				e.IsPR = true
+				return e
+			}(),
+			allowedUsers:   []string{"allowed-user"},
+			expectComments: []string{"can only be used on GitHub issues"},
+		},
+		{
+			name: "non-created action is ignored",
+			event: func() github.GenericCommentEvent {
+				e := validEvent
+				e.Action = github.GenericCommentActionEdited
+				return e
+			}(),
+			allowedUsers: []string{"allowed-user"},
+		},
+		{
+			name: "comment without command is ignored",
+			event: func() github.GenericCommentEvent {
+				e := validEvent
+				e.Body = "just a regular comment"
+				return e
+			}(),
+			allowedUsers: []string{"allowed-user"},
+		},
+		{
+			name:          "team membership check failure returns error without deleting",
+			event:         validEvent,
+			allowedTeams:  []string{"spam-fighters"},
+			teamMemberErr: errors.New("team API error"),
+			wantErr:       true,
+		},
+		{
+			name:         "delete mutation failure posts error comment",
+			event:        validEvent,
+			allowedUsers: []string{"allowed-user"},
+			mutateErr:    errors.New("delete error"),
+			expectComments: []string{
+				"This issue is being deleted because it has been deemed spam",
+				"Unable to delete issue #101. Please try again later.",
+			},
+		},
+	}
+
+	log := logrus.WithField("plugin", pluginName)
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			fc := fakegithub.NewFakeClient()
+			if len(tc.allowedTeams) > 0 {
+				fc.Teams = map[string]map[string]fakegithub.TeamWithMembers{
+					"kubernetes": {
+						tc.allowedTeams[0]: {Members: sets.New(tc.teamMembers...)},
+					},
+				}
+			}
+			gc := &fakeClient{FakeClient: fc, mutateErr: tc.mutateErr, teamMemberErr: tc.teamMemberErr}
+			config := plugins.DeleteSpamIssue{AllowedUsers: tc.allowedUsers, AllowedTeams: tc.allowedTeams}
+
+			err := handleGenericComment(gc, config, log, tc.event)
+
+			if tc.wantErr {
+				if err == nil {
+					t.Error("expected error, got nil")
+				}
+			} else if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+
+			comments := fc.IssueComments[tc.event.Number]
+			if len(comments) != len(tc.expectComments) {
+				t.Fatalf("expected #comments: %d, got %d: %v", len(tc.expectComments), len(comments), comments)
+			}
+			for i, expected := range tc.expectComments {
+				if !strings.Contains(comments[i].Body, expected) {
+					t.Errorf("expected comment %d to contain %q, got: %q", i, expected, comments[i].Body)
+				}
+			}
+
+			if tc.expectDeleted {
+				input, ok := gc.mutateInput.(githubql.DeleteIssueInput)
+				if !ok {
+					t.Fatalf("wrong mutation input type: %T", gc.mutateInput)
+				}
+				if input.IssueID != githubql.ID(tc.event.NodeID) {
+					t.Errorf("wrong issue ID: %v", input.IssueID)
+				}
+			} else if tc.mutateErr == nil && gc.mutateInput != nil {
+				t.Errorf("expected no mutation, got input: %v", gc.mutateInput)
+			}
+		})
+	}
+}

--- a/pkg/plugins/delete-spam-issue/delete-spam-issue_test.go
+++ b/pkg/plugins/delete-spam-issue/delete-spam-issue_test.go
@@ -25,10 +25,14 @@ import (
 	githubql "github.com/shurcooL/githubv4"
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/utils/ptr"
 
 	"sigs.k8s.io/prow/pkg/github"
 	"sigs.k8s.io/prow/pkg/github/fakegithub"
+	"sigs.k8s.io/prow/pkg/layeredsets"
 	"sigs.k8s.io/prow/pkg/plugins"
+	"sigs.k8s.io/prow/pkg/plugins/ownersconfig"
+	"sigs.k8s.io/prow/pkg/repoowners"
 )
 
 // fakeClient wraps fakegithub.FakeClient and adds MutateWithGitHubAppsSupport,
@@ -53,10 +57,63 @@ func (c *fakeClient) TeamBySlugHasMember(org string, teamSlug string, memberLogi
 	return c.FakeClient.TeamBySlugHasMember(org, teamSlug, memberLogin)
 }
 
+// TODO(MadhavJivrajani): see if this can be put into a package somewhere and reused along with
+// the issue-management plugins.
+//
+// fakeOwnersClient implements repoowners.RepoOwner.
+type fakeOwnersClient struct {
+	topLevelApprovers sets.Set[string]
+}
+
+func (foc *fakeOwnersClient) FindApproverOwnersForFile(path string) string    { return "" }
+func (foc *fakeOwnersClient) FindReviewersOwnersForFile(path string) string   { return "" }
+func (foc *fakeOwnersClient) FindLabelsForFile(path string) sets.Set[string]  { return nil }
+func (foc *fakeOwnersClient) IsNoParentOwners(path string) bool               { return false }
+func (foc *fakeOwnersClient) IsAutoApproveUnownedSubfolders(path string) bool { return false }
+func (foc *fakeOwnersClient) LeafApprovers(path string) sets.Set[string]      { return nil }
+func (foc *fakeOwnersClient) Approvers(path string) layeredsets.String        { return layeredsets.String{} }
+func (foc *fakeOwnersClient) LeafReviewers(path string) sets.Set[string]      { return nil }
+func (foc *fakeOwnersClient) Reviewers(path string) layeredsets.String        { return layeredsets.String{} }
+func (foc *fakeOwnersClient) RequiredReviewers(path string) sets.Set[string]  { return nil }
+func (foc *fakeOwnersClient) ParseSimpleConfig(path string) (repoowners.SimpleConfig, error) {
+	return repoowners.SimpleConfig{}, nil
+}
+func (foc *fakeOwnersClient) ParseFullConfig(path string) (repoowners.FullConfig, error) {
+	return repoowners.FullConfig{}, nil
+}
+func (foc *fakeOwnersClient) TopLevelApprovers() sets.Set[string] { return foc.topLevelApprovers }
+func (foc *fakeOwnersClient) Filenames() ownersconfig.Filenames   { return ownersconfig.FakeFilenames }
+func (foc *fakeOwnersClient) AllOwners() sets.Set[string]         { return nil }
+func (foc *fakeOwnersClient) AllApprovers() sets.Set[string]      { return nil }
+func (foc *fakeOwnersClient) AllReviewers() sets.Set[string]      { return nil }
+
+// fakeRepoownersClient implements ownersClient.
+// It wraps fakeOwnersClient and returns it from LoadRepoOwners.
+type fakeRepoownersClient struct {
+	foc *fakeOwnersClient
+	err error
+}
+
+func (froc *fakeRepoownersClient) LoadRepoOwners(org, repo, base string) (repoowners.RepoOwner, error) {
+	if froc.err != nil {
+		return nil, froc.err
+	}
+	return froc.foc, nil
+}
+
+// newFakeRepoownersClient builds a fakeRepoownersClient from a list of approver logins.
+func newFakeRepoownersClient(approvers []string) *fakeRepoownersClient {
+	approverSet := sets.New[string]()
+	for _, a := range approvers {
+		approverSet.Insert(github.NormLogin(a))
+	}
+	return &fakeRepoownersClient{foc: &fakeOwnersClient{topLevelApprovers: approverSet}}
+}
+
 func TestDeleteSpamIssue(t *testing.T) {
 	validEvent := github.GenericCommentEvent{
 		Action: github.GenericCommentActionCreated,
-		Repo:   github.Repo{Owner: github.User{Login: "kubernetes"}, Name: "test-repo"},
+		Repo:   github.Repo{Owner: github.User{Login: "kubernetes"}, Name: "test-repo", DefaultBranch: "main"},
 		Number: 101,
 		NodeID: "fakeIssueNodeID",
 		User:   github.User{Login: "allowed-user"},
@@ -65,16 +122,19 @@ func TestDeleteSpamIssue(t *testing.T) {
 	}
 
 	testCases := []struct {
-		name           string
-		event          github.GenericCommentEvent
-		allowedUsers   []string
-		allowedTeams   []string
-		teamMembers    []string
-		mutateErr      error
-		teamMemberErr  error
-		wantErr        bool
-		expectComments []string
-		expectDeleted  bool
+		name                   string
+		event                  github.GenericCommentEvent
+		allowedUsers           []string
+		allowedTeams           []string
+		teamMembers            []string
+		allowTopLevelApprovers *bool
+		topLevelApprovers      []string
+		loadOwnersErr          error
+		mutateErr              error
+		teamMemberErr          error
+		wantErr                bool
+		expectComments         []string
+		expectDeleted          bool
 	}{
 		{
 			name:           "allowed user deletes issue",
@@ -99,25 +159,25 @@ func TestDeleteSpamIssue(t *testing.T) {
 			expectDeleted:  true,
 		},
 		{
-			name:           "user not in allowed team posts error comment with teams",
+			name:           "user not in allowed team posts comment - should reject",
 			event:          validEvent,
 			allowedTeams:   []string{"spam-fighters"},
 			teamMembers:    []string{"other-user"},
 			expectComments: []string{"not in one of the allowed teams and are not an allowed user. Must be a member of one of these teams: spam-fighters"},
 		},
 		{
-			name:           "unauthorized user posts error comment",
+			name:           "unauthorized user posts comment - should reject",
 			event:          validEvent,
 			allowedUsers:   []string{"other-user"},
 			expectComments: []string{"not in one of the allowed teams and are not an allowed user"},
 		},
 		{
-			name:           "no allowed users or teams configured rejects everyone",
+			name:           "no allowed users or teams configured - rejects everyone",
 			event:          validEvent,
 			expectComments: []string{"not in one of the allowed teams and are not an allowed user"},
 		},
 		{
-			name: "command on pull request posts error comment",
+			name: "command on pull request - should reject",
 			event: func() github.GenericCommentEvent {
 				e := validEvent
 				e.IsPR = true
@@ -143,6 +203,32 @@ func TestDeleteSpamIssue(t *testing.T) {
 				return e
 			}(),
 			allowedUsers: []string{"allowed-user"},
+		},
+		{
+			name:              "top-level approver deletes issue by default",
+			event:             validEvent,
+			topLevelApprovers: []string{"allowed-user"},
+			expectComments:    []string{"This issue is being deleted because it has been deemed spam"},
+			expectDeleted:     true,
+		},
+		{
+			name:                   "top-level approver is rejected when disabled",
+			event:                  validEvent,
+			allowTopLevelApprovers: ptr.To(false),
+			topLevelApprovers:      []string{"allowed-user"},
+			expectComments:         []string{"not in one of the allowed teams and are not an allowed user"},
+		},
+		{
+			name:              "non-approver posts error comment mentioning OWNERS",
+			event:             validEvent,
+			topLevelApprovers: []string{"other-user"},
+			expectComments:    []string{"Approvers from the top-level OWNERS file can also use this command."},
+		},
+		{
+			name:          "LoadRepoOwners failure returns error without deleting",
+			event:         validEvent,
+			loadOwnersErr: errors.New("owners error"),
+			wantErr:       true,
 		},
 		{
 			name:          "team membership check failure returns error without deleting",
@@ -175,9 +261,15 @@ func TestDeleteSpamIssue(t *testing.T) {
 				}
 			}
 			gc := &fakeClient{FakeClient: fc, mutateErr: tc.mutateErr, teamMemberErr: tc.teamMemberErr}
-			config := plugins.DeleteSpamIssue{AllowedUsers: tc.allowedUsers, AllowedTeams: tc.allowedTeams}
+			froc := newFakeRepoownersClient(tc.topLevelApprovers)
+			froc.err = tc.loadOwnersErr
+			config := plugins.DeleteSpamIssue{
+				AllowedUsers:           tc.allowedUsers,
+				AllowedTeams:           tc.allowedTeams,
+				AllowTopLevelApprovers: tc.allowTopLevelApprovers,
+			}
 
-			err := handleGenericComment(gc, config, log, tc.event)
+			err := handleGenericComment(gc, froc, config, log, tc.event)
 
 			if tc.wantErr {
 				if err == nil {

--- a/pkg/plugins/plugin-config-documented.yaml
+++ b/pkg/plugins/plugin-config-documented.yaml
@@ -410,6 +410,10 @@ dco:
         # if the skip DCO option is enabled. The default is the PR's org.
         trusted_org: ' '
 delete_spam_issue:
+    # AllowTopLevelApprovers allows approvers from the top-level OWNERS file
+    # of the repository to delete spam issues with the /delete-spam-issue command.
+    # Defaults to true.
+    allow_top_level_approvers: false
     # AllowedTeams is a list of GitHub team slugs whose members are authorized
     # to delete spam issues with the /delete-spam-issue command.
     allowed_teams:

--- a/pkg/plugins/plugin-config-documented.yaml
+++ b/pkg/plugins/plugin-config-documented.yaml
@@ -409,6 +409,15 @@ dco:
         # TrustedOrg is the org whose members' commits will not be checked for DCO signoff
         # if the skip DCO option is enabled. The default is the PR's org.
         trusted_org: ' '
+delete_spam_issue:
+    # AllowedTeams is a list of GitHub team slugs whose members are authorized
+    # to delete spam issues with the /delete-spam-issue command.
+    allowed_teams:
+        - ""
+    # AllowedUsers is a list of GitHub logins that are authorized to
+    # delete spam issues with the /delete-spam-issue command.
+    allowed_users:
+        - ""
 # ExternalPlugins is a map of repositories (eg "k/k") to lists of
 # external plugins.
 external_plugins:
@@ -443,6 +452,17 @@ help:
     # HelpGuidelinesURL is the URL of the help page, which provides guidance on how and when to use the help wanted and good first issue labels.
     # The default value is "https://git.k8s.io/community/contributors/guide/help-wanted.md".
     help_guidelines_url: ' '
+invalid_commit_msg:
+    - # Checks is a list of check configurations.
+      # Each check can be individually enabled or disabled.
+      checks:
+        - # Disabled indicates whether this check should be skipped.
+          disabled: true
+          # Name is the name of the check (e.g., "fixupPrefix", "issueClosingKeywords").
+          name: ' '
+      # Repos is either of the form org/repos or just org.
+      repos:
+        - ""
 jira:
     # DisabledJiraProjects are projects for which we will never try to create a link,
     # for example including `enterprise` here would disable linking for all issues


### PR DESCRIPTION
_Disclaimer: this commit is authored with the help of Claude Code._

This PR enables https://github.com/kubernetes/org/pull/4994 

There has been a plethora of spam issues created by bots across different repos today and cleaning them up is bottlenecked on the availability of GH admins. We've had amazing folks volunteer and report such spam in a timely manner (thank you @dims!) and they are also highly trusted members of the community.

Deleting issues requires admin privileges, and rather than giving volunteers these elevated privileges, this commit introduces a prow plugin that a subset of *allowed* contributors can use to delete an issue and not rely on GH admins since we've had an increasing number of "spam storms" wherein an account creates nonsense issues in a loop resulting in a lot of them just lurking around.

The current flow that I see taking place with this is as follows:
1. Contributor drops a message on the #github-management slack noting the user ID of the account that created the spam issue (in case admins need to block/report).
2. Contributor comments `/delete-spam-issue`

TODO: the above contributor workflow also needs to be documented in k/community.

Step (1) can be further automated since we already have alerts based on certain GH events to slack setup if needed.

Currently, the allowed contributors are as follows:
1. GitHub admins
2. @dims (https://github.com/kubernetes/org/pull/4994)

We can also use this to create a named contributor role for anyone that helps out in reporting spam. 

/assign @kubernetes-sigs/owners 
for initial review