### PR TITLE
Fix double linking bug when key is a substring of another link

### DIFF
--- a/pkg/plugins/jira/jira.go
+++ b/pkg/plugins/jira/jira.go
@@ -225,7 +225,12 @@ func insertLinksIntoLine(line string, issueNames []string, jiraBaseURL string) s
 // * `[` which we use as heuristic for "Already replaced",
 // * `/` which we use as heuristic for "Part of a link in a previous replacement",
 // * ``` (backtick) which we use as heuristic for "Inline code",
-// * `-` (dash) to prevent replacing a substring that accidentally matches a JIRA issue.
+// * `-` (dash) to prevent replacing a substring that accidentally matches a JIRA issue,
+// * an alphanumeric character, to prevent replacing a shorter issue key that is a
+//   substring of a longer one (e.g. BC-1 inside ABC-123).
+// Similarly, a match is skipped if it is immediately followed by an alphanumeric
+// character, to prevent partial replacements within longer issue numbers
+// (e.g. AC-1 inside AC-1234).
 // If golang would support back-references in regex replacements, this would have been a lot
 // simpler.
 func replaceStringIfNeeded(text, old, new string) string {
@@ -255,16 +260,23 @@ func replaceStringIfNeeded(text, old, new string) string {
 	startingIdx = 0
 	for _, idx := range allOldIdx {
 		result.WriteString(text[startingIdx:idx])
-		if idx == 0 || !strings.Contains("[/`-", string(text[idx-1])) {
+		endIdx := idx + len(old)
+		prefixOk := idx == 0 || (!strings.Contains("[/`-", string(text[idx-1])) && !isAlphanumeric(text[idx-1]))
+		suffixOk := endIdx >= len(text) || !isAlphanumeric(text[endIdx])
+		if prefixOk && suffixOk {
 			result.WriteString(new)
 		} else {
 			result.WriteString(old)
 		}
-		startingIdx = idx + len(old)
+		startingIdx = endIdx
 	}
 	result.WriteString(text[startingIdx:])
 
 	return result.String()
+}
+
+func isAlphanumeric(c byte) bool {
+	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9')
 }
 
 func upsertGitHubLinkToIssue(log *logrus.Entry, issueID string, jc jiraclient.Client, e *github.GenericCommentEvent) error {

--- a/pkg/plugins/jira/jira_test.go
+++ b/pkg/plugins/jira/jira_test.go
@@ -366,9 +366,10 @@ func TestInsertLinksIntoComment(t *testing.T) {
 	t.Parallel()
 	const issueName = "ABC-123"
 	testCases := []struct {
-		name     string
-		body     string
-		expected string
+		name       string
+		body       string
+		issueNames []string
+		expected   string
 	}{
 		{
 			name: "Multiline body starting with issue name",
@@ -467,11 +468,31 @@ is very important` + "\n``ABC-123`` and `ABC-123` shouldn't be replaced, as well
 			body:     "this shouldn't be replaced: whatever-ABC-123 and also inline `whatever-ABC-123`",
 			expected: "this shouldn't be replaced: whatever-ABC-123 and also inline `whatever-ABC-123`",
 		},
+		{
+			name:       "Shorter issue key that is a substring of a longer key is not double linked",
+			issueNames: []string{"ABC-123", "BC-1", "BC-2", "BC-3"},
+			body: `This pull request references ABC-123 which is a valid jira issue.
+
+Additional context
+BC-1: first issue
+BC-2: second issue
+BC-3: third issue`,
+			expected: `This pull request references [ABC-123](https://my-jira.com/browse/ABC-123) which is a valid jira issue.
+
+Additional context
+[BC-1](https://my-jira.com/browse/BC-1): first issue
+[BC-2](https://my-jira.com/browse/BC-2): second issue
+[BC-3](https://my-jira.com/browse/BC-3): third issue`,
+		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			if diff := cmp.Diff(insertLinksIntoComment(tc.body, []string{issueName}, fakejira.FakeJiraUrl), tc.expected); diff != "" {
+			issues := tc.issueNames
+			if issues == nil {
+				issues = []string{issueName}
+			}
+			if diff := cmp.Diff(insertLinksIntoComment(tc.body, issues, fakejira.FakeJiraUrl), tc.expected); diff != "" {
 				t.Errorf("actual result differs from expected result: %s", diff)
 			}
 		})


### PR DESCRIPTION
We ran into a scenario where a random string, in a comment, (like `BC-1:`) that matched the Jira ticket regex, and was a substring with a real link (like `ABC-123`) caused corruption of the main Jira link:

`[A[BC-1](https://redhat.atlassian.net/browse/BC-1)23](...)`

This PR adds a check to prevent replacing a shorter issue key that is a substring of a longer one.

rh-pre-commit.version: 2.4.0
rh-pre-commit.check-secrets: ENABLED