### PR TITLE
Add /override-sticky command for persistent overrides

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -3456,7 +3456,17 @@ const (
 	contextDescriptionBaseSHADelimiterDeprecated = " Basesha:"
 	contextDescriptionMaxLen                     = 140 // https://developer.github.com/v3/repos/deployments/#parameters-2
 	elide                                        = " ... "
+
+	// SkipRetestSentinel can be embedded in a GitHub status description to signal
+	// that Tide should treat the context as permanently passing for the current HEAD SHA
+	// and not retest it when the base branch moves.
+	SkipRetestSentinel = "[prow:skip-retest]"
 )
+
+// IsSkipRetest returns true if the description contains the SkipRetestSentinel.
+func IsSkipRetest(description string) bool {
+	return strings.Contains(description, SkipRetestSentinel)
+}
 
 // truncate converts "really long messages" into "really ... messages".
 func truncate(in string, maxLen int) string {

--- a/pkg/plugins/config.go
+++ b/pkg/plugins/config.go
@@ -2251,10 +2251,6 @@ type Override struct {
 	// AllowedGitHubTeams is a map of orgs and/or repositories (eg "org" or "org/repo") to list of GitHub team slugs,
 	// members of which are allowed to override contexts
 	AllowedGitHubTeams map[string][]string `json:"allowed_github_teams,omitempty"`
-	// StickyForHEAD makes /override persist across retests on the same PR HEAD SHA.
-	// When enabled, Tide will not re-trigger overridden jobs. Pushing a new commit clears overrides.
-	// Also enables the /override-cancel command to remove sticky overrides.
-	StickyForHEAD bool `json:"sticky_for_head,omitempty"`
 }
 
 func (c *Configuration) mergeFrom(other *Configuration) error {

--- a/pkg/plugins/config.go
+++ b/pkg/plugins/config.go
@@ -2251,6 +2251,10 @@ type Override struct {
 	// AllowedGitHubTeams is a map of orgs and/or repositories (eg "org" or "org/repo") to list of GitHub team slugs,
 	// members of which are allowed to override contexts
 	AllowedGitHubTeams map[string][]string `json:"allowed_github_teams,omitempty"`
+	// StickyForHEAD makes /override persist across retests on the same PR HEAD SHA.
+	// When enabled, Tide will not re-trigger overridden jobs. Pushing a new commit clears overrides.
+	// Also enables the /override-cancel command to remove sticky overrides.
+	StickyForHEAD bool `json:"sticky_for_head,omitempty"`
 }
 
 func (c *Configuration) mergeFrom(other *Configuration) error {

--- a/pkg/plugins/override/override.go
+++ b/pkg/plugins/override/override.go
@@ -323,12 +323,14 @@ func authorizedGitHubTeamMember(gc githubClient, log *logrus.Entry, teamSlugs ma
 	return false
 }
 
+const overrideDescriptionPrefix = "Overridden by"
+
 func description(user string) string {
-	return fmt.Sprintf("Overridden by %s", user)
+	return fmt.Sprintf("%s %s", overrideDescriptionPrefix, user)
 }
 
 func stickyDescription(user string) string {
-	return fmt.Sprintf("Overridden by %s %s", user, config.SkipRetestSentinel)
+	return fmt.Sprintf("%s %s %s", overrideDescriptionPrefix, user, config.SkipRetestSentinel)
 }
 
 func formatList(list []string) string {
@@ -649,7 +651,7 @@ func handleOverrideCancel(oc overrideClient, log *logrus.Entry, e *github.Generi
 	cancelDesc := fmt.Sprintf("Override cancelled by %s", user)
 
 	for _, status := range statuses {
-		if !strings.Contains(status.Description, "Overridden by") {
+		if !strings.Contains(status.Description, overrideDescriptionPrefix) {
 			continue
 		}
 		if !cancelAll && !cancelContexts.Has(status.Context) {

--- a/pkg/plugins/override/override.go
+++ b/pkg/plugins/override/override.go
@@ -199,7 +199,7 @@ func helpProvider(config *plugins.Configuration, _ []config.OrgRepo) (*pluginhel
 	})
 	pluginHelp.AddCommand(pluginhelp.Command{
 		Usage:       "/override-cancel [context]",
-		Description: "Cancels sticky overrides. If a context is given, only that override is cancelled. If no context is given, all sticky overrides on the PR are cancelled.",
+		Description: "Removes overrides by setting the status back to failure. Works on both regular and sticky overrides. If a context is given, only that override is removed. If no context is given, all overrides on the PR are removed.",
 		Featured:    false,
 		WhoCanUse:   whoCanUse(overrideConfig, "", ""),
 		Examples:    []string{"/override-cancel pull-repo-whatever", "/override-cancel"},
@@ -242,13 +242,24 @@ func handleGenericComment(pc plugins.Agent, e github.GenericCommentEvent) error 
 
 	options := pc.PluginConfig.Override
 
-	if overrideCancelRe.MatchString(e.Body) {
-		return handleOverrideCancel(c, pc.Logger, &e, options)
+	// process all three handlers, we can have cancellations, overrides, and sticky overrides in the same comment
+	if err := handleOverrideCancel(c, pc.Logger, &e, options); err != nil {
+		return err
 	}
-	if overrideStickyRe.MatchString(e.Body) {
-		return handle(c, pc.Logger, &e, options, true)
+	if err := handle(c, pc.Logger, &e, options, true); err != nil {
+		return err
 	}
 	return handle(c, pc.Logger, &e, options, false)
+}
+
+func isAuthorized(oc overrideClient, log *logrus.Entry, org, repo, user string, options plugins.Override, pr *github.PullRequest) bool {
+	if authorizedUser(oc, log, org, repo, user) {
+		return true
+	}
+	if len(options.AllowedGitHubTeams) > 0 && authorizedGitHubTeamMember(oc, log, options.AllowedGitHubTeams, org, repo, user) {
+		return true
+	}
+	return authorizedTopLevelOwner(oc, options.AllowTopLevelOwners, log, org, repo, user, pr)
 }
 
 func authorizedUser(gc githubClient, log *logrus.Entry, org, repo, user string) bool {
@@ -356,10 +367,12 @@ func handle(oc overrideClient, log *logrus.Entry, e *github.GenericCommentEvent,
 		return nil
 	}
 
+	cmdName := "/override"
 	descFn := description
 	successMsg := "Overrode contexts on behalf of %s: %s"
 	re := overrideRe
 	if sticky {
+		cmdName = "/override-sticky"
 		descFn = stickyDescription
 		successMsg = "Overrode contexts on behalf of %s: %s\n\nThese overrides will persist across retests on the current HEAD SHA. Pushing a new commit will clear them. Use `/override-cancel` to remove them."
 		re = overrideStickyRe
@@ -378,21 +391,11 @@ func handle(oc overrideClient, log *logrus.Entry, e *github.GenericCommentEvent,
 	overrides := sets.New[string]()
 	for _, m := range mat {
 		if m[1] == "" {
-			resp := "/override requires failed status contexts to operate on, but none was given"
+			resp := fmt.Sprintf("%s requires failed status contexts to operate on, but none was given", cmdName)
 			log.Debug(resp)
 			return oc.CreateComment(org, repo, number, plugins.FormatResponseRaw(e.Body, e.HTMLURL, user, resp))
 		}
 		overrides.Insert(parseOverrideInput(m[2])...)
-	}
-
-	authorized := authorizedUser(oc, log, org, repo, user)
-	if !authorized && len(options.AllowedGitHubTeams) > 0 {
-		authorized = authorizedGitHubTeamMember(oc, log, options.AllowedGitHubTeams, org, repo, user)
-	}
-	if !authorized && !options.AllowTopLevelOwners {
-		resp := fmt.Sprintf("%s unauthorized: /override is restricted to %s", user, whoCanUse(options, org, repo))
-		log.Debug(resp)
-		return oc.CreateComment(org, repo, number, plugins.FormatResponseRaw(e.Body, e.HTMLURL, user, resp))
 	}
 
 	pr, err := oc.GetPullRequest(org, repo, number)
@@ -402,8 +405,8 @@ func handle(oc overrideClient, log *logrus.Entry, e *github.GenericCommentEvent,
 		return oc.CreateComment(org, repo, number, plugins.FormatResponseRaw(e.Body, e.HTMLURL, user, resp))
 	}
 
-	if !authorized && !authorizedTopLevelOwner(oc, options.AllowTopLevelOwners, log, org, repo, user, pr) {
-		resp := fmt.Sprintf("%s unauthorized: /override is restricted to %s", user, whoCanUse(options, org, repo))
+	if !isAuthorized(oc, log, org, repo, user, options, pr) {
+		resp := fmt.Sprintf("%s unauthorized: %s is restricted to %s", user, cmdName, whoCanUse(options, org, repo))
 		log.Debug(resp)
 		return oc.CreateComment(org, repo, number, plugins.FormatResponseRaw(e.Body, e.HTMLURL, user, resp))
 	}
@@ -497,7 +500,7 @@ func handle(oc overrideClient, log *logrus.Entry, e *github.GenericCommentEvent,
 	}
 
 	if unknown := overrides.Difference(contexts); unknown.Len() > 0 {
-		resp := fmt.Sprintf(`/override requires failed status contexts, check run or a prowjob name to operate on.
+		resp := fmt.Sprintf(`%s requires failed status contexts, check run or a prowjob name to operate on.
 The following unknown contexts/checkruns were given:
 %s
 
@@ -505,7 +508,7 @@ Only the following failed contexts/checkruns were expected:
 %s
 
 If you are trying to override a checkrun that has a space in it, you must put a double quote on the context.
-`, formatList(sets.List(unknown)), formatList(sets.List(contexts)))
+`, cmdName, formatList(sets.List(unknown)), formatList(sets.List(contexts)))
 		log.Debug(resp)
 		return oc.CreateComment(org, repo, number, plugins.FormatResponseRaw(e.Body, e.HTMLURL, user, resp))
 	}
@@ -609,16 +612,6 @@ func handleOverrideCancel(oc overrideClient, log *logrus.Entry, e *github.Generi
 	number := e.Number
 	user := e.User.Login
 
-	authorized := authorizedUser(oc, log, org, repo, user)
-	if !authorized && len(options.AllowedGitHubTeams) > 0 {
-		authorized = authorizedGitHubTeamMember(oc, log, options.AllowedGitHubTeams, org, repo, user)
-	}
-	if !authorized && !options.AllowTopLevelOwners {
-		resp := fmt.Sprintf("%s unauthorized: override cancel is restricted to %s", user, whoCanUse(options, org, repo))
-		log.Debug(resp)
-		return oc.CreateComment(org, repo, number, plugins.FormatResponseRaw(e.Body, e.HTMLURL, user, resp))
-	}
-
 	pr, err := oc.GetPullRequest(org, repo, number)
 	if err != nil {
 		resp := fmt.Sprintf("Cannot get PR #%d in %s/%s", number, org, repo)
@@ -626,8 +619,8 @@ func handleOverrideCancel(oc overrideClient, log *logrus.Entry, e *github.Generi
 		return oc.CreateComment(org, repo, number, plugins.FormatResponseRaw(e.Body, e.HTMLURL, user, resp))
 	}
 
-	if !authorized && !authorizedTopLevelOwner(oc, options.AllowTopLevelOwners, log, org, repo, user, pr) {
-		resp := fmt.Sprintf("%s unauthorized: override cancel is restricted to %s", user, whoCanUse(options, org, repo))
+	if !isAuthorized(oc, log, org, repo, user, options, pr) {
+		resp := fmt.Sprintf("%s unauthorized: /override-cancel is restricted to %s", user, whoCanUse(options, org, repo))
 		log.Debug(resp)
 		return oc.CreateComment(org, repo, number, plugins.FormatResponseRaw(e.Body, e.HTMLURL, user, resp))
 	}
@@ -656,7 +649,7 @@ func handleOverrideCancel(oc overrideClient, log *logrus.Entry, e *github.Generi
 	cancelDesc := fmt.Sprintf("Override cancelled by %s", user)
 
 	for _, status := range statuses {
-		if !config.IsSkipRetest(status.Description) {
+		if !strings.Contains(status.Description, "Overridden by") {
 			continue
 		}
 		if !cancelAll && !cancelContexts.Has(status.Context) {
@@ -673,12 +666,12 @@ func handleOverrideCancel(oc overrideClient, log *logrus.Entry, e *github.Generi
 	}
 
 	if cancelled.Len() == 0 {
-		resp := "No sticky overrides found to cancel"
+		resp := "No overrides found to cancel"
 		log.Debug(resp)
 		return oc.CreateComment(org, repo, number, plugins.FormatResponseRaw(e.Body, e.HTMLURL, user, resp))
 	}
 
-	msg := fmt.Sprintf("Cancelled sticky overrides on behalf of %s: %s", user, strings.Join(sets.List(cancelled), ", "))
+	msg := fmt.Sprintf("Cancelled overrides on behalf of %s: %s", user, strings.Join(sets.List(cancelled), ", "))
 	log.Info(msg)
 	return oc.CreateComment(org, repo, number, plugins.FormatResponseRaw(e.Body, e.HTMLURL, user, msg))
 }

--- a/pkg/plugins/override/override.go
+++ b/pkg/plugins/override/override.go
@@ -40,8 +40,15 @@ import (
 
 const pluginName = "override"
 
+const StickyOverrideSentinel = "[prow:sticky]"
+
+func IsStickyOverride(description string) bool {
+	return strings.Contains(description, StickyOverrideSentinel)
+}
+
 var (
-	overrideRe = regexp.MustCompile(`(?mi)^/override( ([^\r\n]+))?[\r\n]?$`)
+	overrideRe       = regexp.MustCompile(`(?mi)^/override( ([^\r\n]+))?[\r\n]?$`)
+	overrideCancelRe = regexp.MustCompile(`(?mi)^/override-cancel( ([^\r\n]+))?[\r\n]?$`)
 )
 
 type Context struct {
@@ -181,12 +188,23 @@ func helpProvider(config *plugins.Configuration, _ []config.OrgRepo) (*pluginhel
 	if config != nil {
 		overrideConfig = config.Override
 	}
+	overrideDesc := "Forces github status contexts to green (multiple can be given). If the desired context has spaces, it must be quoted."
+	if overrideConfig.StickyForHEAD {
+		overrideDesc += " With sticky_for_head enabled, overrides persist across retests on the same PR HEAD SHA. Pushing a new commit clears them."
+	}
 	pluginHelp.AddCommand(pluginhelp.Command{
 		Usage:       "/override [context1] [context2]",
-		Description: "Forces github status contexts to green (multiple can be given). If the desired context has spaces, it must be quoted.",
+		Description: overrideDesc,
 		Featured:    false,
 		WhoCanUse:   whoCanUse(overrideConfig, "", ""),
 		Examples:    []string{"/override pull-repo-whatever", "/override \"test / Unit Tests\"", "/override ci/circleci", "/override deleted-job other-job"},
+	})
+	pluginHelp.AddCommand(pluginhelp.Command{
+		Usage:       "/override-cancel [context]",
+		Description: "Cancels sticky overrides (requires sticky_for_head). If a context is given, only that override is cancelled. If no context is given, all sticky overrides on the PR are cancelled.",
+		Featured:    false,
+		WhoCanUse:   whoCanUse(overrideConfig, "", ""),
+		Examples:    []string{"/override-cancel pull-repo-whatever", "/override-cancel"},
 	})
 	return pluginHelp, nil
 }
@@ -223,7 +241,14 @@ func handleGenericComment(pc plugins.Agent, e github.GenericCommentEvent) error 
 		prowJobClient: pc.ProwJobClient,
 		ownersClient:  pc.OwnersClient,
 	}
-	return handle(c, pc.Logger, &e, pc.PluginConfig.Override)
+
+	options := pc.PluginConfig.Override
+
+	if options.StickyForHEAD && overrideCancelRe.MatchString(e.Body) {
+		return handleOverrideCancel(c, pc.Logger, &e, options)
+	}
+
+	return handle(c, pc.Logger, &e, options, options.StickyForHEAD)
 }
 
 func authorizedUser(gc githubClient, log *logrus.Entry, org, repo, user string) bool {
@@ -291,6 +316,10 @@ func description(user string) string {
 	return fmt.Sprintf("Overridden by %s", user)
 }
 
+func stickyDescription(user string) string {
+	return fmt.Sprintf("Overridden by %s %s", user, StickyOverrideSentinel)
+}
+
 func formatList(list []string) string {
 	var lines []string
 	for _, item := range list {
@@ -321,15 +350,22 @@ func parseOverrideInput(in string) []string {
 	return retval
 }
 
-func handle(oc overrideClient, log *logrus.Entry, e *github.GenericCommentEvent, options plugins.Override) error {
+func handle(oc overrideClient, log *logrus.Entry, e *github.GenericCommentEvent, options plugins.Override, sticky bool) error {
 
 	if !e.IsPR || e.IssueState != "open" || e.Action != github.GenericCommentActionCreated {
 		return nil
 	}
 
+	descFn := description
+	successMsg := "Overrode contexts on behalf of %s: %s"
+	if sticky {
+		descFn = stickyDescription
+		successMsg = "Overrode contexts on behalf of %s: %s\n\nThese overrides will persist across retests on the current HEAD SHA. Pushing a new commit will clear them."
+	}
+
 	mat := overrideRe.FindAllStringSubmatch(e.Body, -1)
 	if len(mat) == 0 {
-		return nil // no /override commands given in the comment
+		return nil
 	}
 
 	org := e.Repo.Owner.Login
@@ -479,7 +515,7 @@ If you are trying to override a checkrun that has a space in it, you must put a 
 		if len(done) == 0 {
 			return
 		}
-		msg := fmt.Sprintf("Overrode contexts on behalf of %s: %s", user, strings.Join(sets.List(done), ", "))
+		msg := fmt.Sprintf(successMsg, user, strings.Join(sets.List(done), ", "))
 		log.Info(msg)
 		oc.CreateComment(org, repo, number, plugins.FormatResponseRaw(e.Body, e.HTMLURL, user, msg))
 	}()
@@ -505,7 +541,7 @@ If you are trying to override a checkrun that has a space in it, you must put a 
 				StartTime:      now,
 				CompletionTime: &now,
 				State:          prowapi.SuccessState,
-				Description:    description(user),
+				Description:    descFn(user),
 				URL:            e.HTMLURL,
 			}
 
@@ -518,7 +554,7 @@ If you are trying to override a checkrun that has a space in it, you must put a 
 			contextsWithCreatedJobs.Insert(status.Context)
 		}
 		status.State = github.StatusSuccess
-		status.Description = description(user)
+		status.Description = descFn(user)
 		if err := oc.CreateStatus(org, repo, sha, status); err != nil {
 			resp := fmt.Sprintf("Cannot update PR status for context %s", status.Context)
 			log.WithError(err).Warn(resp)
@@ -554,6 +590,95 @@ If you are trying to override a checkrun that has a space in it, you must put a 
 	}
 
 	return nil
+}
+
+func handleOverrideCancel(oc overrideClient, log *logrus.Entry, e *github.GenericCommentEvent, options plugins.Override) error {
+	if !e.IsPR || e.IssueState != "open" || e.Action != github.GenericCommentActionCreated {
+		return nil
+	}
+
+	mat := overrideCancelRe.FindAllStringSubmatch(e.Body, -1)
+	if len(mat) == 0 {
+		return nil
+	}
+
+	org := e.Repo.Owner.Login
+	repo := e.Repo.Name
+	number := e.Number
+	user := e.User.Login
+
+	authorized := authorizedUser(oc, log, org, repo, user)
+	if !authorized && len(options.AllowedGitHubTeams) > 0 {
+		authorized = authorizedGitHubTeamMember(oc, log, options.AllowedGitHubTeams, org, repo, user)
+	}
+	if !authorized && !options.AllowTopLevelOwners {
+		resp := fmt.Sprintf("%s unauthorized: override cancel is restricted to %s", user, whoCanUse(options, org, repo))
+		log.Debug(resp)
+		return oc.CreateComment(org, repo, number, plugins.FormatResponseRaw(e.Body, e.HTMLURL, user, resp))
+	}
+
+	pr, err := oc.GetPullRequest(org, repo, number)
+	if err != nil {
+		resp := fmt.Sprintf("Cannot get PR #%d in %s/%s", number, org, repo)
+		log.WithError(err).Warn(resp)
+		return oc.CreateComment(org, repo, number, plugins.FormatResponseRaw(e.Body, e.HTMLURL, user, resp))
+	}
+
+	if !authorized && !authorizedTopLevelOwner(oc, options.AllowTopLevelOwners, log, org, repo, user, pr) {
+		resp := fmt.Sprintf("%s unauthorized: override cancel is restricted to %s", user, whoCanUse(options, org, repo))
+		log.Debug(resp)
+		return oc.CreateComment(org, repo, number, plugins.FormatResponseRaw(e.Body, e.HTMLURL, user, resp))
+	}
+
+	sha := pr.Head.SHA
+
+	// Determine which contexts to cancel
+	cancelAll := false
+	cancelContexts := sets.New[string]()
+	for _, m := range mat {
+		if m[1] == "" {
+			cancelAll = true
+			break
+		}
+		cancelContexts.Insert(parseOverrideInput(m[2])...)
+	}
+
+	statuses, err := oc.ListStatuses(org, repo, sha)
+	if err != nil {
+		resp := fmt.Sprintf("Cannot get commit statuses for PR #%d in %s/%s", number, org, repo)
+		log.WithError(err).Warn(resp)
+		return oc.CreateComment(org, repo, number, plugins.FormatResponseRaw(e.Body, e.HTMLURL, user, resp))
+	}
+
+	cancelled := sets.New[string]()
+	cancelDesc := fmt.Sprintf("Override cancelled by %s", user)
+
+	for _, status := range statuses {
+		if !IsStickyOverride(status.Description) {
+			continue
+		}
+		if !cancelAll && !cancelContexts.Has(status.Context) {
+			continue
+		}
+		status.State = github.StatusFailure
+		status.Description = cancelDesc
+		if err := oc.CreateStatus(org, repo, sha, status); err != nil {
+			resp := fmt.Sprintf("Cannot update PR status for context %s", status.Context)
+			log.WithError(err).Warn(resp)
+			return oc.CreateComment(org, repo, number, plugins.FormatResponseRaw(e.Body, e.HTMLURL, user, resp))
+		}
+		cancelled.Insert(status.Context)
+	}
+
+	if cancelled.Len() == 0 {
+		resp := "No sticky overrides found to cancel"
+		log.Debug(resp)
+		return oc.CreateComment(org, repo, number, plugins.FormatResponseRaw(e.Body, e.HTMLURL, user, resp))
+	}
+
+	msg := fmt.Sprintf("Cancelled sticky overrides on behalf of %s: %s", user, strings.Join(sets.List(cancelled), ", "))
+	log.Info(msg)
+	return oc.CreateComment(org, repo, number, plugins.FormatResponseRaw(e.Body, e.HTMLURL, user, msg))
 }
 
 // shaGetterFactory is a closure to retrieve a sha once. It is not threadsafe.

--- a/pkg/plugins/override/override.go
+++ b/pkg/plugins/override/override.go
@@ -40,12 +40,6 @@ import (
 
 const pluginName = "override"
 
-const StickyOverrideSentinel = "[prow:sticky]"
-
-func IsStickyOverride(description string) bool {
-	return strings.Contains(description, StickyOverrideSentinel)
-}
-
 var (
 	overrideRe       = regexp.MustCompile(`(?mi)^/override( ([^\r\n]+))?[\r\n]?$`)
 	overrideCancelRe = regexp.MustCompile(`(?mi)^/override-cancel( ([^\r\n]+))?[\r\n]?$`)
@@ -314,7 +308,7 @@ func description(user string) string {
 }
 
 func stickyDescription(user string) string {
-	return fmt.Sprintf("Overridden by %s %s", user, StickyOverrideSentinel)
+	return fmt.Sprintf("Overridden by %s %s", user, config.SkipRetestSentinel)
 }
 
 func formatList(list []string) string {
@@ -505,6 +499,13 @@ If you are trying to override a checkrun that has a space in it, you must put a 
 		return oc.CreateComment(org, repo, number, plugins.FormatResponseRaw(e.Body, e.HTMLURL, user, resp))
 	}
 
+	baseSHA, err := baseSHAGetter()
+	if err != nil {
+		resp := "Cannot get base ref of PR"
+		log.WithError(err).Warn(resp)
+		return oc.CreateComment(org, repo, number, plugins.FormatResponseRaw(e.Body, e.HTMLURL, user, resp))
+	}
+
 	done := sets.Set[string]{}
 	contextsWithCreatedJobs := sets.Set[string]{}
 
@@ -525,13 +526,6 @@ If you are trying to override a checkrun that has a space in it, you must put a 
 
 		// Create the overridden prow result if necessary
 		if pre != nil {
-			baseSHA, err := baseSHAGetter()
-			if err != nil {
-				resp := "Cannot get base ref of PR"
-				log.WithError(err).Warn(resp)
-				return oc.CreateComment(org, repo, number, plugins.FormatResponseRaw(e.Body, e.HTMLURL, user, resp))
-			}
-
 			pj := pjutil.NewPresubmit(*pr, baseSHA, *pre, e.GUID, nil)
 			now := metav1.Now()
 			pj.Status = prowapi.ProwJobStatus{
@@ -551,7 +545,7 @@ If you are trying to override a checkrun that has a space in it, you must put a 
 			contextsWithCreatedJobs.Insert(status.Context)
 		}
 		status.State = github.StatusSuccess
-		status.Description = descFn(user)
+		status.Description = config.ContextDescriptionWithBaseSha(descFn(user), baseSHA)
 		if err := oc.CreateStatus(org, repo, sha, status); err != nil {
 			resp := fmt.Sprintf("Cannot update PR status for context %s", status.Context)
 			log.WithError(err).Warn(resp)
@@ -651,7 +645,7 @@ func handleOverrideCancel(oc overrideClient, log *logrus.Entry, e *github.Generi
 	cancelDesc := fmt.Sprintf("Override cancelled by %s", user)
 
 	for _, status := range statuses {
-		if !IsStickyOverride(status.Description) {
+		if !config.IsSkipRetest(status.Description) {
 			continue
 		}
 		if !cancelAll && !cancelContexts.Has(status.Context) {

--- a/pkg/plugins/override/override.go
+++ b/pkg/plugins/override/override.go
@@ -41,8 +41,9 @@ import (
 const pluginName = "override"
 
 var (
-	overrideRe       = regexp.MustCompile(`(?mi)^/override( ([^\r\n]+))?[\r\n]?$`)
+	overrideStickyRe = regexp.MustCompile(`(?mi)^/override-sticky( ([^\r\n]+))?[\r\n]?$`)
 	overrideCancelRe = regexp.MustCompile(`(?mi)^/override-cancel( ([^\r\n]+))?[\r\n]?$`)
+	overrideRe       = regexp.MustCompile(`(?mi)^/override( ([^\r\n]+))?[\r\n]?$`)
 )
 
 type Context struct {
@@ -182,17 +183,23 @@ func helpProvider(config *plugins.Configuration, _ []config.OrgRepo) (*pluginhel
 	if config != nil {
 		overrideConfig = config.Override
 	}
-	overrideDesc := "Forces github status contexts to green (multiple can be given). If the desired context has spaces, it must be quoted. When sticky_for_head is enabled, overrides persist across retests on the same PR HEAD SHA. Pushing a new commit clears them."
 	pluginHelp.AddCommand(pluginhelp.Command{
 		Usage:       "/override [context1] [context2]",
-		Description: overrideDesc,
+		Description: "Forces github status contexts to green (multiple can be given). If the desired context has spaces, it must be quoted. Overrides expire when the base branch moves.",
 		Featured:    false,
 		WhoCanUse:   whoCanUse(overrideConfig, "", ""),
 		Examples:    []string{"/override pull-repo-whatever", "/override \"test / Unit Tests\"", "/override ci/circleci", "/override deleted-job other-job"},
 	})
 	pluginHelp.AddCommand(pluginhelp.Command{
+		Usage:       "/override-sticky [context1] [context2]",
+		Description: "Like /override, but the override persists across retests on the current HEAD SHA even when the base branch moves. Pushing a new commit clears them. Use /override-cancel to remove.",
+		Featured:    false,
+		WhoCanUse:   whoCanUse(overrideConfig, "", ""),
+		Examples:    []string{"/override-sticky pull-repo-whatever", "/override-sticky \"test / Unit Tests\""},
+	})
+	pluginHelp.AddCommand(pluginhelp.Command{
 		Usage:       "/override-cancel [context]",
-		Description: "Cancels sticky overrides (requires sticky_for_head). If a context is given, only that override is cancelled. If no context is given, all sticky overrides on the PR are cancelled.",
+		Description: "Cancels sticky overrides. If a context is given, only that override is cancelled. If no context is given, all sticky overrides on the PR are cancelled.",
 		Featured:    false,
 		WhoCanUse:   whoCanUse(overrideConfig, "", ""),
 		Examples:    []string{"/override-cancel pull-repo-whatever", "/override-cancel"},
@@ -235,11 +242,13 @@ func handleGenericComment(pc plugins.Agent, e github.GenericCommentEvent) error 
 
 	options := pc.PluginConfig.Override
 
-	if options.StickyForHEAD && overrideCancelRe.MatchString(e.Body) {
+	if overrideCancelRe.MatchString(e.Body) {
 		return handleOverrideCancel(c, pc.Logger, &e, options)
 	}
-
-	return handle(c, pc.Logger, &e, options, options.StickyForHEAD)
+	if overrideStickyRe.MatchString(e.Body) {
+		return handle(c, pc.Logger, &e, options, true)
+	}
+	return handle(c, pc.Logger, &e, options, false)
 }
 
 func authorizedUser(gc githubClient, log *logrus.Entry, org, repo, user string) bool {
@@ -349,12 +358,14 @@ func handle(oc overrideClient, log *logrus.Entry, e *github.GenericCommentEvent,
 
 	descFn := description
 	successMsg := "Overrode contexts on behalf of %s: %s"
+	re := overrideRe
 	if sticky {
 		descFn = stickyDescription
-		successMsg = "Overrode contexts on behalf of %s: %s\n\nThese overrides will persist across retests on the current HEAD SHA. Pushing a new commit will clear them."
+		successMsg = "Overrode contexts on behalf of %s: %s\n\nThese overrides will persist across retests on the current HEAD SHA. Pushing a new commit will clear them. Use `/override-cancel` to remove them."
+		re = overrideStickyRe
 	}
 
-	mat := overrideRe.FindAllStringSubmatch(e.Body, -1)
+	mat := re.FindAllStringSubmatch(e.Body, -1)
 	if len(mat) == 0 {
 		return nil
 	}

--- a/pkg/plugins/override/override.go
+++ b/pkg/plugins/override/override.go
@@ -188,10 +188,7 @@ func helpProvider(config *plugins.Configuration, _ []config.OrgRepo) (*pluginhel
 	if config != nil {
 		overrideConfig = config.Override
 	}
-	overrideDesc := "Forces github status contexts to green (multiple can be given). If the desired context has spaces, it must be quoted."
-	if overrideConfig.StickyForHEAD {
-		overrideDesc += " With sticky_for_head enabled, overrides persist across retests on the same PR HEAD SHA. Pushing a new commit clears them."
-	}
+	overrideDesc := "Forces github status contexts to green (multiple can be given). If the desired context has spaces, it must be quoted. When sticky_for_head is enabled, overrides persist across retests on the same PR HEAD SHA. Pushing a new commit clears them."
 	pluginHelp.AddCommand(pluginhelp.Command{
 		Usage:       "/override [context1] [context2]",
 		Description: overrideDesc,

--- a/pkg/plugins/override/override_test.go
+++ b/pkg/plugins/override/override_test.go
@@ -44,9 +44,17 @@ const (
 	fakePR      = 33
 	fakeSHA     = "deadbeef"
 	fakeBaseRef = "fake-branch"
-	fakeBaseSHA = "fffffff"
+	fakeBaseSHA = "fffffffffffffffffffffffffffffffffffffff0"
 	adminUser   = "admin-user"
 )
+
+func statusDescription(user string) string {
+	return config.ContextDescriptionWithBaseSha(description(user), fakeBaseSHA)
+}
+
+func stickyStatusDescription(user string) string {
+	return config.ContextDescriptionWithBaseSha(stickyDescription(user), fakeBaseSHA)
+}
 
 type fakeRepoownersClient struct {
 	foc *fakeOwnersClient
@@ -387,7 +395,7 @@ func TestHandle(t *testing.T) {
 			expected: []github.Status{
 				{
 					Context:     "broken-test",
-					Description: description(adminUser),
+					Description: statusDescription(adminUser),
 					State:       github.StatusSuccess,
 				},
 			},
@@ -459,12 +467,12 @@ func TestHandle(t *testing.T) {
 			expected: []github.Status{
 				{
 					Context:     "broken-test",
-					Description: description(adminUser),
+					Description: statusDescription(adminUser),
 					State:       github.StatusSuccess,
 				},
 				{
 					Context:     "hung-test",
-					Description: description(adminUser),
+					Description: statusDescription(adminUser),
 					State:       github.StatusSuccess,
 				},
 			},
@@ -550,7 +558,7 @@ func TestHandle(t *testing.T) {
 			expected: []github.Status{
 				{
 					Context:     "hung-test",
-					Description: description(adminUser),
+					Description: statusDescription(adminUser),
 					State:       github.StatusSuccess,
 				},
 			},
@@ -638,12 +646,12 @@ func TestHandle(t *testing.T) {
 			expected: []github.Status{
 				{
 					Context:     "broken-test",
-					Description: description(adminUser),
+					Description: statusDescription(adminUser),
 					State:       github.StatusSuccess,
 				},
 				{
 					Context:     "hung-test",
-					Description: description(adminUser),
+					Description: statusDescription(adminUser),
 					State:       github.StatusSuccess,
 				},
 			},
@@ -665,12 +673,12 @@ func TestHandle(t *testing.T) {
 			expected: []github.Status{
 				{
 					Context:     "broken-test",
-					Description: description(adminUser),
+					Description: statusDescription(adminUser),
 					State:       github.StatusSuccess,
 				},
 				{
 					Context:     "hung-test",
-					Description: description(adminUser),
+					Description: statusDescription(adminUser),
 					State:       github.StatusSuccess,
 				},
 			},
@@ -689,7 +697,7 @@ func TestHandle(t *testing.T) {
 			expected: []github.Status{
 				{
 					Context:     "broken-test",
-					Description: description(adminUser),
+					Description: statusDescription(adminUser),
 					State:       github.StatusSuccess,
 				},
 			},
@@ -860,7 +868,7 @@ func TestHandle(t *testing.T) {
 				{
 					Context:     "prow-job",
 					State:       github.StatusSuccess,
-					Description: description(adminUser),
+					Description: statusDescription(adminUser),
 				},
 			},
 		},
@@ -889,7 +897,7 @@ func TestHandle(t *testing.T) {
 				{
 					Context:     "ci/prow/pkg-job",
 					State:       github.StatusSuccess,
-					Description: description(adminUser),
+					Description: statusDescription(adminUser),
 				},
 			},
 		},
@@ -923,12 +931,12 @@ func TestHandle(t *testing.T) {
 				{
 					Context:     "ci/prow/context",
 					State:       github.StatusSuccess,
-					Description: description(adminUser),
+					Description: statusDescription(adminUser),
 				},
 				{
 					Context:     "ci/prow/pkg-job",
 					State:       github.StatusSuccess,
-					Description: description(adminUser),
+					Description: statusDescription(adminUser),
 				},
 			},
 		},
@@ -957,7 +965,7 @@ func TestHandle(t *testing.T) {
 				{
 					Context:     "ci/prow/pkg-job",
 					State:       github.StatusSuccess,
-					Description: description(adminUser),
+					Description: statusDescription(adminUser),
 				},
 			},
 		},
@@ -974,7 +982,7 @@ func TestHandle(t *testing.T) {
 			expected: []github.Status{
 				{
 					Context:     "job",
-					Description: description(adminUser),
+					Description: statusDescription(adminUser),
 					State:       github.StatusSuccess,
 				},
 			},
@@ -995,7 +1003,7 @@ func TestHandle(t *testing.T) {
 			expected: []github.Status{
 				{
 					Context:     "job",
-					Description: description("code_owner"),
+					Description: statusDescription("code_owner"),
 					State:       github.StatusSuccess,
 				},
 			},
@@ -1016,7 +1024,7 @@ func TestHandle(t *testing.T) {
 			expected: []github.Status{
 				{
 					Context:     "job",
-					Description: description("Code_owner"),
+					Description: statusDescription("Code_owner"),
 					State:       github.StatusSuccess,
 				},
 			},
@@ -1060,7 +1068,7 @@ func TestHandle(t *testing.T) {
 			expected: []github.Status{
 				{
 					Context:     "job",
-					Description: description("user1"),
+					Description: statusDescription("user1"),
 					State:       github.StatusSuccess,
 				},
 			},
@@ -1084,7 +1092,7 @@ func TestHandle(t *testing.T) {
 			expected: []github.Status{
 				{
 					Context:     "job",
-					Description: description("user1"),
+					Description: statusDescription("user1"),
 					State:       github.StatusSuccess,
 				},
 			},
@@ -1112,7 +1120,7 @@ func TestHandle(t *testing.T) {
 			expected: []github.Status{
 				{
 					Context:     "job",
-					Description: description(adminUser),
+					Description: statusDescription(adminUser),
 					State:       github.StatusSuccess,
 				},
 			},
@@ -1133,7 +1141,7 @@ func TestHandle(t *testing.T) {
 			expected: []github.Status{
 				{
 					Context:     "job",
-					Description: description(adminUser),
+					Description: statusDescription(adminUser),
 					State:       github.StatusSuccess,
 				},
 			},
@@ -1170,7 +1178,7 @@ func TestHandle(t *testing.T) {
 			expected: []github.Status{
 				{
 					Context:     "problematic-test",
-					Description: description(adminUser),
+					Description: statusDescription(adminUser),
 					State:       github.StatusSuccess,
 				},
 				{
@@ -1431,21 +1439,22 @@ func TestValidateGitHubTeamSlugs(t *testing.T) {
 	}
 }
 
-func TestIsStickyOverride(t *testing.T) {
+func TestIsSkipRetest(t *testing.T) {
 	cases := []struct {
 		description string
 		expected    bool
 	}{
-		{"Overridden by admin-user [prow:sticky]", true},
-		{"Overridden by bot [prow:sticky]", true},
-		{"something [prow:sticky] else", true},
+		{"Overridden by admin-user [prow:skip-retest]", true},
+		{"Overridden by bot [prow:skip-retest]", true},
+		{"something [prow:skip-retest] else", true},
+		{stickyStatusDescription("admin-user"), true},
 		{"Overridden by admin-user", false},
 		{"Build succeeded", false},
 		{"", false},
 	}
 	for _, tc := range cases {
-		if got := IsStickyOverride(tc.description); got != tc.expected {
-			t.Errorf("IsStickyOverride(%q) = %v, want %v", tc.description, got, tc.expected)
+		if got := config.IsSkipRetest(tc.description); got != tc.expected {
+			t.Errorf("IsSkipRetest(%q) = %v, want %v", tc.description, got, tc.expected)
 		}
 	}
 }
@@ -1466,7 +1475,7 @@ func TestHandleStickyOverride(t *testing.T) {
 				{Context: "job-a", State: github.StatusFailure, Description: "Build failed"},
 			},
 			expected: []github.Status{
-				{Context: "job-a", State: github.StatusSuccess, Description: "Overridden by admin-user [prow:sticky]"},
+				{Context: "job-a", State: github.StatusSuccess, Description: stickyStatusDescription(adminUser)},
 			},
 		},
 		{
@@ -1476,7 +1485,7 @@ func TestHandleStickyOverride(t *testing.T) {
 				{Context: "job-a", State: github.StatusFailure, Description: "Build failed"},
 			},
 			expected: []github.Status{
-				{Context: "job-a", State: github.StatusSuccess, Description: "Overridden by admin-user"},
+				{Context: "job-a", State: github.StatusSuccess, Description: statusDescription(adminUser)},
 			},
 		},
 	}
@@ -1522,12 +1531,12 @@ func TestHandleStickyCancel(t *testing.T) {
 			name: "cancel specific sticky override",
 			body: "/override-cancel job-a",
 			statuses: []github.Status{
-				{Context: "job-a", State: github.StatusSuccess, Description: "Overridden by admin-user [prow:sticky]"},
-				{Context: "job-b", State: github.StatusSuccess, Description: "Overridden by admin-user [prow:sticky]"},
+				{Context: "job-a", State: github.StatusSuccess, Description: "Overridden by admin-user [prow:skip-retest]"},
+				{Context: "job-b", State: github.StatusSuccess, Description: "Overridden by admin-user [prow:skip-retest]"},
 			},
 			expectedStatuses: []github.Status{
 				{Context: "job-a", State: github.StatusFailure, Description: "Override cancelled by admin-user"},
-				{Context: "job-b", State: github.StatusSuccess, Description: "Overridden by admin-user [prow:sticky]"},
+				{Context: "job-b", State: github.StatusSuccess, Description: "Overridden by admin-user [prow:skip-retest]"},
 			},
 			expectedComment: "Cancelled sticky overrides",
 		},
@@ -1535,8 +1544,8 @@ func TestHandleStickyCancel(t *testing.T) {
 			name: "cancel all sticky overrides",
 			body: "/override-cancel",
 			statuses: []github.Status{
-				{Context: "job-a", State: github.StatusSuccess, Description: "Overridden by admin-user [prow:sticky]"},
-				{Context: "job-b", State: github.StatusSuccess, Description: "Overridden by admin-user [prow:sticky]"},
+				{Context: "job-a", State: github.StatusSuccess, Description: "Overridden by admin-user [prow:skip-retest]"},
+				{Context: "job-b", State: github.StatusSuccess, Description: "Overridden by admin-user [prow:skip-retest]"},
 			},
 			expectedStatuses: []github.Status{
 				{Context: "job-a", State: github.StatusFailure, Description: "Override cancelled by admin-user"},

--- a/pkg/plugins/override/override_test.go
+++ b/pkg/plugins/override/override_test.go
@@ -162,15 +162,12 @@ func (c *fakeClient) CreateStatus(org, repo, ref string, s github.Status) error 
 		return fmt.Errorf("bad ref: %s", ref)
 	}
 	for i, status := range c.statuses {
-		if status.State != github.StatusSuccess && status.Context == s.Context {
+		if status.Context == s.Context {
 			c.statuses[i] = s
 			return nil
 		}
 	}
-	//handle branch protection case
-	if len(c.statuses) == 0 {
-		c.statuses = append(c.statuses, s)
-	}
+	c.statuses = append(c.statuses, s)
 	return nil
 }
 
@@ -1244,7 +1241,7 @@ func TestHandle(t *testing.T) {
 				tc.jobs = sets.Set[string]{}
 			}
 
-			err := handle(&fc, log, &event, tc.options)
+			err := handle(&fc, log, &event, tc.options, false)
 			switch {
 			case err != nil:
 				if !tc.err {
@@ -1313,10 +1310,14 @@ func TestHelpProvider(t *testing.T) {
 		switch {
 		case help == nil:
 			t.Errorf("%s: expected a valid plugin help object, got nil", tc.name)
-		case len(help.Commands) != 1:
-			t.Errorf("%s: expected a single command from plugin help, got: %v", tc.name, help.Commands)
-		case help.Commands[0].WhoCanUse != tc.expectedWho:
-			t.Errorf("%s: expected a single command with WhoCanUse set to %s, got %s instead", tc.name, tc.expectedWho, help.Commands[0].WhoCanUse)
+		case len(help.Commands) != 2:
+			t.Errorf("%s: expected 2 commands from plugin help, got %d: %v", tc.name, len(help.Commands), help.Commands)
+		default:
+			for _, cmd := range help.Commands {
+				if cmd.WhoCanUse != tc.expectedWho {
+					t.Errorf("%s: expected command %q with WhoCanUse set to %s, got %s instead", tc.name, cmd.Usage, tc.expectedWho, cmd.WhoCanUse)
+				}
+			}
 		}
 	}
 }
@@ -1427,5 +1428,164 @@ func TestValidateGitHubTeamSlugs(t *testing.T) {
 		if !reflect.DeepEqual(err, tc.err) {
 			t.Errorf("%s: actual: %v != expected %v", tc.name, err, tc.err)
 		}
+	}
+}
+
+func TestIsStickyOverride(t *testing.T) {
+	cases := []struct {
+		description string
+		expected    bool
+	}{
+		{"Overridden by admin-user [prow:sticky]", true},
+		{"Overridden by bot [prow:sticky]", true},
+		{"something [prow:sticky] else", true},
+		{"Overridden by admin-user", false},
+		{"Build succeeded", false},
+		{"", false},
+	}
+	for _, tc := range cases {
+		if got := IsStickyOverride(tc.description); got != tc.expected {
+			t.Errorf("IsStickyOverride(%q) = %v, want %v", tc.description, got, tc.expected)
+		}
+	}
+}
+
+func TestHandleStickyOverride(t *testing.T) {
+	log := logrus.WithField("plugin", pluginName)
+
+	cases := []struct {
+		name     string
+		sticky   bool
+		statuses []github.Status
+		expected []github.Status
+	}{
+		{
+			name:   "StickyForHEAD enabled sets sticky description",
+			sticky: true,
+			statuses: []github.Status{
+				{Context: "job-a", State: github.StatusFailure, Description: "Build failed"},
+			},
+			expected: []github.Status{
+				{Context: "job-a", State: github.StatusSuccess, Description: "Overridden by admin-user [prow:sticky]"},
+			},
+		},
+		{
+			name:   "StickyForHEAD disabled sets regular description",
+			sticky: false,
+			statuses: []github.Status{
+				{Context: "job-a", State: github.StatusFailure, Description: "Build failed"},
+			},
+			expected: []github.Status{
+				{Context: "job-a", State: github.StatusSuccess, Description: "Overridden by admin-user"},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fc := &fakeClient{
+				statuses: tc.statuses,
+				jobs:     sets.New[string](),
+			}
+			event := github.GenericCommentEvent{
+				IsPR:       true,
+				IssueState: "open",
+				Action:     github.GenericCommentActionCreated,
+				Body:       "/override job-a",
+				Number:     fakePR,
+				User:       github.User{Login: adminUser},
+				Repo:       github.Repo{Owner: github.User{Login: fakeOrg}, Name: fakeRepo},
+			}
+
+			err := handle(fc, log, &event, plugins.Override{}, tc.sticky)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if diff := cmp.Diff(tc.expected, fc.statuses); diff != "" {
+				t.Errorf("statuses mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestHandleStickyCancel(t *testing.T) {
+	log := logrus.WithField("plugin", pluginName)
+
+	cases := []struct {
+		name             string
+		body             string
+		statuses         []github.Status
+		expectedStatuses []github.Status
+		expectedComment  string
+	}{
+		{
+			name: "cancel specific sticky override",
+			body: "/override-cancel job-a",
+			statuses: []github.Status{
+				{Context: "job-a", State: github.StatusSuccess, Description: "Overridden by admin-user [prow:sticky]"},
+				{Context: "job-b", State: github.StatusSuccess, Description: "Overridden by admin-user [prow:sticky]"},
+			},
+			expectedStatuses: []github.Status{
+				{Context: "job-a", State: github.StatusFailure, Description: "Override cancelled by admin-user"},
+				{Context: "job-b", State: github.StatusSuccess, Description: "Overridden by admin-user [prow:sticky]"},
+			},
+			expectedComment: "Cancelled sticky overrides",
+		},
+		{
+			name: "cancel all sticky overrides",
+			body: "/override-cancel",
+			statuses: []github.Status{
+				{Context: "job-a", State: github.StatusSuccess, Description: "Overridden by admin-user [prow:sticky]"},
+				{Context: "job-b", State: github.StatusSuccess, Description: "Overridden by admin-user [prow:sticky]"},
+			},
+			expectedStatuses: []github.Status{
+				{Context: "job-a", State: github.StatusFailure, Description: "Override cancelled by admin-user"},
+				{Context: "job-b", State: github.StatusFailure, Description: "Override cancelled by admin-user"},
+			},
+			expectedComment: "Cancelled sticky overrides",
+		},
+		{
+			name: "cancel does not affect regular overrides",
+			body: "/override-cancel",
+			statuses: []github.Status{
+				{Context: "job-a", State: github.StatusSuccess, Description: "Overridden by admin-user"},
+			},
+			expectedStatuses: []github.Status{
+				{Context: "job-a", State: github.StatusSuccess, Description: "Overridden by admin-user"},
+			},
+			expectedComment: "No sticky overrides found to cancel",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fc := &fakeClient{
+				statuses: tc.statuses,
+				jobs:     sets.New[string](),
+			}
+			event := github.GenericCommentEvent{
+				IsPR:       true,
+				IssueState: "open",
+				Action:     github.GenericCommentActionCreated,
+				Body:       tc.body,
+				Number:     fakePR,
+				User:       github.User{Login: adminUser},
+				Repo:       github.Repo{Owner: github.User{Login: fakeOrg}, Name: fakeRepo},
+			}
+
+			err := handleOverrideCancel(fc, log, &event, plugins.Override{})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if diff := cmp.Diff(tc.expectedStatuses, fc.statuses); diff != "" {
+				t.Errorf("statuses mismatch (-want +got):\n%s", diff)
+			}
+			if len(fc.comments) == 0 {
+				t.Fatal("expected a comment")
+			}
+			if !strings.Contains(fc.comments[len(fc.comments)-1], tc.expectedComment) {
+				t.Errorf("expected comment containing %q, got %q", tc.expectedComment, fc.comments[len(fc.comments)-1])
+			}
+		})
 	}
 }

--- a/pkg/plugins/override/override_test.go
+++ b/pkg/plugins/override/override_test.go
@@ -1318,8 +1318,8 @@ func TestHelpProvider(t *testing.T) {
 		switch {
 		case help == nil:
 			t.Errorf("%s: expected a valid plugin help object, got nil", tc.name)
-		case len(help.Commands) != 2:
-			t.Errorf("%s: expected 2 commands from plugin help, got %d: %v", tc.name, len(help.Commands), help.Commands)
+		case len(help.Commands) != 3:
+			t.Errorf("%s: expected 3 commands from plugin help, got %d: %v", tc.name, len(help.Commands), help.Commands)
 		default:
 			for _, cmd := range help.Commands {
 				if cmd.WhoCanUse != tc.expectedWho {
@@ -1464,12 +1464,14 @@ func TestHandleStickyOverride(t *testing.T) {
 
 	cases := []struct {
 		name     string
+		body     string
 		sticky   bool
 		statuses []github.Status
 		expected []github.Status
 	}{
 		{
-			name:   "StickyForHEAD enabled sets sticky description",
+			name:   "/override-sticky sets sticky description",
+			body:   "/override-sticky job-a",
 			sticky: true,
 			statuses: []github.Status{
 				{Context: "job-a", State: github.StatusFailure, Description: "Build failed"},
@@ -1479,7 +1481,8 @@ func TestHandleStickyOverride(t *testing.T) {
 			},
 		},
 		{
-			name:   "StickyForHEAD disabled sets regular description",
+			name:   "/override sets regular description",
+			body:   "/override job-a",
 			sticky: false,
 			statuses: []github.Status{
 				{Context: "job-a", State: github.StatusFailure, Description: "Build failed"},
@@ -1500,7 +1503,7 @@ func TestHandleStickyOverride(t *testing.T) {
 				IsPR:       true,
 				IssueState: "open",
 				Action:     github.GenericCommentActionCreated,
-				Body:       "/override job-a",
+				Body:       tc.body,
 				Number:     fakePR,
 				User:       github.User{Login: adminUser},
 				Repo:       github.Repo{Owner: github.User{Login: fakeOrg}, Name: fakeRepo},

--- a/pkg/plugins/override/override_test.go
+++ b/pkg/plugins/override/override_test.go
@@ -1531,7 +1531,7 @@ func TestHandleStickyCancel(t *testing.T) {
 		expectedComment  string
 	}{
 		{
-			name: "cancel specific sticky override",
+			name: "cancel specific override",
 			body: "/override-cancel job-a",
 			statuses: []github.Status{
 				{Context: "job-a", State: github.StatusSuccess, Description: "Overridden by admin-user [prow:skip-retest]"},
@@ -1541,10 +1541,10 @@ func TestHandleStickyCancel(t *testing.T) {
 				{Context: "job-a", State: github.StatusFailure, Description: "Override cancelled by admin-user"},
 				{Context: "job-b", State: github.StatusSuccess, Description: "Overridden by admin-user [prow:skip-retest]"},
 			},
-			expectedComment: "Cancelled sticky overrides",
+			expectedComment: "Cancelled overrides",
 		},
 		{
-			name: "cancel all sticky overrides",
+			name: "cancel all overrides",
 			body: "/override-cancel",
 			statuses: []github.Status{
 				{Context: "job-a", State: github.StatusSuccess, Description: "Overridden by admin-user [prow:skip-retest]"},
@@ -1554,18 +1554,29 @@ func TestHandleStickyCancel(t *testing.T) {
 				{Context: "job-a", State: github.StatusFailure, Description: "Override cancelled by admin-user"},
 				{Context: "job-b", State: github.StatusFailure, Description: "Override cancelled by admin-user"},
 			},
-			expectedComment: "Cancelled sticky overrides",
+			expectedComment: "Cancelled overrides",
 		},
 		{
-			name: "cancel does not affect regular overrides",
+			name: "cancel also affects regular overrides",
 			body: "/override-cancel",
 			statuses: []github.Status{
 				{Context: "job-a", State: github.StatusSuccess, Description: "Overridden by admin-user"},
 			},
 			expectedStatuses: []github.Status{
-				{Context: "job-a", State: github.StatusSuccess, Description: "Overridden by admin-user"},
+				{Context: "job-a", State: github.StatusFailure, Description: "Override cancelled by admin-user"},
 			},
-			expectedComment: "No sticky overrides found to cancel",
+			expectedComment: "Cancelled overrides",
+		},
+		{
+			name: "cancel does not affect non-override statuses",
+			body: "/override-cancel",
+			statuses: []github.Status{
+				{Context: "job-a", State: github.StatusSuccess, Description: "Build succeeded"},
+			},
+			expectedStatuses: []github.Status{
+				{Context: "job-a", State: github.StatusSuccess, Description: "Build succeeded"},
+			},
+			expectedComment: "No overrides found to cancel",
 		},
 	}
 
@@ -1599,5 +1610,17 @@ func TestHandleStickyCancel(t *testing.T) {
 				t.Errorf("expected comment containing %q, got %q", tc.expectedComment, fc.comments[len(fc.comments)-1])
 			}
 		})
+	}
+}
+
+func TestStickyDescriptionFitsGitHubLimit(t *testing.T) {
+	maxUsername := strings.Repeat("x", 39)
+	desc := stickyDescription(maxUsername)
+	full := config.ContextDescriptionWithBaseSha(desc, strings.Repeat("f", 40))
+	if len(full) > 140 {
+		t.Errorf("sticky description with max-length username exceeds 140 chars: got %d (%q)", len(full), full)
+	}
+	if !strings.Contains(full, config.SkipRetestSentinel) {
+		t.Errorf("sticky description lost sentinel after ContextDescriptionWithBaseSha: %q", full)
 	}
 }

--- a/pkg/tide/tide.go
+++ b/pkg/tide/tide.go
@@ -46,7 +46,6 @@ import (
 	"sigs.k8s.io/prow/pkg/io"
 	"sigs.k8s.io/prow/pkg/kube"
 	"sigs.k8s.io/prow/pkg/pjutil"
-	"sigs.k8s.io/prow/pkg/plugins/override"
 	"sigs.k8s.io/prow/pkg/tide/blockers"
 	"sigs.k8s.io/prow/pkg/tide/history"
 	_ "sigs.k8s.io/prow/pkg/version"
@@ -1039,7 +1038,7 @@ func (c *syncController) accumulateBatch(sp subpool) (successBatch []CodeReviewC
 }
 
 // prowJobsFromContexts constructs ProwJob objects from successful presubmit contexts that either
-// include a matching baseSHA in their description or carry a sticky override sentinel.
+// include a matching baseSHA in their description or carry the skip-retest sentinel.
 // This is needed because otherwise we would always need retesting for results that are older than sinkers
 // max_prowjob_age.
 func (c *syncController) prowJobsFromContexts(pr *CodeReviewCommon, baseSHA string) ([]prowapi.ProwJob, error) {
@@ -1054,7 +1053,7 @@ func (c *syncController) prowJobsFromContexts(pr *CodeReviewCommon, baseSHA stri
 		}
 		desc := string(headContext.Description)
 		baseSHAForContext := config.BaseSHAFromContextDescription(desc)
-		if override.IsStickyOverride(desc) || baseSHAForContext != "" && baseSHAForContext == baseSHA {
+		if config.IsSkipRetest(desc) || baseSHAForContext != "" && baseSHAForContext == baseSHA {
 			passingCurrentContexts = append(passingCurrentContexts, string(headContext.Context))
 		}
 	}

--- a/pkg/tide/tide.go
+++ b/pkg/tide/tide.go
@@ -1038,7 +1038,8 @@ func (c *syncController) accumulateBatch(sp subpool) (successBatch []CodeReviewC
 	return successBatch, pendingBatch
 }
 
-// prowJobsFromContexts constructs ProwJob objects from all successful presubmit contexts that include a baseSHA.
+// prowJobsFromContexts constructs ProwJob objects from successful presubmit contexts that either
+// include a matching baseSHA in their description or carry a sticky override sentinel.
 // This is needed because otherwise we would always need retesting for results that are older than sinkers
 // max_prowjob_age.
 func (c *syncController) prowJobsFromContexts(pr *CodeReviewCommon, baseSHA string) ([]prowapi.ProwJob, error) {

--- a/pkg/tide/tide.go
+++ b/pkg/tide/tide.go
@@ -1053,7 +1053,7 @@ func (c *syncController) prowJobsFromContexts(pr *CodeReviewCommon, baseSHA stri
 		}
 		desc := string(headContext.Description)
 		baseSHAForContext := config.BaseSHAFromContextDescription(desc)
-		if config.IsSkipRetest(desc) || baseSHAForContext != "" && baseSHAForContext == baseSHA {
+		if config.IsSkipRetest(desc) || (baseSHAForContext != "" && baseSHAForContext == baseSHA) {
 			passingCurrentContexts = append(passingCurrentContexts, string(headContext.Context))
 		}
 	}

--- a/pkg/tide/tide.go
+++ b/pkg/tide/tide.go
@@ -46,6 +46,7 @@ import (
 	"sigs.k8s.io/prow/pkg/io"
 	"sigs.k8s.io/prow/pkg/kube"
 	"sigs.k8s.io/prow/pkg/pjutil"
+	"sigs.k8s.io/prow/pkg/plugins/override"
 	"sigs.k8s.io/prow/pkg/tide/blockers"
 	"sigs.k8s.io/prow/pkg/tide/history"
 	_ "sigs.k8s.io/prow/pkg/version"
@@ -1050,8 +1051,10 @@ func (c *syncController) prowJobsFromContexts(pr *CodeReviewCommon, baseSHA stri
 		if headContext.State != githubql.StatusStateSuccess {
 			continue
 		}
-		if baseSHAForContext := config.BaseSHAFromContextDescription(string(headContext.Description)); baseSHAForContext != "" && baseSHAForContext == baseSHA {
-			passingCurrentContexts = append(passingCurrentContexts, string((headContext.Context)))
+		desc := string(headContext.Description)
+		baseSHAForContext := config.BaseSHAFromContextDescription(desc)
+		if override.IsStickyOverride(desc) || baseSHAForContext != "" && baseSHAForContext == baseSHA {
+			passingCurrentContexts = append(passingCurrentContexts, string(headContext.Context))
 		}
 	}
 


### PR DESCRIPTION
Adds `/override-sticky` — a variant of `/override` that persists across Tide retests on the same PR HEAD SHA. Regular `/override` now also embeds the baseSHA in the status description, fixing a bug where overrides expired after ~48h when Sinker reaped the synthetic ProwJob.

### Commands

- `/override <context>` — forces a context to green. Expires when the base branch moves (same behavior as any normal CI result).
- `/override-sticky <context>` — forces a context to green and persists across base branch movement. Pushing a new commit clears it (new SHA = clean slate).
- `/override-cancel [context]` — removes sticky overrides. If no context given, cancels all sticky overrides on the PR.

### How it works

- Sticky overrides embed a `[prow:skip-retest]` sentinel in the GitHub status description. This is a generic contract owned by `config` (not override-specific) — Tide treats any successful status with this sentinel as permanently passing for the current HEAD SHA.
- Regular overrides now embed the baseSHA via `config.ContextDescriptionWithBaseSha()`, so Tide can synthesize passing ProwJobs after Sinker reaps the originals.
- Tide no longer imports the override plugin. The dependency direction is: override consumes Tide/config contracts, not the other way around.
- Trigger doesn't need changes — `/test` commands re-trigger regardless of override status, and `/retest` naturally skips successful contexts.

Fixes kubernetes-sigs/prow#768