### PR TITLE
git: Disable gc.autoDetach to prevent zombie processes

### DIFF
--- a/pkg/git/v2/executor.go
+++ b/pkg/git/v2/executor.go
@@ -60,7 +60,9 @@ func NewCensoringExecutor(dir string, censor Censor, logger *logrus.Entry) (exec
 		git:    g,
 		censor: censor,
 		execute: func(dir, command string, args ...string) ([]byte, error) {
-			c := exec.Command(command, args...)
+			// gc.autoDetach=false prevents git gc --auto from forking a detached
+			// background process, which would become a zombie when running as PID 1.
+			c := exec.Command(command, append([]string{"-c", "gc.autoDetach=false"}, args...)...)
 			c.Dir = dir
 			return c.CombinedOutput()
 		},


### PR DESCRIPTION
Prow components that use git (e.g. tide, hook) accumulate zombie `[git]` processes when running as PID 1 in a container. Git operations internally trigger `git gc --auto`, which by default forks a detached background process (`gc.autoDetach` defaults to `true` since git 2.0). Go's runtime at PID 1 only reaps children it created via `os/exec`, not orphaned processes reparented from exited git commands.

Passes `-c gc.autoDetach=false` to every git invocation in the censoring executor, making gc run synchronously so it gets properly reaped.