### PR TITLE
Fix expiring token handling gaps in secret agent

### DIFF
--- a/pkg/config/secret/agent.go
+++ b/pkg/config/secret/agent.go
@@ -46,6 +46,7 @@ func init() {
 // censoring formatter that removes secret occurrences from the logs.
 func (a *agent) Start(paths []string) error {
 	a.secretsMap = make(map[string]secretReloader, len(paths))
+	a.expiringTokens = make(map[string]time.Time)
 	a.ReloadingCensorer = secretutil.NewCensorer()
 
 	for _, path := range paths {
@@ -196,6 +197,9 @@ func (a *agent) getSecrets() sets.Set[string] {
 	secrets := sets.New[string]()
 	for _, v := range a.secretsMap {
 		secrets.Insert(string(v.getRaw()))
+	}
+	for token := range a.expiringTokens {
+		secrets.Insert(token)
 	}
 	return secrets
 }

--- a/pkg/config/secret/agent_test.go
+++ b/pkg/config/secret/agent_test.go
@@ -98,6 +98,84 @@ func TestAddExpiringToken(t *testing.T) {
 	}
 }
 
+func TestStartResetsExpiringTokens(t *testing.T) {
+	a := &agent{
+		secretsMap: make(map[string]secretReloader),
+		expiringTokens: map[string]time.Time{
+			"stale-token": time.Date(2099, 1, 1, 0, 0, 0, 0, time.UTC),
+		},
+		ReloadingCensorer: secretutil.NewCensorer(),
+	}
+
+	if err := a.Start(nil); err != nil {
+		t.Fatalf("Start failed: %v", err)
+	}
+
+	if len(a.expiringTokens) != 0 {
+		t.Fatalf("expiringTokens after Start = %v, want empty map", a.expiringTokens)
+	}
+}
+
+func TestExpiringTokenCensoring(t *testing.T) {
+	token := "ghs_secret123"
+	input := []byte("https://x-access-token:" + token + "@github.com/org/repo")
+	censored := "https://x-access-token:" + "XXXXXXXXXXXXX" + "@github.com/org/repo"
+
+	t.Run("active token is censored", func(t *testing.T) {
+		a := &agent{
+			secretsMap:        make(map[string]secretReloader),
+			expiringTokens:    make(map[string]time.Time),
+			ReloadingCensorer: secretutil.NewCensorer(),
+		}
+		a.addExpiringToken(token, time.Date(2099, 1, 1, 0, 0, 0, 0, time.UTC))
+
+		got := a.Censor(input)
+		if string(got) != censored {
+			t.Fatalf("Censor() = %q, want %q", string(got), censored)
+		}
+	})
+
+	t.Run("expired token is not censored", func(t *testing.T) {
+		a := &agent{
+			secretsMap:        make(map[string]secretReloader),
+			expiringTokens:    make(map[string]time.Time),
+			ReloadingCensorer: secretutil.NewCensorer(),
+		}
+		a.addExpiringToken(token, time.Date(1980, 1, 1, 0, 0, 0, 0, time.UTC))
+
+		got := a.Censor(input)
+		if string(got) != string(input) {
+			t.Fatalf("Censor() = %q, want %q (unchanged)", string(got), string(input))
+		}
+	})
+}
+
+func TestGetSecretsIncludesExpiringTokens(t *testing.T) {
+	dir := t.TempDir()
+	secretPath := filepath.Join(dir, "secret")
+	if err := os.WriteFile(secretPath, []byte("file-secret"), 0644); err != nil {
+		t.Fatalf("failed to write secret file: %v", err)
+	}
+
+	a := &agent{
+		secretsMap:        make(map[string]secretReloader),
+		expiringTokens:    make(map[string]time.Time),
+		ReloadingCensorer: secretutil.NewCensorer(),
+	}
+	if err := a.Add(secretPath); err != nil {
+		t.Fatalf("Add failed: %v", err)
+	}
+	a.addExpiringToken("expiring-token", time.Date(2099, 1, 1, 0, 0, 0, 0, time.UTC))
+
+	secrets := a.getSecrets()
+	if !secrets.Has("file-secret") {
+		t.Errorf("getSecrets() missing file-based secret")
+	}
+	if !secrets.Has("expiring-token") {
+		t.Errorf("getSecrets() missing expiring token")
+	}
+}
+
 func TestCensoringFormatter(t *testing.T) {
 	var err error
 	secret1, err := os.CreateTemp("", "")


### PR DESCRIPTION
Followup to #696. Addresses three gaps in the expiring token support added to the secret agent:

- `Start` now resets `expiringTokens` alongside `secretsMap` and `ReloadingCensorer`, preventing stale entries from surviving a restart
- `getSecrets()` now includes expiring token values, so the legacy `CensoringFormatter` path censors them too
- Added end-to-end test verifying the censorer actually redacts active tokens and stops redacting expired ones

Proposed and assisted by Claude Code