### PR TITLE
branchprotector: add require_signed_commits config

### DIFF
--- a/cmd/branchprotector/protect.go
+++ b/cmd/branchprotector/protect.go
@@ -84,10 +84,21 @@ func gatherOptions() options {
 }
 
 type requirements struct {
-	Org     string
-	Repo    string
-	Branch  string
+	Org    string
+	Repo   string
+	Branch string
+	// Request is the main branch protection PUT payload.
 	Request *github.BranchProtectionRequest
+	// Separate holds settings managed via dedicated GitHub API endpoints
+	// rather than the main branch protection PUT.
+	Separate *separateRequests
+}
+
+// separateRequests groups branch protection settings that GitHub manages
+// through individual API endpoints (POST/DELETE) rather than the main
+// branch protection PUT body.
+type separateRequests struct {
+	RequireSignedCommits *bool
 }
 
 // Errors holds a list of errors, including a method to concurrently append.
@@ -159,6 +170,8 @@ type client interface {
 	GetBranchProtection(org, repo, branch string) (*github.BranchProtection, error)
 	RemoveBranchProtection(org, repo, branch string) error
 	UpdateBranchProtection(org, repo, branch string, config github.BranchProtectionRequest) error
+	EnableCommitSignProtection(org, repo, branch string) error
+	DisableCommitSignProtection(org, repo, branch string) error
 	GetBranches(org, repo string, onlyProtected bool) ([]github.Branch, error)
 	GetRepo(owner, name string) (github.FullRepo, error)
 	GetRepos(org string, user bool) ([]github.Repo, error)
@@ -191,8 +204,26 @@ func (p *protector) configureBranches() {
 		if err := p.client.UpdateBranchProtection(u.Org, u.Repo, u.Branch, *u.Request); err != nil {
 			p.errors.add(fmt.Errorf("update %s/%s=%s protection to %v failed: %w", u.Org, u.Repo, u.Branch, *u.Request, err))
 		}
+
+		if u.Separate != nil {
+			p.applySeparateRequests(u.Org, u.Repo, u.Branch, u.Separate)
+		}
 	}
 	p.done <- p.errors.errs
+}
+
+func (p *protector) applySeparateRequests(org, repo, branch string, sep *separateRequests) {
+	if sep.RequireSignedCommits != nil {
+		if *sep.RequireSignedCommits {
+			if err := p.client.EnableCommitSignProtection(org, repo, branch); err != nil {
+				p.errors.add(fmt.Errorf("enable %s/%s=%s commit sign protection failed: %w", org, repo, branch, err))
+			}
+		} else {
+			if err := p.client.DisableCommitSignProtection(org, repo, branch); err != nil {
+				p.errors.add(fmt.Errorf("disable %s/%s=%s commit sign protection failed: %w", org, repo, branch, err))
+			}
+		}
+	}
 }
 
 // protect protects branches specified in the presubmit and branch-protection config sections.
@@ -502,16 +533,24 @@ func (p *protector) UpdateBranch(orgName, repo string, branchName string, branch
 		return fmt.Errorf("get current branch protection: %w", err)
 	}
 
-	if equalBranchProtections(currentBP, req) {
+	var sep *separateRequests
+	if bp.RequireSignedCommits != nil {
+		sep = &separateRequests{
+			RequireSignedCommits: bp.RequireSignedCommits,
+		}
+	}
+
+	if equalBranchProtections(currentBP, req) && equalSeparateRequests(currentBP, sep) {
 		logrus.Debugf("%s/%s=%s: current branch protection matches policy, skipping", orgName, repo, branchName)
 		return nil
 	}
 
 	p.updates <- requirements{
-		Org:     orgName,
-		Repo:    repo,
-		Branch:  branchName,
-		Request: req,
+		Org:      orgName,
+		Repo:     repo,
+		Branch:   branchName,
+		Request:  req,
+		Separate: sep,
 	}
 	return nil
 }
