### PR TITLE
Fix pagination redirect test to actually reproduce the bug

### DIFF
--- a/pkg/github/client.go
+++ b/pkg/github/client.go
@@ -1989,17 +1989,23 @@ func (c *client) readPaginatedResultsWithValuesWithContext(ctx context.Context, 
 			break
 		}
 
-		// For GitHub Enterprise, c.bases[0] may include a path prefix like /api/v3.
-		// We need to strip that prefix from the Link header URL so that when we
-		// prepend c.bases[hostIndex] we don't duplicate it.
-		// For standard GitHub (with or without ghproxy), there is no path prefix.
-		//
-		// We compare only the Path components (ignoring query strings) to compute
-		// the prefix. The previous approach used the full RequestURI (path+query)
-		// for TrimSuffix, which breaks when resp.Request.URL differs from what we
-		// sent (e.g. due to a redirect): the suffix doesn't match, leaving prefix
-		// set to the entire response URI. A subsequent TrimPrefix then strips too
-		// much from the next-page URL, producing a malformed path like "&page=2".
+		// Example for github.com:
+		// * c.bases[0]: api.github.com
+		// * initial call: api.github.com/repos/kubernetes/kubernetes/pulls?per_page=100
+		// * next: api.github.com/repositories/22/pulls?per_page=100&page=2
+		// * prefix will be empty; we call the path returned by next as-is
+		// Example for github enterprise:
+		// * c.bases[0]: <ghe-url>/api/v3
+		// * initial call: <ghe-url>/api/v3/repos/kubernetes/kubernetes/pulls?per_page=100
+		// * next: <ghe-url>/api/v3/repositories/22/pulls?per_page=100&page=2
+		// * prefix will be "/api/v3" and we strip it so we don't duplicate it
+		//   when prepending c.bases[hostIndex]
+		// Example for a redirect (e.g. repo rename):
+		// * initial call: api.github.com/repos/old-org/old-repo/pulls?per_page=100
+		// * resp.Request.URL (after redirect): api.github.com/repos/new-org/new-repo/pulls?per_page=100
+		// * next: api.github.com/repos/new-org/new-repo/pulls?per_page=100&page=2
+		// * prefix will be empty; we compare only Path (not full RequestURI) so
+		//   the differing response URL doesn't break the suffix match
 		pathOnly := strings.SplitN(pagedPath, "?", 2)[0]
 		prefix := strings.TrimSuffix(resp.Request.URL.Path, pathOnly)
 

--- a/pkg/github/client_test.go
+++ b/pkg/github/client_test.go
@@ -1387,11 +1387,11 @@ func TestReadPaginatedResultsWithValuesSamePathPagination(t *testing.T) {
 		case r.URL.Query().Get("page") == "2":
 			labels = []Label{{Name: "page2"}}
 		default:
-			t.Fatalf("Unexpected request: %s", r.URL.String())
+			t.Errorf("Unexpected request: %s", r.URL.String())
 		}
 		b, err := json.Marshal(labels)
 		if err != nil {
-			t.Fatalf("Failed to marshal: %v", err)
+			t.Errorf("Failed to marshal: %v", err)
 		}
 		fmt.Fprint(w, string(b))
 	}))
@@ -1431,7 +1431,9 @@ func TestReadPaginatedResultsWithRedirect(t *testing.T) {
 	// due to a repo rename/transfer). After the redirect, resp.Request.URL
 	// differs from the original pagedPath. The pagination URL construction
 	// must still produce a valid URL for the next page.
+	requestCount := 0
 	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
 		switch r.URL.Path {
 		case "/repos/old-org/old-repo/branches":
 			newURL := fmt.Sprintf("https://%s/repos/new-org/new-repo/branches", r.Host)
@@ -1444,14 +1446,14 @@ func TestReadPaginatedResultsWithRedirect(t *testing.T) {
 			if r.URL.Query().Get("page") == "" {
 				labels = []Label{{Name: "page1"}}
 				w.Header().Set("Link", fmt.Sprintf(
-					`<https://%s/repos/new-org/new-repo/branches?per_page=100&page=2>; rel="next"`,
-					r.Host))
+					`<https://%s/repos/new-org/new-repo/branches?%s&page=2>; rel="next"`,
+					r.Host, r.URL.RawQuery))
 			} else {
 				labels = []Label{{Name: "page2"}}
 			}
 			b, err := json.Marshal(labels)
 			if err != nil {
-				t.Fatalf("Failed to marshal: %v", err)
+				t.Errorf("Failed to marshal: %v", err)
 			}
 			fmt.Fprint(w, string(b))
 		default:
@@ -1484,6 +1486,9 @@ func TestReadPaginatedResultsWithRedirect(t *testing.T) {
 	expected := []Label{{Name: "page1"}, {Name: "page2"}}
 	if !reflect.DeepEqual(labels, expected) {
 		t.Errorf("Expected %v, got %v", expected, labels)
+	}
+	if requestCount != 3 {
+		t.Errorf("Expected 3 requests (redirect + page1 + page2), got %d", requestCount)
 	}
 }
 


### PR DESCRIPTION
Addresses unresolved review feedback from #748 as a followup:

- **Fix redirect test**: echo `r.URL.RawQuery` in the Link header instead of hardcoding query params, so the test actually fails on the pre-fix code with the `invalid port` error from the PR description. Previously the test passed on both pre-fix and post-fix code.
- **Goroutine safety**: use `t.Errorf` instead of `t.Fatalf` in HTTP handler goroutines in both new tests (handler runs on a separate goroutine where `FailNow` is not safe).
- **Request counting**: add request count assertion to the redirect test.
- **Comment examples**: restore the original URL-progression examples in the pagination comment and extend with a redirect case.

Assisted by Claude Code