### PR TITLE
handle github teams lookup correctly with github apps

### DIFF
--- a/pkg/github/app_auth_roundtripper.go
+++ b/pkg/github/app_auth_roundtripper.go
@@ -153,7 +153,7 @@ func extractOrgFromContext(ctx context.Context) string {
 func (arr *appsRoundTripper) addAppInstallationAuth(r *http.Request) *appsAuthError {
 	org := extractOrgFromContext(r.Context())
 	if org == "" {
-		return &appsAuthError{fmt.Errorf("BUG apps auth requested but empty org, please report this to the test-infra repo. Stack: %s", string(debug.Stack()))}
+		return &appsAuthError{fmt.Errorf("BUG apps auth requested but empty org, please report this to the kubernetes-sigs/prow repo. Stack: %s", string(debug.Stack()))}
 	}
 
 	token, expiresAt, err := arr.installationTokenFor(org)

--- a/pkg/github/client.go
+++ b/pkg/github/client.go
@@ -211,7 +211,7 @@ type TeamClient interface {
 	ListTeams(org string) ([]Team, error)
 	UpdateTeamMembershipBySlug(org, teamSlug, user string, maintainer bool) (*TeamMembership, error)
 	RemoveTeamMembershipBySlug(org, teamSlug, user string) error
-	ListTeamMembers(org string, id int, role string) ([]TeamMember, error)
+	ListTeamMembersByID(org string, id int, role string) ([]TeamMember, error)
 	ListTeamMembersBySlug(org, teamSlug, role string) ([]TeamMember, error)
 	ListTeamReposBySlug(org, teamSlug string) ([]Repo, error)
 	UpdateTeamRepoBySlug(org, teamSlug, repo string, permission TeamPermission) error
@@ -3893,22 +3893,20 @@ func (c *client) RemoveTeamMembershipBySlug(org, teamSlug, user string) error {
 	return err
 }
 
-// ListTeamMembers gets a list of team members for the given team id
+// ListTeamMembersByID gets a list of team members for the given team id
 //
 // Role options are "all", "maintainer" and "member"
 //
 // https://developer.github.com/v3/teams/members/#list-team-members
-// Deprecated: please use ListTeamMembersBySlug
-func (c *client) ListTeamMembers(org string, id int, role string) ([]TeamMember, error) {
-	c.logger.WithField("methodName", "ListTeamMembers").
-		Warn("method is deprecated, please use ListTeamMembersBySlug")
-	durationLogger := c.log("ListTeamMembers", id, role)
+// Note: the API accepts both team_id and team_slug, but not fully documented
+func (c *client) ListTeamMembersByID(org string, id int, role string) ([]TeamMember, error) {
+	durationLogger := c.log("ListTeamMembersByID", id, role)
 	defer durationLogger()
 
 	if c.fake {
 		return nil, nil
 	}
-	path := fmt.Sprintf("/teams/%d/members", id)
+	path := fmt.Sprintf("/orgs/%s/team/%d/members", org, id)
 	var teamMembers []TeamMember
 	err := c.readPaginatedResultsWithValues(
 		path,
@@ -4972,7 +4970,7 @@ func (c *client) TeamHasMember(org string, teamID int, memberLogin string) (bool
 	durationLogger := c.log("TeamHasMember", teamID, memberLogin)
 	defer durationLogger()
 
-	projectMaintainers, err := c.ListTeamMembers(org, teamID, RoleAll)
+	projectMaintainers, err := c.ListTeamMembersByID(org, teamID, RoleAll)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/github/client_test.go
+++ b/pkg/github/client_test.go
@@ -2255,11 +2255,11 @@ func TestEditTeam(t *testing.T) {
 	}
 }
 
-func TestListTeamMembers(t *testing.T) {
-	ts := simpleTestServer(t, "/teams/1/members", []TeamMember{{Login: "foo"}}, http.StatusOK)
+func TestListTeamMembersByID(t *testing.T) {
+	ts := simpleTestServer(t, "/orgs/orgName/team/1/members", []TeamMember{{Login: "foo"}}, http.StatusOK)
 	defer ts.Close()
 	c := getClient(ts.URL)
-	teamMembers, err := c.ListTeamMembers("orgName", 1, RoleAll)
+	teamMembers, err := c.ListTeamMembersByID("orgName", 1, RoleAll)
 	if err != nil {
 		t.Errorf("Didn't expect error: %v", err)
 	} else if len(teamMembers) != 1 {
@@ -3836,7 +3836,6 @@ func TestCollaboratorMethodsDryRun(t *testing.T) {
 		t.Errorf("Expected 0 API calls in dry-run mode, but got %d", callCount)
 	}
 }
-
 
 func TestGetPendingApprovalActionRuns(t *testing.T) {
 	const (

--- a/pkg/github/fakegithub/fakegithub.go
+++ b/pkg/github/fakegithub/fakegithub.go
@@ -738,8 +738,8 @@ func (f *FakeClient) ListTeams(org string) ([]github.Team, error) {
 	}, nil
 }
 
-// ListTeamMembers return a fake team with a single "sig-lead" GitHub teammember
-func (f *FakeClient) ListTeamMembers(org string, teamID int, role string) ([]github.TeamMember, error) {
+// ListTeamMembersbyID return a fake team with a single "sig-lead" GitHub teammember
+func (f *FakeClient) ListTeamMembersByID(org string, teamID int, role string) ([]github.TeamMember, error) {
 	f.lock.RLock()
 	defer f.lock.RUnlock()
 	if role != github.RoleAll {
@@ -1176,7 +1176,7 @@ func (f *FakeClient) MoveProjectCard(org string, projectCardID int, newColumnID 
 
 // TeamHasMember checks if a user belongs to a team
 func (f *FakeClient) TeamHasMember(org string, teamID int, memberLogin string) (bool, error) {
-	teamMembers, _ := f.ListTeamMembers(org, teamID, github.RoleAll)
+	teamMembers, _ := f.ListTeamMembersByID(org, teamID, github.RoleAll)
 	for _, member := range teamMembers {
 		if member.Login == memberLogin {
 			return true, nil

--- a/pkg/plugins/milestone/milestone.go
+++ b/pkg/plugins/milestone/milestone.go
@@ -46,7 +46,7 @@ type githubClient interface {
 	CreateComment(owner, repo string, number int, comment string) error
 	ClearMilestone(org, repo string, num int) error
 	SetMilestone(org, repo string, issueNum, milestoneNum int) error
-	ListTeamMembers(org string, id int, role string) ([]github.TeamMember, error)
+	ListTeamMembersByID(org string, id int, role string) ([]github.TeamMember, error)
 	ListTeamMembersBySlug(org, teamSlug, role string) ([]github.TeamMember, error)
 	ListMilestones(org, repo string) ([]github.Milestone, error)
 }
@@ -170,5 +170,5 @@ func determineMaintainers(gc githubClient, milestone plugins.Milestone, org stri
 	if milestone.MaintainersTeam != "" {
 		return gc.ListTeamMembersBySlug(org, milestone.MaintainersTeam, github.RoleAll)
 	}
-	return gc.ListTeamMembers(org, milestone.MaintainersID, github.RoleAll)
+	return gc.ListTeamMembersByID(org, milestone.MaintainersID, github.RoleAll)
 }

--- a/pkg/plugins/milestonestatus/milestonestatus.go
+++ b/pkg/plugins/milestonestatus/milestonestatus.go
@@ -47,7 +47,7 @@ var (
 type githubClient interface {
 	CreateComment(owner, repo string, number int, comment string) error
 	AddLabel(owner, repo string, number int, label string) error
-	ListTeamMembers(org string, id int, role string) ([]github.TeamMember, error)
+	ListTeamMembersByID(org string, id int, role string) ([]github.TeamMember, error)
 	ListTeamMembersBySlug(org, teamSlug, role string) ([]github.TeamMember, error)
 }
 
@@ -141,5 +141,5 @@ func determineMaintainers(gc githubClient, milestone plugins.Milestone, org stri
 	if milestone.MaintainersTeam != "" {
 		return gc.ListTeamMembersBySlug(org, milestone.MaintainersTeam, github.RoleAll)
 	}
-	return gc.ListTeamMembers(org, milestone.MaintainersID, github.RoleAll)
+	return gc.ListTeamMembersByID(org, milestone.MaintainersID, github.RoleAll)
 }

--- a/pkg/plugins/project/project.go
+++ b/pkg/plugins/project/project.go
@@ -56,7 +56,7 @@ var (
 type githubClient interface {
 	BotUserChecker() (func(candidate string) bool, error)
 	CreateComment(owner, repo string, number int, comment string) error
-	ListTeamMembers(org string, id int, role string) ([]github.TeamMember, error)
+	ListTeamMembersByID(org string, id int, role string) ([]github.TeamMember, error)
 	GetRepos(org string, isUser bool) ([]github.Repo, error)
 	GetRepoProjects(owner, repo string) ([]github.Project, error)
 	GetOrgProjects(org string) ([]github.Project, error)

--- a/site/content/en/docs/components/cli-tools/peribolos.md
+++ b/site/content/en/docs/components/cli-tools/peribolos.md
@@ -2,7 +2,6 @@
 title: "Peribolos"
 weight: 10
 description: >
-  
 ---
 
 Peribolos allows the org settings, teams and memberships to be declared in a yaml file. GitHub is then updated to match the declared configuration.
@@ -65,19 +64,19 @@ orgs:
 
 This config will:
 
-* Ensure the org settings match the following:
-  * Set the company, email, name and descriptions fields for the org to foo
-  * Allow projects to be created at the org and repo levels
-  * Give everyone read access to repos by default
-  * Disallow members from creating repositories
-* Ensure the following memberships exist:
-  * anne and bob are members, carl is an admin
-* Configure the node and another-team in the following manner:
-  * Set node's description and privacy setting.
-  * Rename the backend team to node
-  * Add anne as a member and jane as a maintainer to node
-  * Similar things for another-team (details elided)
-* Ensure that the team has admin rights to `some-repo`, read access to `other-repo` and no other privileges
+- Ensure the org settings match the following:
+  - Set the company, email, name and descriptions fields for the org to foo
+  - Allow projects to be created at the org and repo levels
+  - Give everyone read access to repos by default
+  - Disallow members from creating repositories
+- Ensure the following memberships exist:
+  - anne and bob are members, carl is an admin
+- Configure the node and another-team in the following manner:
+  - Set node's description and privacy setting.
+  - Rename the backend team to node
+  - Add anne as a member and jane as a maintainer to node
+  - Similar things for another-team (details elided)
+- Ensure that the team has admin rights to `some-repo`, read access to `other-repo` and no other privileges
 
 Note that any fields missing from the config will not be managed by peribolos. So if description is missing from the org setting, the current value will remain.
 
@@ -96,8 +95,8 @@ INFO: Build completed successfully, 1 total action
 {"client":"github","component":"peribolos","level":"info","msg":"ListOrgMembers(kubernetes-sigs, admin)","time":"2018-09-28T13:17:42-07:00"}
 {"client":"github","component":"peribolos","level":"info","msg":"ListOrgMembers(kubernetes-sigs, member)","time":"2018-09-28T13:17:43-07:00"}
 {"client":"github","component":"peribolos","level":"info","msg":"ListTeams(kubernetes-sigs)","time":"2018-09-28T13:17:45-07:00"}
-{"client":"github","component":"peribolos","level":"info","msg":"ListTeamMembers(2671356, maintainer)","time":"2018-09-28T13:17:46-07:00"}
-{"client":"github","component":"peribolos","level":"info","msg":"ListTeamMembers(2671356, member)","time":"2018-09-28T13:17:46-07:00"}
+{"client":"github","component":"peribolos","level":"info","msg":"ListTeamMembersByID(2671356, maintainer)","time":"2018-09-28T13:17:46-07:00"}
+{"client":"github","component":"peribolos","level":"info","msg":"ListTeamMembersByID(2671356, member)","time":"2018-09-28T13:17:46-07:00"}
 ...
 admins:
 - calebamiles
@@ -152,17 +151,17 @@ $ go run ./cmd/peribolos --config-path ~/current.yaml --github-token-path ~/gith
 
 In order to mitigate the chance of applying erroneous configs, the peribolos binary includes a few safety checks:
 
-* `--required-admins=` - a list of people who must be configured as admins in order to accept the config (defaults to empty list)
-* `--min-admins=5` - the config must specify at least this many admins
-* `--require-self=true` - require the bot applying the config to be an admin.
+- `--required-admins=` - a list of people who must be configured as admins in order to accept the config (defaults to empty list)
+- `--min-admins=5` - the config must specify at least this many admins
+- `--require-self=true` - require the bot applying the config to be an admin.
 
 These flags are designed to ensure that any problems can be corrected by rerunning the tool with a fixed config and/or binary.
 
-* `--maximum-removal-delta=0.25` - reject a config that deletes more than 25% of the current memberships.
+- `--maximum-removal-delta=0.25` - reject a config that deletes more than 25% of the current memberships.
 
 This flag is designed to protect against typos in the configuration which might cause massive, unwanted deletions. Raising this value to 1.0 will allow deleting everyone, and reducing it to 0.0 will prevent any deletions.
 
-* `--confirm=false` - no github mutations will be made until this flag is true. It is safe to run the binary without this flag. It will print what it would do, without actually making any changes.
+- `--confirm=false` - no github mutations will be made until this flag is true. It is safe to run the binary without this flag. It will print what it would do, without actually making any changes.
 
 See `go run ./cmd/peribolos --help` for the full and current list of settings that can be configured with flags.
 


### PR DESCRIPTION
```
Get "http://ghproxy/teams/2009231/members?per_page=100&role=all": BUG apps auth requested but empty org, please report this to the test-infra repo. Stack: goroutine 2267973 [running]:
runtime/debug.Stack()
	runtime/debug/stack.go:26 +0x5e
sigs.k8s.io/prow/pkg/github.(*appsRoundTripper).addAppInstallationAuth(0xc01e7439a0, 0xc05687e280)
	sigs.k8s.io/prow/pkg/github/app_auth_roundtripper.go:156 +0x9b
sigs.k8s.io/prow/pkg/github.(*appsRoundTripper).RoundTrip(0xc01e7439a0, 0xc05687e280)
	sigs.k8s.io/prow/pkg/github/app_auth_roundtripper.go:101 +0x13e
net/http.send(0xc05687e000, {0x3e8aa80, 0xc01e7439a0}, {0x1?, 0x0?, 0x5f8c9a0?})
	net/http/client.go:259 +0x5e2
net/http.(*Client).send(0xc0297e9170, 0xc05687e000, {0xc00e44df50?, 0x4?, 0x5f8c9a0?})
	net/http/client.go:180 +0x91
net/http.(*Client).do(0xc0297e9170, 0xc05687e000)
	net/http/client.go:729 +0x9c9
net/http.(*Client).Do(0xc0297e9290?, 0x3ed72b8?)
	net/http/client.go:587 +0x13
sigs.k8s.io/prow/pkg/github.(*ghThrottler).Do(0xc01d352d70, 0xc05687e000)
	sigs.k8s.io/prow/pkg/github/client.go:445 +0x10c
sigs.k8s.io/prow/pkg/github.(*client).doRequest(0xc01e0d3500, {0x3ed72b8?, 0x5fafc80?}, {0x3861464?, 0xc044127710?}, {0xc0737e5e40?, 0xc044127680?}, {0x389f468, 0x1b}, {0x0, ...}, ...)
	sigs.k8s.io/prow/pkg/github/client.go:1164 +0x9cd
sigs.k8s.io/prow/pkg/github.(*client).requestRetryWithContext(0xc01e0d3500, {0x3ed72b8, 0x5fafc80}, {0x3861464, 0x3}, {0xc02c1e8c30, 0x2c}, {0x389f468, 0x1b}, {0x0, ...}, ...)
	sigs.k8s.io/prow/pkg/github/client.go:1013 +0x245
sigs.k8s.io/prow/pkg/github.(*client).readPaginatedResultsWithValuesWithContext(0xc01e0d3500, {0x3ed72b8, 0x5fafc80}, {0xc013e09bc0?, 0x16?}, 0xf5?, {0x389f468, 0x1b}, {0x0, 0x0}, ...)
	sigs.k8s.io/prow/pkg/github/client.go:1998 +0x185
sigs.k8s.io/prow/pkg/github.(*client).readPaginatedResultsWithValues(...)
	sigs.k8s.io/prow/pkg/github/client.go:1989
sigs.k8s.io/prow/pkg/github.(*client).ListTeamMembers(0xc01e0d3500, {0x0, 0x0}, 0x1ea88f, {0x38615ab, 0x3})
	sigs.k8s.io/prow/pkg/github/client.go:3913 +0x4f3
sigs.k8s.io/prow/pkg/github.(*client).TeamHasMember(0xc01e0d3500, {0x0, 0x0}, 0x1ea88f, {0xc01b90b4b8, 0x8})
	sigs.k8s.io/prow/pkg/github/client.go:4975 +0x117
sigs.k8s.io/prow/pkg/apis/prowjobs/v1.(*RerunAuthConfig).IsAuthorized(0xc0050cdd50, {0x0, 0x0}, {0xc01b90b4b8, 0x8}, {0x7d7f44bd3310, 0xc01e0d3500})
	sigs.k8s.io/prow/pkg/apis/prowjobs/v1/types.go:314 +0x36d
main.canTriggerJob({_, _}, {{{0x386627e, 0x7}, {0x3875cb2, 0xe}}, {{0xc03176aae0, 0x24}, {0x0, 0x0}, ...}, ...}, ...)
	sigs.k8s.io/prow/cmd/deck/rerun.go:175 +0xef
main.isAllowedToRerun(_, _, _, {_, _}, {{{0x386627e, 0x7}, {0x3875cb2, 0xe}}, {{0xc03176aae0, ...}, ...}, ...}, ...)
	sigs.k8s.io/prow/cmd/deck/rerun.go:228 +0x2cb
main.prodOnlyMain.handleRerun.func14({0x3ec17d0, 0xc05a55f340}, 0xc072f03b80)
	sigs.k8s.io/prow/cmd/deck/rerun.go:305 +0x717
net/http.HandlerFunc.ServeHTTP(0xc01816c8e0?, {0x3ec17d0?, 0xc05a55f340?}, 0x4?)
	net/http/server.go:2322 +0x29
github.com/NYTimes/gziphandler.GzipHandlerWithOpts.func1.1({0x3ec0840, 0xc0489de640}, 0xc072f03b80)
	github.com/NYTimes/gziphandlergzip.go:338 +0x2a2
net/http.HandlerFunc.ServeHTTP(0xc000872840?, {0x3ec0840?, 0xc0489de640?}, 0xc04bbe38c0?)
	net/http/server.go:2322 +0x29
net/http.(*ServeMux).ServeHTTP(0x7d7f48badfe0?, {0x3ec0840, 0xc0489de640}, 0xc072f03b80)
	net/http/server.go:2861 +0x1c7
main.init.TraceHandler.traceHandlerWithCustomTimer.func1.1({0x3ec0ca0, 0xc0678565a0}, 0xc072f03b80)
	sigs.k8s.io/prow/pkg/metrics/http.go:143 +0xfb
net/http.HandlerFunc.ServeHTTP(0x0?, {0x3ec0ca0?, 0xc0678565a0?}, 0x4?)
	net/http/server.go:2322 +0x29
github.com/gorilla/csrf.(*csrf).ServeHTTP(0xc02042e000, {0x3ec0ca0, 0xc0678565a0}, 0xc072f037c0)
	github.com/gorilla/csrfcsrf.go:358 +0xb26
net/http.serverHandler.ServeHTTP({0xc056a19200?}, {0x3ec0ca0?, 0xc0678565a0?}, 0x6?)
	net/http/server.go:3340 +0x8e
net/http.(*conn).serve(0xc039a0f0e0, {0x3ed74b8, 0xc012650c60})
	net/http/server.go:2109 +0x665
created by net/http.(*Server).Serve in goroutine 182
	net/http/server.go:3493 +0x485
```

instead of doing `gh api teams/2009231/members`, you need to do `gh api orgs/kubernetes-sigs/team/2009231/members`

https://docs.github.com/en/rest/teams/members?apiVersion=2026-03-10#list-pending-team-invitations