### PR TITLE
deck: filter tide history per-record instead of per-pool

### DIFF
--- a/cmd/deck/tide.go
+++ b/cmd/deck/tide.go
@@ -187,23 +187,21 @@ func noTenantIDOrDefaultTenantID(ids []string) bool {
 	return true
 }
 
-func recordIDs(records []history.Record) sets.Set[string] {
-	res := sets.Set[string]{}
-	for _, record := range records {
-		res.Insert(record.TenantIDs...)
-	}
-	return res
-}
-
 func (ta *tideAgent) filterHistory(hist map[string][]history.Record) map[string][]history.Record {
 	filtered := make(map[string][]history.Record, len(hist))
 	for pool, records := range hist {
 		orgRepo := strings.Split(pool, ":")[0]
-		curIDs := recordIDs(records).Insert()
 		orgRepoID := ta.cfg().GetProwJobDefault(orgRepo, "*").TenantID
 		needsHide := matches(orgRepo, ta.hiddenRepos())
-		if match := ta.filter(orgRepoID, curIDs, needsHide); match {
-			filtered[pool] = records
+		var filteredRecords []history.Record
+		for _, record := range records {
+			curIDs := sets.New[string](record.TenantIDs...)
+			if match := ta.filter(orgRepoID, curIDs, needsHide); match {
+				filteredRecords = append(filteredRecords, record)
+			}
+		}
+		if len(filteredRecords) > 0 {
+			filtered[pool] = filteredRecords
 		}
 	}
 	return filtered

--- a/cmd/deck/tide_test.go
+++ b/cmd/deck/tide_test.go
@@ -535,7 +535,7 @@ func TestFilter(t *testing.T) {
 			},
 			expectedHist: map[string][]history.Record{
 				"tenanted/test:master":         {{Action: "TRIGGER_BATCH"}, {Action: "MERGE_BATCH"}},
-				"clustered-tenant/test:master": {{Action: "TRIGGER_BATCH", TenantIDs: []string{"t"}}, {Action: "MERGE_BATCH"}},
+				"clustered-tenant/test:master": {{Action: "TRIGGER_BATCH", TenantIDs: []string{"t"}}},
 			},
 		},
 		{
@@ -589,7 +589,7 @@ func TestFilter(t *testing.T) {
 			},
 			expectedHist: map[string][]history.Record{
 				"tenanted/test:master":         {{Action: "TRIGGER_BATCH"}, {Action: "MERGE_BATCH"}},
-				"clustered-tenant/test:master": {{Action: "TRIGGER_BATCH", TenantIDs: []string{"t"}}, {Action: "MERGE_BATCH"}},
+				"clustered-tenant/test:master": {{Action: "TRIGGER_BATCH", TenantIDs: []string{"t"}}},
 			},
 		},
 		{
@@ -731,6 +731,32 @@ func TestFilter(t *testing.T) {
 			expectedHist: map[string][]history.Record{
 				"kubernetes/test-infra:master": {{Action: "MERGE", TenantIDs: []string{config.DefaultTenantID}}},
 				"upstream/no-prow-jobs:main":   {{Action: "MERGE"}},
+			},
+		},
+		{
+			name: "per-record filtering keeps matching records when pool has mixed tenant IDs",
+
+			tenantIDs: []string{config.DefaultTenantID},
+			pools: []tide.Pool{
+				{Org: "kubernetes", Repo: "test-infra", TenantIDs: []string{config.DefaultTenantID}},
+			},
+			hist: map[string][]history.Record{
+				"kubernetes/test-infra:master": {
+					{Action: "MERGE", TenantIDs: []string{config.DefaultTenantID}},
+					{Action: "TRIGGER", TenantIDs: []string{config.DefaultTenantID, "private"}},
+					{Action: "MERGE_BATCH", TenantIDs: []string{"private"}},
+					{Action: "TRIGGER_BATCH"},
+				},
+			},
+
+			expectedPools: []tide.Pool{
+				{Org: "kubernetes", Repo: "test-infra", TenantIDs: []string{config.DefaultTenantID}},
+			},
+			expectedHist: map[string][]history.Record{
+				"kubernetes/test-infra:master": {
+					{Action: "MERGE", TenantIDs: []string{config.DefaultTenantID}},
+					{Action: "TRIGGER_BATCH"},
+				},
 			},
 		},
 	}


### PR DESCRIPTION
`filterHistory` previously aggregated tenant IDs from all records in a pool into a single set, then used `HasAll` to check if Deck's tenant IDs were a superset. A single record with a non-matching tenant ID caused the entire pool's history to be hidden.

Changed to evaluate each record individually: records with matching tenant IDs are kept, others are dropped. Pools with at least one matching record remain visible.

This fixes tide history being completely invisible for repositories where some records (e.g. from batch merges) carry tenant IDs that the serving Deck instance is not configured for.