### PR TITLE
Add Git ref mutation methods to GitHub client

### DIFF
--- a/pkg/github/client.go
+++ b/pkg/github/client.go
@@ -156,6 +156,11 @@ type CommitClient interface {
 	GetCombinedStatus(org, repo, ref string) (*CombinedStatus, error)
 	ListCheckRuns(org, repo, ref string) (*CheckRunList, error)
 	GetRef(org, repo, ref string) (string, error)
+	GetRefWithContext(ctx context.Context, org, repo, ref string) (string, error)
+	CreateRef(org, repo, ref, sha string) error
+	CreateRefWithContext(ctx context.Context, org, repo, ref, sha string) error
+	UpdateRef(org, repo, ref, sha string, force bool) error
+	UpdateRefWithContext(ctx context.Context, org, repo, ref, sha string, force bool) error
 	DeleteRef(org, repo, ref string) error
 	ListFileCommits(org, repo, path string) ([]RepositoryCommit, error)
 	CreateCheckRun(org, repo string, checkRun CheckRun) (int64, error)
@@ -881,6 +886,21 @@ func IsNotFound(err error) bool {
 		}
 	}
 	return false
+}
+
+// IsUnprocessableEntity reports whether GitHub rejected a semantically invalid
+// request, such as a non-fast-forward ref update.
+func IsUnprocessableEntity(err error) bool {
+	if err == nil {
+		return false
+	}
+	var requestErr requestError
+	return errors.As(err, &requestErr) && requestErr.StatusCode == http.StatusUnprocessableEntity
+}
+
+// NewUnprocessableEntity returns an unprocessable-entity error for tests.
+func NewUnprocessableEntity() error {
+	return requestError{StatusCode: http.StatusUnprocessableEntity}
 }
 
 // NewForbidden returns a forbiddenError which may be useful for tests
