### PR TITLE
ghproxy: support git ref paths with slash-separated branch names

### DIFF
--- a/pkg/github/ghmetrics/ghpath.go
+++ b/pkg/github/ghmetrics/ghpath.go
@@ -68,7 +68,7 @@ func repositoryTree() []simplifypath.Node {
 			l("ref", v("refId")),
 			l("tags", v("tagId")),
 			l("trees", v("sha")),
-			l("refs", l("heads", v("ref")))),
+			l("refs", l("heads", simplifypath.VGreedy("ref")))),
 		l("stars"),
 		l("merges"),
 		l("stargazers"),

--- a/pkg/github/ghmetrics/ghpath_test.go
+++ b/pkg/github/ghmetrics/ghpath_test.go
@@ -197,6 +197,7 @@ func Test_GetSimplifiedPathRepos(t *testing.T) {
 		{name: "repo transfer", args: args{path: "/repos/testOwner/testRepo/transfer"}, want: "/repos/:owner/:repo/transfer"},
 
 		{name: "master ref", args: args{path: "/repos/cri-o/cri-o/git/refs/heads/master"}, want: "/repos/:owner/:repo/git/refs/heads/:ref"},
+		{name: "ref with slashes", args: args{path: "/repos/kubernetes-sigs/agent-sandbox/git/refs/heads/feature/v1beta1-migrate"}, want: "/repos/:owner/:repo/git/refs/heads/:ref"},
 		{name: "issue comments", args: args{path: "/repos/openshift/aws-account-operator/issues/104/comments"}, want: "/repos/:owner/:repo/issues/:issueId/comments"},
 		{name: "issue labels", args: args{path: "/repos/openshift/aws-account-operator/issues/104/labels"}, want: "/repos/:owner/:repo/issues/:issueId/labels"},
 		{name: "issue label", args: args{path: "/repos/openshift/aws-account-operator/issues/104/labels/needs-rebase"}, want: "/repos/:owner/:repo/issues/:issueId/labels/:labelId"},
@@ -331,6 +332,7 @@ func Test_GetSimplifiedPathRepositories(t *testing.T) {
 		{name: "repo transfer", args: args{path: "/repositories/testRepository/transfer"}, want: "/repositories/:repoId/transfer"},
 
 		{name: "master ref", args: args{path: "/repositories/168397/git/refs/heads/master"}, want: "/repositories/:repoId/git/refs/heads/:ref"},
+		{name: "ref with slashes", args: args{path: "/repositories/168397/git/refs/heads/feature/v1beta1-migrate"}, want: "/repositories/:repoId/git/refs/heads/:ref"},
 		{name: "issue comments", args: args{path: "/repositories/168397/issues/104/comments"}, want: "/repositories/:repoId/issues/:issueId/comments"},
 		{name: "issue labels", args: args{path: "/repositories/168397/issues/104/labels"}, want: "/repositories/:repoId/issues/:issueId/labels"},
 		{name: "issue label", args: args{path: "/repositories/168397/issues/104/labels/needs-rebase"}, want: "/repositories/:repoId/issues/:issueId/labels/:labelId"},


### PR DESCRIPTION
Fixes: https://github.com/kubernetes-sigs/prow/issues/760

## What this PR does ?
This PR fixes ghproxy's path simplifier to correctly handle git reference paths where branch names contain forward slashes, such as `feature/v1beta1-migrate` or `release/v2.0`.

Previously, these paths would trigger "Path not handled" debug logs because the simplifier only matched a single path segment after `refs/heads/`, causing paths like `/repos/kubernetes-sigs/agent-sandbox/git/refs/heads/feature/v1beta1-migrate` to be unmatched.