### PR TITLE
assign: add only_org_members config with warn/block action

### DIFF
--- a/pkg/plugins/assign/assign.go
+++ b/pkg/plugins/assign/assign.go
@@ -41,16 +41,31 @@ func init() {
 	plugins.RegisterGenericCommentHandler(pluginName, handleGenericComment, helpProvider)
 }
 
-func helpProvider(config *plugins.Configuration, _ []config.OrgRepo) (*pluginhelp.PluginHelp, error) {
-	// The Config field is omitted because this plugin is not configurable.
+func helpProvider(config *plugins.Configuration, enabledRepos []config.OrgRepo) (*pluginhelp.PluginHelp, error) {
+	configInfo := map[string]string{}
+	for _, repo := range enabledRepos {
+		cfg := config.AssignFor(repo.Org, repo.Repo)
+		if cfg.OnlyOrgMembers {
+			action := string(plugins.AssignActionWarn)
+			if cfg.Action == plugins.AssignActionBlock {
+				action = string(plugins.AssignActionBlock)
+			}
+			msg := fmt.Sprintf("Non-org-member assigns are handled with action=%q.", action)
+			if len(cfg.ExemptLabels) > 0 {
+				msg += fmt.Sprintf(" Issues with any of the following labels are exempt: %s.", strings.Join(cfg.ExemptLabels, ", "))
+			}
+			configInfo[repo.String()] = msg
+		}
+	}
 	pluginHelp := &pluginhelp.PluginHelp{
+		Config: configInfo,
 		Description: "The assign plugin assigns or requests reviews from users/teams. Specific users can be assigned with the command '/assign @user1' or have reviews requested of them with the command '/cc @user1'. If no users are specified, the commands default to targeting the user who created the command. Assignments and requested reviews can be removed in the same way that they are added by prefixing the commands with 'un'.",
 	}
 	pluginHelp.AddCommand(pluginhelp.Command{
 		Usage:       "/[un]assign [[@]<username>...|[@]<orgname/teamname>...]",
 		Description: "Assigns assignee(s) or team(s) to the PR",
 		Featured:    true,
-		WhoCanUse:   "Anyone can use the command, but the target user(s) must be an org member, a repo collaborator, or should have previously commented on the issue or PR.",
+		WhoCanUse:   "Anyone can use the command, but the target user(s) must be an org member, a repo collaborator, or should have previously commented on the issue or PR. When only_org_members is configured, non-org-member assigns are either warned (default) or blocked depending on the action setting. Issues with exempt labels bypass this restriction.",
 		Examples:    []string{"/assign", "/unassign", "/assign @spongebob", "/assign spongebob patrick", "/assign @kubernetes/sig-foo-bar"},
 	})
 	pluginHelp.AddCommand(pluginhelp.Command{
@@ -71,13 +86,17 @@ type githubClient interface {
 	UnrequestReview(org, repo string, number int, logins []string) error
 
 	CreateComment(owner, repo string, number int, comment string) error
+
+	GetIssueLabels(org, repo string, number int) ([]github.Label, error)
+	IsMember(org, user string) (bool, error)
 }
 
 func handleGenericComment(pc plugins.Agent, e github.GenericCommentEvent) error {
 	if e.Action != github.GenericCommentActionCreated {
 		return nil
 	}
-	err := handle(newAssignHandler(e, pc.GitHubClient, pc.Logger))
+	cfg := pc.PluginConfig.AssignFor(e.Repo.Owner.Login, e.Repo.Name)
+	err := handle(newAssignHandler(e, pc.GitHubClient, pc.Logger, cfg))
 	if e.IsPR {
 		err = combineErrors(err, handle(newReviewHandler(e, pc.GitHubClient, pc.Logger)))
 	}
@@ -187,22 +206,114 @@ type handler struct {
 	userType string
 }
 
-func newAssignHandler(e github.GenericCommentEvent, gc githubClient, log *logrus.Entry) *handler {
+func newAssignHandler(e github.GenericCommentEvent, gc githubClient, log *logrus.Entry, cfg *plugins.Assign) *handler {
 	org := e.Repo.Owner.Login
 	addFailureResponse := func(mu github.MissingUsers) string {
 		return fmt.Sprintf("GitHub didn't allow me to assign the following users: %s.\n\nNote that only [%s members](https://%s/orgs/%s/people) with read permissions, repo collaborators and people who have commented on this issue/PR can be assigned. Additionally, issues/PRs can only have 10 assignees at the same time.\nFor more information please see [the contributor guide](https://git.k8s.io/community/contributors/guide/first-contribution.md#issue-assignment-in-github)", strings.Join(mu.Users, ", "), org, github.DefaultHost, org)
 	}
 
+	add := gc.AssignIssue
+	if cfg.OnlyOrgMembers {
+		add = orgMemberAssignFunc(e, gc, log, cfg, org)
+		if cfg.Action == plugins.AssignActionBlock {
+			addFailureResponse = func(mu github.MissingUsers) string {
+				return fmt.Sprintf("Cannot assign the following users: %s.\n\nOnly [%s members](https://%s/orgs/%s/people) can be assigned when `only_org_members` is configured.", strings.Join(mu.Users, ", "), org, github.DefaultHost, org)
+			}
+		}
+	}
+
 	return &handler{
 		addFailureResponse: addFailureResponse,
 		remove:             gc.UnassignIssue,
-		add:                gc.AssignIssue,
+		add:                add,
 		event:              &e,
 		regexp:             assignRe,
 		gc:                 gc,
 		log:                log,
 		userType:           "assignee(s)",
 	}
+}
+
+func orgMemberAssignFunc(e github.GenericCommentEvent, gc githubClient, log *logrus.Entry, cfg *plugins.Assign, org string) func(string, string, int, []string) error {
+	return func(owner, repo string, number int, logins []string) error {
+		if len(cfg.ExemptLabels) > 0 {
+			labels, err := gc.GetIssueLabels(owner, repo, number)
+			if err != nil {
+				return err
+			}
+			if hasExemptLabel(labels, cfg.ExemptLabels) {
+				return gc.AssignIssue(owner, repo, number, logins)
+			}
+		}
+
+		members, nonMembers, err := splitByMembership(gc, org, logins)
+		if err != nil {
+			return err
+		}
+
+		if cfg.Action == plugins.AssignActionBlock {
+			return blockNonMembers(gc, owner, repo, number, members, nonMembers)
+		}
+
+		// AssignActionWarn (default): assign everyone but post a nudge comment for non-members.
+		assignErr := gc.AssignIssue(owner, repo, number, logins)
+		if len(nonMembers) > 0 {
+			warnMsg := fmt.Sprintf(
+				"Note: the following users are not members of the **%s** organization: %s.\n\n"+
+					"This issue has not been labeled as available for new contributors. "+
+					"If you are new to this project, consider looking for issues labeled "+
+					"`good first issue` to get started.",
+				org, strings.Join(nonMembers, ", "),
+			)
+			if cerr := gc.CreateComment(owner, repo, number, plugins.FormatResponseRaw(e.Body, e.HTMLURL, e.User.Login, warnMsg)); cerr != nil {
+				log.WithError(cerr).Error("failed to post warning comment for non-org-member assign")
+			}
+		}
+		return assignErr
+	}
+}
+
+func splitByMembership(gc githubClient, org string, logins []string) (members, nonMembers []string, err error) {
+	for _, login := range logins {
+		member, err := gc.IsMember(org, login)
+		if err != nil {
+			return nil, nil, err
+		}
+		if member {
+			members = append(members, login)
+		} else {
+			nonMembers = append(nonMembers, login)
+		}
+	}
+	return members, nonMembers, nil
+}
+
+func blockNonMembers(gc githubClient, owner, repo string, number int, members, nonMembers []string) error {
+	var assignErr error
+	if len(members) > 0 {
+		assignErr = gc.AssignIssue(owner, repo, number, members)
+	}
+	if len(nonMembers) > 0 {
+		mu := github.MissingUsers{Users: nonMembers}
+		if merr, ok := assignErr.(github.MissingUsers); ok {
+			mu.Users = append(mu.Users, merr.Users...)
+		} else if assignErr != nil {
+			return assignErr
+		}
+		return mu
+	}
+	return assignErr
+}
+
+func hasExemptLabel(issueLabels []github.Label, exemptLabels []string) bool {
+	for _, il := range issueLabels {
+		for _, el := range exemptLabels {
+			if strings.EqualFold(il.Name, el) {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func newReviewHandler(e github.GenericCommentEvent, gc githubClient, log *logrus.Entry) *handler {

--- a/pkg/plugins/assign/assign_test.go
+++ b/pkg/plugins/assign/assign_test.go
@@ -17,12 +17,14 @@ limitations under the License.
 package assign
 
 import (
+	"errors"
 	"sort"
 	"testing"
 
 	"github.com/sirupsen/logrus"
 
 	"sigs.k8s.io/prow/pkg/github"
+	"sigs.k8s.io/prow/pkg/plugins"
 )
 
 type fakeClient struct {
@@ -32,8 +34,12 @@ type fakeClient struct {
 	requested    map[string]int
 	unrequested  map[string]int
 	contributors map[string]bool
+	members      map[string]bool
+	labels       []github.Label
 
-	commented bool
+	commented      bool
+	memberCheckErr error
+	labelCheckErr  error
 }
 
 func (c *fakeClient) UnassignIssue(owner, repo string, number int, assignees []string) error {
@@ -95,9 +101,24 @@ func (c *fakeClient) CreateComment(owner, repo string, number int, comment strin
 	return nil
 }
 
+func (c *fakeClient) GetIssueLabels(org, repo string, number int) ([]github.Label, error) {
+	if c.labelCheckErr != nil {
+		return nil, c.labelCheckErr
+	}
+	return c.labels, nil
+}
+
+func (c *fakeClient) IsMember(org, user string) (bool, error) {
+	if c.memberCheckErr != nil {
+		return false, c.memberCheckErr
+	}
+	return c.members[user], nil
+}
+
 func newFakeClient(contribs []string) *fakeClient {
 	c := &fakeClient{
 		contributors: make(map[string]bool),
+		members:      make(map[string]bool),
 		requested:    make(map[string]int),
 		unrequested:  make(map[string]int),
 		assigned:     make(map[string]int),
@@ -395,7 +416,7 @@ func TestAssignAndReview(t *testing.T) {
 			Repo:   github.Repo{Name: "repo", Owner: github.User{Login: "org"}},
 			Number: 5,
 		}
-		if err := handle(newAssignHandler(e, fc, logrus.WithField("plugin", pluginName))); err != nil {
+		if err := handle(newAssignHandler(e, fc, logrus.WithField("plugin", pluginName), &plugins.Assign{})); err != nil {
 			t.Errorf("For case %s, didn't expect error from handle: %v", tc.name, err)
 			continue
 		}
@@ -449,5 +470,128 @@ func TestAssignAndReview(t *testing.T) {
 				}
 			}
 		}
+	}
+}
+
+func TestAssignOnlyOrgMembers(t *testing.T) {
+	testcases := []struct {
+		name           string
+		body           string
+		commenter      string
+		cfg            *plugins.Assign
+		members        []string
+		labels         []github.Label
+		memberCheckErr error
+		labelCheckErr  error
+		assigned       []string
+		commented      bool
+		expectErr      bool
+	}{
+		{
+			name:      "block: non-member rejected",
+			body:      "/assign",
+			commenter: "outsider",
+			cfg:       &plugins.Assign{OnlyOrgMembers: true, Action: plugins.AssignActionBlock},
+			members:   []string{"member1"},
+			commented: true,
+		},
+		{
+			name:      "block: member allowed",
+			body:      "/assign",
+			commenter: "member1",
+			cfg:       &plugins.Assign{OnlyOrgMembers: true, Action: plugins.AssignActionBlock},
+			members:   []string{"member1"},
+			assigned:  []string{"member1"},
+		},
+		{
+			name:      "block: mixed",
+			body:      "/assign @member1 @outsider",
+			commenter: "someone",
+			cfg:       &plugins.Assign{OnlyOrgMembers: true, Action: plugins.AssignActionBlock},
+			members:   []string{"member1"},
+			assigned:  []string{"member1"},
+			commented: true,
+		},
+		{
+			name:      "exempt label bypasses restriction",
+			body:      "/assign",
+			commenter: "outsider",
+			cfg:       &plugins.Assign{OnlyOrgMembers: true, Action: plugins.AssignActionBlock, ExemptLabels: []string{"good first issue"}},
+			members:   []string{"member1"},
+			labels:    []github.Label{{Name: "good first issue"}},
+			assigned:  []string{"outsider"},
+		},
+		{
+			name:      "warn: non-member assigned with comment",
+			body:      "/assign",
+			commenter: "outsider",
+			cfg:       &plugins.Assign{OnlyOrgMembers: true},
+			members:   []string{"member1"},
+			assigned:  []string{"outsider"},
+			commented: true,
+		},
+		{
+			name:      "warn: member, no comment",
+			body:      "/assign",
+			commenter: "member1",
+			cfg:       &plugins.Assign{OnlyOrgMembers: true},
+			members:   []string{"member1"},
+			assigned:  []string{"member1"},
+		},
+		{
+			name:           "IsMember error propagates",
+			body:           "/assign",
+			commenter:      "someone",
+			cfg:            &plugins.Assign{OnlyOrgMembers: true},
+			memberCheckErr: errors.New("api rate limit"),
+			expectErr:      true,
+		},
+		{
+			name:          "GetIssueLabels error propagates",
+			body:          "/assign",
+			commenter:     "someone",
+			cfg:           &plugins.Assign{OnlyOrgMembers: true, ExemptLabels: []string{"good first issue"}},
+			labelCheckErr: errors.New("api error"),
+			expectErr:     true,
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			fc := newFakeClient(nil)
+			for _, m := range tc.members {
+				fc.members[m] = true
+			}
+			fc.labels = tc.labels
+			fc.memberCheckErr = tc.memberCheckErr
+			fc.labelCheckErr = tc.labelCheckErr
+			e := github.GenericCommentEvent{
+				Body:   tc.body,
+				User:   github.User{Login: tc.commenter},
+				Repo:   github.Repo{Name: "repo", Owner: github.User{Login: "org"}},
+				Number: 5,
+			}
+			err := handle(newAssignHandler(e, fc, logrus.WithField("plugin", pluginName), tc.cfg))
+			if tc.expectErr {
+				if err == nil {
+					t.Fatal("expected error but got none")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tc.commented != fc.commented {
+				t.Errorf("commented: got %v, want %v", fc.commented, tc.commented)
+			}
+			if len(fc.assigned) != len(tc.assigned) {
+				t.Fatalf("assigned: got %v, want %v", fc.assigned, tc.assigned)
+			}
+			for _, who := range tc.assigned {
+				if n, ok := fc.assigned[who]; !ok || n < 1 {
+					t.Errorf("assigned: got %v, want %v", fc.assigned, tc.assigned)
+					break
+				}
+			}
+		})
 	}
 }

--- a/pkg/plugins/config.go
+++ b/pkg/plugins/config.go
@@ -68,6 +68,7 @@ type Configuration struct {
 
 	// Built-in plugins specific configuration.
 	Approve              []Approve                    `json:"approve,omitempty"`
+	Assign               map[string]*Assign           `json:"assign,omitempty"`
 	Blockades            []Blockade                   `json:"blockades,omitempty"`
 	Blunderbuss          Blunderbuss                  `json:"blunderbuss,omitempty"`
 	Bugzilla             Bugzilla                     `json:"bugzilla,omitempty"`
@@ -98,6 +99,32 @@ type Configuration struct {
 	Override             Override                     `json:"override,omitempty"`
 	Help                 Help                         `json:"help,omitempty"`
 	InvalidCommitMsg     []InvalidCommitMsg           `json:"invalid_commit_msg,omitempty"`
+}
+
+// AssignAction defines the action to take when a non-org-member uses /assign.
+type AssignAction string
+
+const (
+	// AssignActionWarn allows the assign but posts a nudge comment.
+	AssignActionWarn AssignAction = "warn"
+	// AssignActionBlock rejects the assign and posts an error comment.
+	AssignActionBlock AssignAction = "block"
+)
+
+// Assign specifies configuration for the assign plugin.
+type Assign struct {
+	// OnlyOrgMembers restricts issue/PR assignment to only org members.
+	OnlyOrgMembers bool `json:"only_org_members,omitempty"`
+	// ExemptLabels is a list of labels that exempt an issue from the
+	// OnlyOrgMembers restriction, allowing anyone to self-assign.
+	// For example, setting this to ["good first issue"] lets non-members
+	// assign themselves to issues labeled "good first issue" while still
+	// blocking drive-by assigns on other issues.
+	ExemptLabels []string `json:"exempt_labels,omitempty"`
+	// Action controls what happens when a non-org-member tries to use
+	// /assign on an issue without an exempt label.
+	// Valid values: "warn" (default), "block".
+	Action AssignAction `json:"action,omitempty"`
 }
 
 type Help struct {
@@ -1079,6 +1106,21 @@ func (c *Configuration) LgtmFor(org, repo string) *Lgtm {
 	return &Lgtm{}
 }
 
+// AssignFor finds the Assign config for a repo, if one exists.
+// Repo-level config is prioritized over org-level config.
+func (c *Configuration) AssignFor(org, repo string) *Assign {
+	if c.Assign[fmt.Sprintf("%s/%s", org, repo)] != nil {
+		return c.Assign[fmt.Sprintf("%s/%s", org, repo)]
+	}
+	if c.Assign[org] != nil {
+		return c.Assign[org]
+	}
+	if c.Assign["*"] != nil {
+		return c.Assign["*"]
+	}
+	return &Assign{}
+}
+
 // TriggerFor finds the Trigger for a repo, if one exists
 // a trigger can be listed for the repo itself or for the
 // owning organization
@@ -1526,6 +1568,18 @@ func validateTrigger(triggers []Trigger) error {
 	return nil
 }
 
+func validateAssign(assign map[string]*Assign) error {
+	for key, cfg := range assign {
+		if cfg == nil {
+			continue
+		}
+		if cfg.Action != "" && cfg.Action != AssignActionWarn && cfg.Action != AssignActionBlock {
+			return fmt.Errorf("assign[%q]: invalid action %q, must be %q or %q", key, cfg.Action, AssignActionWarn, AssignActionBlock)
+		}
+	}
+	return nil
+}
+
 var validInvalidCommitMsgChecks = sets.New[string]("fixupPrefix", "issueClosingKeywords")
 
 func validateInvalidCommitMsg(cfgs []InvalidCommitMsg) error {
@@ -1658,6 +1712,9 @@ func (c *Configuration) Validate() error {
 		return err
 	}
 	if err := validateTrigger(c.Triggers); err != nil {
+		return err
+	}
+	if err := validateAssign(c.Assign); err != nil {
 		return err
 	}
 	if err := validateRepoDupes(c.Approve); err != nil {

--- a/pkg/plugins/plugin-config-documented.yaml
+++ b/pkg/plugins/plugin-config-documented.yaml
@@ -23,6 +23,21 @@ approve:
       # RequireSelfApproval disables automatic approval from PR authors with approval rights.
       # Otherwise the plugin assumes the author of the PR with approval rights approves the changes in the PR.
       require_self_approval: false
+assign:
+    "":
+        # Action controls what happens when a non-org-member tries to use
+        # /assign on an issue without an exempt label.
+        # Valid values: "warn" (default), "block".
+        action: ' '
+        # ExemptLabels is a list of labels that exempt an issue from the
+        # OnlyOrgMembers restriction, allowing anyone to self-assign.
+        # For example, setting this to ["good first issue"] lets non-members
+        # assign themselves to issues labeled "good first issue" while still
+        # blocking drive-by assigns on other issues.
+        exempt_labels:
+            - ""
+        # OnlyOrgMembers restricts issue/PR assignment to only org members.
+        only_org_members: true
 blockades:
     - # BlockRegexps are regular expressions matching the file paths to block.
       blockregexps:
@@ -443,6 +458,17 @@ help:
     # HelpGuidelinesURL is the URL of the help page, which provides guidance on how and when to use the help wanted and good first issue labels.
     # The default value is "https://git.k8s.io/community/contributors/guide/help-wanted.md".
     help_guidelines_url: ' '
+invalid_commit_msg:
+    - # Checks is a list of check configurations.
+      # Each check can be individually enabled or disabled.
+      checks:
+        - # Disabled indicates whether this check should be skipped.
+          disabled: true
+          # Name is the name of the check (e.g., "fixupPrefix", "issueClosingKeywords").
+          name: ' '
+      # Repos is either of the form org/repos or just org.
+      repos:
+        - ""
 jira:
     # DisabledJiraProjects are projects for which we will never try to create a link,
     # for example including `enterprise` here would disable linking for all issues


### PR DESCRIPTION
Adds per-repo config for the assign plugin to restrict /assign to org members, with label-aware exemptions.

Configuration uses `map[string]*Assign` keyed by org or org/repo (like Dco):

```yaml
assign:
  org/repo:
    only_org_members: true
    exempt_labels: ["good first issue"]
    action: block
```

Options:
1. `only_org_members`: enable org membership checks on /assign
2. `action`: "warn" (default) allows the assign but posts a nudge comment; "block" rejects it
3. `exempt_labels`: labels that bypass the restriction (e.g. "good first issue")

When no config is set, behavior is unchanged.

Fixes: #391 
Fixes: #762