@@ -3398,11 +3418,16 @@ func (c *client) ReopenPullRequest(org, repo string, number int) error {
 // The gitbub api does prefix matching and might return multiple results,
 // in which case we will return a GetRefTooManyResultsError
 func (c *client) GetRef(org, repo, ref string) (string, error) {
+	return c.GetRefWithContext(context.Background(), org, repo, ref)
+}
+
+// GetRefWithContext returns the SHA of the given ref, such as "heads/master".
+func (c *client) GetRefWithContext(ctx context.Context, org, repo, ref string) (string, error) {
 	durationLogger := c.log("GetRef", org, repo, ref)
 	defer durationLogger()
 
 	res := GetRefResponse{}
-	_, err := c.request(&request{
+	_, err := c.requestWithContext(ctx, &request{
 		method:    http.MethodGet,
 		path:      fmt.Sprintf("/repos/%s/%s/git/refs/%s", org, repo, ref),
 		org:       org,
@@ -3422,6 +3447,53 @@ func (c *client) GetRef(org, repo, ref string) (string, error) {
 		return "", GetRefTooManyResultsError{org: org, repo: repo, ref: ref, resultsRefs: res.RefNames()}
 	}
 	return res[0].Object.SHA, nil
+}
+
+// CreateRef creates a ref at the given SHA. The ref must include its namespace,
+// for example "refs/heads/my-branch".
+func (c *client) CreateRef(org, repo, ref, sha string) error {
+	return c.CreateRefWithContext(context.Background(), org, repo, ref, sha)
+}
+
+// CreateRefWithContext creates a ref at the given SHA.
+func (c *client) CreateRefWithContext(ctx context.Context, org, repo, ref, sha string) error {
+	durationLogger := c.log("CreateRef", org, repo, ref, sha)
+	defer durationLogger()
+
+	_, err := c.requestWithContext(ctx, &request{
+		method: http.MethodPost,
+		path:   fmt.Sprintf("/repos/%s/%s/git/refs", org, repo),
+		org:    org,
+		requestBody: map[string]string{
+			"ref": ref,
+			"sha": sha,
+		},
+		exitCodes: []int{http.StatusCreated},
+	}, nil)
+	return err
+}
+
+// UpdateRef updates a ref to the given SHA.
+func (c *client) UpdateRef(org, repo, ref, sha string, force bool) error {
+	return c.UpdateRefWithContext(context.Background(), org, repo, ref, sha, force)
+}
+
+// UpdateRefWithContext updates a ref to the given SHA.
+func (c *client) UpdateRefWithContext(ctx context.Context, org, repo, ref, sha string, force bool) error {
+	durationLogger := c.log("UpdateRef", org, repo, ref, sha, force)
+	defer durationLogger()
+
+	_, err := c.requestWithContext(ctx, &request{
+		method: http.MethodPatch,
+		path:   fmt.Sprintf("/repos/%s/%s/git/refs/%s", org, repo, ref),
+		org:    org,
+		requestBody: map[string]interface{}{
+			"sha":   sha,
+			"force": force,
+		},
+		exitCodes: []int{http.StatusOK},
+	}, nil)
+	return err
 }
 
 type GetRefTooManyResultsError struct {

--- a/pkg/github/client_test.go
+++ b/pkg/github/client_test.go
@@ -652,6 +652,62 @@ func TestDeleteRef(t *testing.T) {
 	}
 }
 
+func TestCreateRef(t *testing.T) {
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("Bad method: %s", r.Method)
+		}
+		if r.URL.Path != "/repos/k8s/kuber/git/refs" {
+			t.Errorf("Bad request path: %s", r.URL.Path)
+		}
+		var body map[string]interface{}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		if diff := cmp.Diff(map[string]interface{}{"ref": "refs/heads/my-feature", "sha": "abcde"}, body); diff != "" {
+			t.Errorf("unexpected request body (-want +got):\n%s", diff)
+		}
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer ts.Close()
+	if err := getClient(ts.URL).CreateRef("k8s", "kuber", "refs/heads/my-feature", "abcde"); err != nil {
+		t.Fatalf("CreateRef: %v", err)
+	}
+}
+
+func TestUpdateRef(t *testing.T) {
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPatch {
+			t.Errorf("Bad method: %s", r.Method)
+		}
+		if r.URL.Path != "/repos/k8s/kuber/git/refs/heads/my-feature" {
+			t.Errorf("Bad request path: %s", r.URL.Path)
+		}
+		var body map[string]interface{}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		if diff := cmp.Diff(map[string]interface{}{"force": false, "sha": "abcde"}, body); diff != "" {
+			t.Errorf("unexpected request body (-want +got):\n%s", diff)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+	if err := getClient(ts.URL).UpdateRef("k8s", "kuber", "heads/my-feature", "abcde", false); err != nil {
+		t.Fatalf("UpdateRef: %v", err)
+	}
+}
+
+func TestIsUnprocessableEntity(t *testing.T) {
+	err := requestError{StatusCode: http.StatusUnprocessableEntity}
+	if !IsUnprocessableEntity(fmt.Errorf("wrapped: %w", err)) {
+		t.Fatal("expected wrapped 422 error to be recognized")
+	}
+	if IsUnprocessableEntity(requestError{StatusCode: http.StatusBadRequest}) {
+		t.Fatal("did not expect 400 error to be recognized as 422")
+	}
+}
+
 func TestListFileCommits(t *testing.T) {
 	githubResponse := []byte(`
 [

--- a/pkg/github/fakegithub/fakegithub.go
+++ b/pkg/github/fakegithub/fakegithub.go
@@ -104,6 +104,11 @@ type FakeClient struct {
 	RemoteDirectories map[string]map[string][]github.DirectoryContent
 
 	// A list of refs that got deleted via DeleteRef
+	RefsCreated []struct{ Org, Repo, Ref, SHA string }
+	RefsUpdated []struct {
+		Org, Repo, Ref, SHA string
+		Force               bool
+	}
 	RefsDeleted []struct{ Org, Repo, Ref string }
 
 	// A map of repo names to projects
@@ -495,6 +500,35 @@ func (f *FakeClient) GetPullRequestChanges(org, repo string, number int) ([]gith
 // GetRef returns the hash of a ref.
 func (f *FakeClient) GetRef(owner, repo, ref string) (string, error) {
 	return TestRef, nil
+}
+
+func (f *FakeClient) GetRefWithContext(_ context.Context, owner, repo, ref string) (string, error) {
+	return f.GetRef(owner, repo, ref)
+}
+
+func (f *FakeClient) CreateRef(owner, repo, ref, sha string) error {
+	return f.CreateRefWithContext(context.Background(), owner, repo, ref, sha)
+}
+
+func (f *FakeClient) CreateRefWithContext(_ context.Context, owner, repo, ref, sha string) error {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+	f.RefsCreated = append(f.RefsCreated, struct{ Org, Repo, Ref, SHA string }{owner, repo, ref, sha})
+	return nil
+}
+
+func (f *FakeClient) UpdateRef(owner, repo, ref, sha string, force bool) error {
+	return f.UpdateRefWithContext(context.Background(), owner, repo, ref, sha, force)
+}
+
+func (f *FakeClient) UpdateRefWithContext(_ context.Context, owner, repo, ref, sha string, force bool) error {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+	f.RefsUpdated = append(f.RefsUpdated, struct {
+		Org, Repo, Ref, SHA string
+		Force               bool
+	}{owner, repo, ref, sha, force})
+	return nil
 }
 
 // DeleteRef returns an error indicating if deletion of the given ref was successful


### PR DESCRIPTION
This extends the shared Prow GitHub client with context-aware reference reads, creation, and updates. It routes all operations through the existing authentication, throttling, retry, logging, and request machinery. It exposes unprocessable-entity classification so callers can distinguish rejected ref mutations from transient failures. It updates the fake GitHub client to record created and updated references for downstream tests. Unit tests verify request methods, paths, payloads, force behavior, and error classification.