### PR TITLE
fix a bug with cla and github apps auth

### DIFF
--- a/pkg/plugins/cla/cla.go
+++ b/pkg/plugins/cla/cla.go
@@ -66,7 +66,7 @@ type gitHubClient interface {
 	AddLabel(owner, repo string, number int, label string) error
 	RemoveLabel(owner, repo string, number int, label string) error
 	GetPullRequest(owner, repo string, number int) (*github.PullRequest, error)
-	FindIssues(query, sort string, asc bool) ([]github.Issue, error)
+	FindIssuesWithOrg(org, query, sort string, asc bool) ([]github.Issue, error)
 	GetIssueLabels(org, repo string, number int) ([]github.Label, error)
 	GetCombinedStatus(org, repo, ref string) (*github.CombinedStatus, error)
 }
@@ -102,7 +102,7 @@ func handle(gc gitHubClient, log *logrus.Entry, se github.StatusEvent) error {
 	var issues []github.Issue
 	var err error
 	for range maxRetries {
-		issues, err = gc.FindIssues(fmt.Sprintf("%s repo:%s/%s type:pr state:open", se.SHA, org, repo), "", false)
+		issues, err = gc.FindIssuesWithOrg(org, fmt.Sprintf("%s repo:%s/%s type:pr state:open", se.SHA, org, repo), "", false)
 		if err != nil {
 			return fmt.Errorf("error searching for issues matching commit: %w", err)
 		}


### PR DESCRIPTION
THIS IS AN URGENT BUG, it's blocking prow from adding the cla labels

```
Get "http://ghproxy/search/issues?per_page=100&q=c846312a1b033c30be0e799f8363376b8ab5a211+repo%3Akubernetes-sigs%2Fgateway-api+type%3Apr+state%3Aopen": BUG apps auth requested but empty org, please report this to the test-infra repo. Stack: goroutine 60346 [running]:
runtime/debug.Stack()
	runtime/debug/stack.go:26 +0x5e
sigs.k8s.io/prow/pkg/github.(*appsRoundTripper).addAppInstallationAuth(0xc001c0e0a0, 0xc009554f00)
	sigs.k8s.io/prow/pkg/github/app_auth_roundtripper.go:156 +0x9b
sigs.k8s.io/prow/pkg/github.(*appsRoundTripper).RoundTrip(0xc001c0e0a0, 0xc009554f00)
	sigs.k8s.io/prow/pkg/github/app_auth_roundtripper.go:101 +0x13e
net/http.send(0xc009554dc0, {0x3fea8e0, 0xc001c0e0a0}, {0xc0139d9001?, 0x4ef4b3?, 0x61cf1c0?})
	net/http/client.go:259 +0x5e2
net/http.(*Client).send(0xc009c76db0, 0xc009554dc0, {0xc014049770?, 0x4?, 0x61cf1c0?})
	net/http/client.go:180 +0x91
net/http.(*Client).do(0xc009c76db0, 0xc009554dc0)
	net/http/client.go:729 +0x9c9
net/http.(*Client).Do(0xc009c76ed0?, 0x4037d78?)
	net/http/client.go:587 +0x13
sigs.k8s.io/prow/pkg/github.(*ghThrottler).Do(0xc0049f99d0, 0xc009554dc0)
	sigs.k8s.io/prow/pkg/github/client.go:445 +0x10c
sigs.k8s.io/prow/pkg/github.(*client).doRequest(0xc01406a7c0, {0x4037d78?, 0x61f3f40?}, {0x397d6df?, 0x0?}, {0xc008b46240?, 0x0?}, {0x0, 0x0}, {0x0, ...}, ...)
	sigs.k8s.io/prow/pkg/github/client.go:1164 +0x9cd
sigs.k8s.io/prow/pkg/github.(*client).requestRetryWithContext(0xc01406a7c0, {0x4037d78, 0x61f3f40}, {0x397d6df, 0x3}, {0xc008b46120, 0x82}, {0x0, 0x0}, {0x0, ...}, ...)
	sigs.k8s.io/prow/pkg/github/client.go:1013 +0x245
sigs.k8s.io/prow/pkg/github.(*client).readPaginatedResultsWithValuesWithContext(0xc01406a7c0, {0x4037d78, 0x61f3f40}, {0x399318b?, 0xe?}, 0x1?, {0x0, 0x0}, {0x0, 0x0}, ...)
	sigs.k8s.io/prow/pkg/github/client.go:1998 +0x185
sigs.k8s.io/prow/pkg/github.(*client).readPaginatedResultsWithValues(...)
	sigs.k8s.io/prow/pkg/github/client.go:1989
sigs.k8s.io/prow/pkg/github.(*client).FindIssuesWithOrg(0xc01406a7c0, {0x0, 0x0}, {0xc00a304540, 0x5c}, {0x0, 0x0}, 0x0)
	sigs.k8s.io/prow/pkg/github/client.go:3651 +0x48d
sigs.k8s.io/prow/pkg/github.(*client).FindIssues(0xc0139db5e8?, {0xc00a304540?, 0x3?}, {0x0?, 0xc00a304540?}, 0xb0?)
	sigs.k8s.io/prow/pkg/github/client.go:3620 +0x30
sigs.k8s.io/prow/pkg/plugins/cla.handle({_, _}, _, {{0xc014140a20, 0x28}, {0xc008ab0ed7, 0x7}, {0xc00d066640, 0x37}, {0xc00d066600, ...}, ...})
	sigs.k8s.io/prow/pkg/plugins/cla/cla.go:105 +0x2b3
sigs.k8s.io/prow/pkg/plugins/cla.handleStatusEvent({{0x40a0900, 0xc013a083a0}, {0x4053c80, 0xc009c445a0}, {0x4088c78, 0xc009c7f180}, 0xc009d3bf50, {0x4038518, 0xc005bc6e70}, 0xc009d42ac0, ...}, ...)
	sigs.k8s.io/prow/pkg/plugins/cla/cla.go:75 +0x85
sigs.k8s.io/prow/pkg/hook.(*Server).handleStatusEvent.func1.1()
	sigs.k8s.io/prow/pkg/hook/events.go:346 +0x7f
sigs.k8s.io/prow/pkg/hook.errorOnPanic(0x40a0900?)
	sigs.k8s.io/prow/pkg/hook/events.go:386 +0x51
sigs.k8s.io/prow/pkg/hook.(*Server).handleStatusEvent.func1({0xc010fef9c9, 0x3}, 0x3b22f88)
	sigs.k8s.io/prow/pkg/hook/events.go:346 +0x17c
created by sigs.k8s.io/prow/pkg/hook.(*Server).handleStatusEvent in goroutine 60344
	sigs.k8s.io/prow/pkg/hook/events.go:342 +0x586

```