@@ -576,6 +615,19 @@ func equalAllowDeletions(state github.AllowDeletions, request bool) bool {
 
 func equalAllowForcePushes(state github.AllowForcePushes, request bool) bool {
 	return state.Enabled == request
+}
+
+func equalSeparateRequests(state *github.BranchProtection, sep *separateRequests) bool {
+	if sep == nil {
+		return true
+	}
+	if sep.RequireSignedCommits != nil {
+		currentSigned := state != nil && state.RequiredSignatures.Enabled
+		if currentSigned != *sep.RequireSignedCommits {
+			return false
+		}
+	}
+	return true
 }
 
 func equalAdminEnforcement(state github.EnforceAdmins, request *bool) bool {

--- a/cmd/branchprotector/protect_test.go
+++ b/cmd/branchprotector/protect_test.go
@@ -81,14 +81,15 @@ func TestOptions_Validate(t *testing.T) {
 }
 
 type fakeClient struct {
-	repos             map[string][]github.Repo
-	branches          map[string][]github.Branch
-	deleted           map[string]bool
-	updated           map[string]github.BranchProtectionRequest
-	branchProtections map[string]github.BranchProtection
-	appInstallations  []github.AppInstallation
-	collaborators     []github.User
-	teams             []github.Team
+	repos                map[string][]github.Repo
+	branches             map[string][]github.Branch
+	deleted              map[string]bool
+	updated              map[string]github.BranchProtectionRequest
+	branchProtections    map[string]github.BranchProtection
+	appInstallations     []github.AppInstallation
+	collaborators        []github.User
+	teams                []github.Team
+	signedCommitsEnabled map[string]bool
 }
 
 func (c fakeClient) GetRepo(org string, repo string) (github.FullRepo, error) {
@@ -162,6 +163,30 @@ func (c *fakeClient) RemoveBranchProtection(org, repo, branch string) error {
 	}
 	ctx := org + "/" + repo + "=" + branch
 	c.deleted[ctx] = true
+	return nil
+}
+
+func (c *fakeClient) EnableCommitSignProtection(org, repo, branch string) error {
+	if branch == "error" {
+		return errors.New("failed to enable commit sign protection")
+	}
+	if c.signedCommitsEnabled == nil {
+		c.signedCommitsEnabled = map[string]bool{}
+	}
+	ctx := org + "/" + repo + "=" + branch
+	c.signedCommitsEnabled[ctx] = true
+	return nil
+}
+
+func (c *fakeClient) DisableCommitSignProtection(org, repo, branch string) error {
+	if branch == "error" {
+		return errors.New("failed to disable commit sign protection")
+	}
+	if c.signedCommitsEnabled == nil {
+		c.signedCommitsEnabled = map[string]bool{}
+	}
+	ctx := org + "/" + repo + "=" + branch
+	c.signedCommitsEnabled[ctx] = false
 	return nil
 }
 
@@ -1364,6 +1389,46 @@ branch-protection:
 			},
 		},
 		{
+			name:     "require signed commits",
+			branches: []string{"cfgdef/repo1=master", "cfgdef/repo1=branch", "cfgdef/repo2=master"},
+			config: `
+branch-protection:
+  protect: true
+  require_signed_commits: true
+  orgs:
+    cfgdef:
+`,
+			expected: []requirements{
+				{
+					Org:    "cfgdef",
+					Repo:   "repo1",
+					Branch: "master",
+					Request: &github.BranchProtectionRequest{
+						EnforceAdmins: &no,
+					},
+					Separate: &separateRequests{RequireSignedCommits: &yes},
+				},
+				{
+					Org:    "cfgdef",
+					Repo:   "repo1",
+					Branch: "branch",
+					Request: &github.BranchProtectionRequest{
+						EnforceAdmins: &no,
+					},
+					Separate: &separateRequests{RequireSignedCommits: &yes},
+				},
+				{
+					Org:    "cfgdef",
+					Repo:   "repo2",
+					Branch: "master",
+					Request: &github.BranchProtectionRequest{
+						EnforceAdmins: &no,
+					},
+					Separate: &separateRequests{RequireSignedCommits: &yes},
+				},
+			},
+		},
+		{
 			name:     "Global unmanaged: true makes us not do anything",
 			branches: []string{"cfgdef/repo1=master", "cfgdef/repo1=branch", "cfgdef/repo2=master"},
 			config: `
@@ -1893,6 +1958,72 @@ func TestEqualBranchProtection(t *testing.T) {
 	for _, testCase := range testCases {
 		if actual, expected := equalBranchProtections(testCase.state, testCase.request), testCase.expected; actual != expected {
 			t.Errorf("%s: didn't compute equality correctly, expected %v got %v", testCase.name, expected, actual)
+		}
+	}
+}
+
+func TestEqualSeparateRequests(t *testing.T) {
+	yes := true
+	no := false
+	var testCases = []struct {
+		name     string
+		state    *github.BranchProtection
+		sep      *separateRequests
+		expected bool
+	}{
+		{
+			name:     "nil separate always matches",
+			state:    &github.BranchProtection{},
+			sep:      nil,
+			expected: true,
+		},
+		{
+			name:     "nil signed commits desired always matches",
+			state:    &github.BranchProtection{},
+			sep:      &separateRequests{},
+			expected: true,
+		},
+		{
+			name:     "nil state with desired false matches",
+			state:    nil,
+			sep:      &separateRequests{RequireSignedCommits: &no},
+			expected: true,
+		},
+		{
+			name:     "nil state with desired true does not match",
+			state:    nil,
+			sep:      &separateRequests{RequireSignedCommits: &yes},
+			expected: false,
+		},
+		{
+			name: "enabled state matches desired true",
+			state: &github.BranchProtection{
+				RequiredSignatures: github.RequiredSignatures{Enabled: true},
+			},
+			sep:      &separateRequests{RequireSignedCommits: &yes},
+			expected: true,
+		},
+		{
+			name: "disabled state does not match desired true",
+			state: &github.BranchProtection{
+				RequiredSignatures: github.RequiredSignatures{Enabled: false},
+			},
+			sep:      &separateRequests{RequireSignedCommits: &yes},
+			expected: false,
+		},
+		{
+			name: "enabled state does not match desired false",
+			state: &github.BranchProtection{
+				RequiredSignatures: github.RequiredSignatures{Enabled: true},
+			},
+			sep:      &separateRequests{RequireSignedCommits: &no},
+			expected: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		if actual := equalSeparateRequests(tc.state, tc.sep); actual != tc.expected {
+			t.Errorf("%s: expected %v got %v", tc.name, tc.expected, actual)
 		}
 	}
 }

--- a/pkg/config/branch_protection.go
+++ b/pkg/config/branch_protection.go
@@ -51,6 +51,8 @@ type Policy struct {
 	AllowForcePushes *bool `json:"allow_force_pushes,omitempty"`
 	// AllowDeletions allows deletion of the protected branch by anyone with write access to the repository.
 	AllowDeletions *bool `json:"allow_deletions,omitempty"`
+	// RequireSignedCommits requires all commits pushed to the branch to be signed with a verified signature.
+	RequireSignedCommits *bool `json:"require_signed_commits,omitempty"`
 	// Exclude specifies a set of regular expressions which identify branches
 	// that should be excluded from the protection policy, mutually exclusive with Include
 	Exclude []string `json:"exclude,omitempty"`
@@ -66,7 +68,8 @@ func (p Policy) Managed() bool {
 
 func (p Policy) defined() bool {
 	return p.Protect != nil || p.RequiredStatusChecks != nil || p.Admins != nil || p.Restrictions != nil || p.RequireManuallyTriggeredJobs != nil ||
-		p.RequiredPullRequestReviews != nil || p.RequiredLinearHistory != nil || p.AllowForcePushes != nil || p.AllowDeletions != nil
+		p.RequiredPullRequestReviews != nil || p.RequiredLinearHistory != nil || p.AllowForcePushes != nil || p.AllowDeletions != nil ||
+		p.RequireSignedCommits != nil
 }
 
 // ContextPolicy configures required github contexts.
@@ -225,6 +228,7 @@ func (p Policy) Apply(child Policy) Policy {
 		RequiredLinearHistory:        selectBool(p.RequiredLinearHistory, child.RequiredLinearHistory),
 		AllowForcePushes:             selectBool(p.AllowForcePushes, child.AllowForcePushes),
 		AllowDeletions:               selectBool(p.AllowDeletions, child.AllowDeletions),
+		RequireSignedCommits:         selectBool(p.RequireSignedCommits, child.RequireSignedCommits),
 		RequireManuallyTriggeredJobs: selectBool(p.RequireManuallyTriggeredJobs, child.RequireManuallyTriggeredJobs),
 		Restrictions:                 mergeRestrictions(p.Restrictions, child.Restrictions),
 		RequiredPullRequestReviews:   mergeReviewPolicy(p.RequiredPullRequestReviews, child.RequiredPullRequestReviews),

--- a/pkg/config/prow-config-documented.yaml
+++ b/pkg/config/prow-config-documented.yaml
@@ -65,6 +65,8 @@ branch-protection:
                             # RequireManuallyTriggeredJobs enforces a context presence when job runs conditionally, but not automatically,
                             # that results in params always_run: false, optional: false, and skip_if_only_change, run_if_changed not present.
                             require_manually_triggered_jobs: false
+                            # RequireSignedCommits requires all commits pushed to the branch to be signed with a verified signature.
+                            require_signed_commits: false
                             # RequiredLinearHistory enforces a linear commit Git history, which prevents anyone from pushing merge commits to a branch.
                             required_linear_history: false
                             # RequiredPullRequestReviews specifies github approval/review criteria.
@@ -119,6 +121,8 @@ branch-protection:
                     # RequireManuallyTriggeredJobs enforces a context presence when job runs conditionally, but not automatically,
                     # that results in params always_run: false, optional: false, and skip_if_only_change, run_if_changed not present.
                     require_manually_triggered_jobs: false
+                    # RequireSignedCommits requires all commits pushed to the branch to be signed with a verified signature.
+                    require_signed_commits: false
                     # RequiredLinearHistory enforces a linear commit Git history, which prevents anyone from pushing merge commits to a branch.
                     required_linear_history: false
                     # RequiredPullRequestReviews specifies github approval/review criteria.
@@ -161,6 +165,8 @@ branch-protection:
             # RequireManuallyTriggeredJobs enforces a context presence when job runs conditionally, but not automatically,
             # that results in params always_run: false, optional: false, and skip_if_only_change, run_if_changed not present.
             require_manually_triggered_jobs: false
+            # RequireSignedCommits requires all commits pushed to the branch to be signed with a verified signature.
+            require_signed_commits: false
             # RequiredLinearHistory enforces a linear commit Git history, which prevents anyone from pushing merge commits to a branch.
             required_linear_history: false
             # RequiredPullRequestReviews specifies github approval/review criteria.
@@ -212,6 +218,8 @@ branch-protection:
     # RequireManuallyTriggeredJobs enforces a context presence when job runs conditionally, but not automatically,
     # that results in params always_run: false, optional: false, and skip_if_only_change, run_if_changed not present.
     require_manually_triggered_jobs: false
+    # RequireSignedCommits requires all commits pushed to the branch to be signed with a verified signature.
+    require_signed_commits: false
     # RequiredLinearHistory enforces a linear commit Git history, which prevents anyone from pushing merge commits to a branch.
     required_linear_history: false
     # RequiredPullRequestReviews specifies github approval/review criteria.

--- a/pkg/github/client.go
+++ b/pkg/github/client.go
@@ -171,6 +171,8 @@ type RepositoryClient interface {
 	GetBranchProtection(org, repo, branch string) (*BranchProtection, error)
 	RemoveBranchProtection(org, repo, branch string) error
 	UpdateBranchProtection(org, repo, branch string, config BranchProtectionRequest) error
+	EnableCommitSignProtection(org, repo, branch string) error
+	DisableCommitSignProtection(org, repo, branch string) error
 	AddRepoLabel(org, repo, label, description, color string) error
 	UpdateRepoLabel(org, repo, label, newName, description, color string) error
 	DeleteRepoLabel(org, repo, label string) error
@@ -2801,6 +2803,38 @@ func (c *client) UpdateBranchProtection(org, repo, branch string, config BranchP
 		org:         org,
 		requestBody: config,
 		exitCodes:   []int{200},
+	}, nil)
+	return err
+}
+
+// EnableCommitSignProtection enables required signed commits for a branch.
+//
+// See https://docs.github.com/en/rest/branches/branch-protection#create-commit-signature-protection
+func (c *client) EnableCommitSignProtection(org, repo, branch string) error {
+	durationLogger := c.log("EnableCommitSignProtection", org, repo, branch)
+	defer durationLogger()
+
+	_, err := c.request(&request{
+		method:    http.MethodPost,
+		path:      fmt.Sprintf("/repos/%s/%s/branches/%s/protection/required_signatures", org, repo, branch),
+		org:       org,
+		exitCodes: []int{200},
+	}, nil)
+	return err
+}
+
+// DisableCommitSignProtection disables required signed commits for a branch.
+//
+// See https://docs.github.com/en/rest/branches/branch-protection#delete-commit-signature-protection
+func (c *client) DisableCommitSignProtection(org, repo, branch string) error {
+	durationLogger := c.log("DisableCommitSignProtection", org, repo, branch)
+	defer durationLogger()
+
+	_, err := c.request(&request{
+		method:    http.MethodDelete,
+		path:      fmt.Sprintf("/repos/%s/%s/branches/%s/protection/required_signatures", org, repo, branch),
+		org:       org,
+		exitCodes: []int{204},
 	}, nil)
 	return err
 }

--- a/pkg/github/types.go
+++ b/pkg/github/types.go
@@ -557,10 +557,16 @@ type BranchProtection struct {
 	AllowForcePushes           AllowForcePushes            `json:"allow_force_pushes"`
 	RequiredLinearHistory      RequiredLinearHistory       `json:"required_linear_history"`
 	AllowDeletions             AllowDeletions              `json:"allow_deletions"`
+	RequiredSignatures         RequiredSignatures          `json:"required_signatures"`
 }
 
 // AllowDeletions specifies whether to permit users with push access to delete matching branches.
 type AllowDeletions struct {
+	Enabled bool `json:"enabled"`
+}
+
+// RequiredSignatures specifies whether commits pushed to the branch must be signed with a verified signature.
+type RequiredSignatures struct {
 	Enabled bool `json:"enabled"`
 }
 


### PR DESCRIPTION
## Summary

- Add `require_signed_commits` field to the branch protection `Policy` config struct, enabling declarative management of GitHub's commit signature protection
- GitHub manages this setting via a separate API endpoint (`/required_signatures` with POST/DELETE) rather than the main branch protection PUT body, so this introduces a `separateRequests` struct to cleanly group such settings — future separate-endpoint features can be added there
- Add `EnableCommitSignProtection` / `DisableCommitSignProtection` methods to the GitHub client

Generated with the help of Claude Code.