### PR TITLE
log more info about failing webhooks

### DIFF
--- a/pkg/github/hmac.go
+++ b/pkg/github/hmac.go
@@ -39,20 +39,20 @@ type HMACToken struct {
 type HMACsForRepo []HMACToken
 
 // ValidatePayload ensures that the request payload signature matches the key.
-func ValidatePayload(payload []byte, sig string, tokenGenerator func() []byte) bool {
+func ValidatePayload(payload []byte, sig string, tokenGenerator func() []byte) (bool, string) {
 	var event GenericEvent
 	if err := json.Unmarshal(payload, &event); err != nil {
 		logrus.WithError(err).Info("validatePayload couldn't unmarshal the github event payload")
-		return false
+		return false, "invalid payload"
 	}
 
 	if !strings.HasPrefix(sig, "sha256=") {
-		return false
+		return false, "invalid signature"
 	}
 	sig = sig[7:]
 	sb, err := hex.DecodeString(sig)
 	if err != nil {
-		return false
+		return false, "invalid signature"
 	}
 
 	orgRepo := event.Repo.FullName
@@ -63,7 +63,7 @@ func ValidatePayload(payload []byte, sig string, tokenGenerator func() []byte) b
 	hmacs, err := extractHMACs(orgRepo, tokenGenerator)
 	if err != nil {
 		logrus.WithError(err).Warning("failed to get an appropriate hmac secret")
-		return false
+		return false, "failed to get an appropriate hmac secret"
 	}
 
 	// If we have a match with any valid hmac, we can validate successfully.
@@ -72,10 +72,10 @@ func ValidatePayload(payload []byte, sig string, tokenGenerator func() []byte) b
 		mac.Write(payload)
 		expected := mac.Sum(nil)
 		if hmac.Equal(sb, expected) {
-			return true
+			return true, ""
 		}
 	}
-	return false
+	return false, "misconfigured webhook secret from organization/repo: " + orgRepo
 }
 
 // PayloadSignature returns the signature that matches the payload.

--- a/pkg/github/hmac_test.go
+++ b/pkg/github/hmac_test.go
@@ -95,9 +95,9 @@ func TestValidatePayload(t *testing.T) {
 		},
 	}
 	for _, tc := range testcases {
-		res := ValidatePayload([]byte(tc.payload), tc.sig, tc.tokenGenerator)
-		if res != tc.valid {
-			t.Errorf("Wrong validation for the test %q: expected %t but got %t", tc.name, tc.valid, res)
+		valid, msg := ValidatePayload([]byte(tc.payload), tc.sig, tc.tokenGenerator)
+		if valid != tc.valid {
+			t.Errorf("Wrong validation for the test %q: expected %t but got %t, message: %s", tc.name, tc.valid, valid, msg)
 		}
 	}
 }

--- a/pkg/github/types.go
+++ b/pkg/github/types.go
@@ -211,7 +211,7 @@ const (
 
 // GenericEvent is a lightweight struct containing just Sender, Organization and Repo as
 // they are allWebhook payload object common properties:
-// https://developer.github.com/webhooks/event-payloads/#webhook-payload-object-common-properties
+// https://docs.github.com/en/webhooks/webhook-events-and-payloads#webhook-payload-object-common-properties
 type GenericEvent struct {
 	Sender User         `json:"sender"`
 	Org    Organization `json:"organization"`

--- a/pkg/github/webhooks.go
+++ b/pkg/github/webhooks.go
@@ -62,8 +62,9 @@ func ValidateWebhook(w http.ResponseWriter, r *http.Request, tokenGenerator func
 		return "", "", nil, false, http.StatusInternalServerError
 	}
 	// Validate the payload with our HMAC secret.
-	if !ValidatePayload(payload, sig, tokenGenerator) {
-		responseHTTPError(w, http.StatusForbidden, "403 Forbidden: Invalid X-Hub-Signature-256")
+	valid, message := ValidatePayload(payload, sig, tokenGenerator)
+	if !valid {
+		responseHTTPError(w, http.StatusForbidden, "403 Forbidden: Invalid X-Hub-Signature-256 - "+message)
 		return "", "", nil, false, http.StatusForbidden
 	}
 


### PR DESCRIPTION
The prow instance used by kubernetes is receiving webhooks with a misconfigured secret.

This change will tell us exactly where the bad webhook event is coming from.

before: `403 Forbidden: Invalid X-Hub-Signature-256`

after: `403 Forbidden: Invalid X-Hub-Signature-256 - misconfigured webhook secret from organization/repo: foobar/foobar`

Also, other errors should have more verbose details