### PR TITLE
github: centralize dry-run bypass logic in isDryRunAllowed

### DIFF
--- a/pkg/github/client.go
+++ b/pkg/github/client.go
@@ -932,8 +932,13 @@ func (c *client) requestWithContext(ctx context.Context, r *request, ret interfa
 }
 
 // isDryRunAllowed returns true if this request should be allowed in dry-run mode.
-// Enforces a hardcoded allowlist; currently only allows GitHub App token acquisition.
+// GET requests are always allowed. Non-GET requests are only allowed if they match
+// a hardcoded allowlist (currently only GitHub App token acquisition).
 func isDryRunAllowed(r *request) bool {
+	if r.method == http.MethodGet {
+		return true
+	}
+
 	if !r.allowInDryRun {
 		return false
 	}
@@ -959,8 +964,7 @@ func (c *client) requestRaw(r *request) (int, []byte, error) {
 }
 
 func (c *client) requestRawWithContext(ctx context.Context, r *request) (int, []byte, error) {
-	// In dry-run mode, block all non-GET requests except for explicitly allowed read-only operations
-	if c.fake || (c.dry && r.method != http.MethodGet && !isDryRunAllowed(r)) {
+	if c.fake || (c.dry && !isDryRunAllowed(r)) {
 		return r.exitCodes[0], nil, nil
 	}
 	resp, err := c.requestRetryWithContext(ctx, r.method, r.path, r.accept, r.org, r.requestBody)
@@ -5122,9 +5126,6 @@ func (c *client) IsAppInstalled(org, repo string) (bool, error) {
 	durationLogger := c.log("IsAppInstalled", org, repo)
 	defer durationLogger()
 
-	if c.dry {
-		return false, fmt.Errorf("not getting AppInstallation in dry-run mode")
-	}
 	if !c.usesAppsAuth {
 		return false, fmt.Errorf("IsAppInstalled was called when not using appsAuth")
 	}

--- a/pkg/github/client_test.go
+++ b/pkg/github/client_test.go
@@ -3765,6 +3765,20 @@ func TestIsAppInstalled(t *testing.T) {
 			}
 		})
 	}
+
+	// IsAppInstalled is a GET request, so it should work in dry-run mode too
+	c.dry = true
+	for _, tc := range testCases {
+		t.Run("dry-run/"+tc.name, func(t *testing.T) {
+			installed, err := c.IsAppInstalled(tc.org, tc.repo)
+			if err != nil {
+				t.Fatalf("unexpected error in dry-run mode: %v", err)
+			}
+			if installed != tc.expected {
+				t.Fatalf("response: %v doesn't match expected: %v", installed, tc.expected)
+			}
+		})
+	}
 }
 
 func TestCollaboratorMethodsDryRun(t *testing.T) {


### PR DESCRIPTION
Refactor followup to #530.

- Move the GET-method check from the `requestRawWithContext` condition into `isDryRunAllowed`, making it the single source of truth for what is allowed in dry-run mode.
- Remove the stale `c.dry` guard from `IsAppInstalled` — it uses a GET request that was never blocked by `requestRawWithContext` anyway.

Proposed and assisted by Claude Code