### PR TITLE
spyglass/junit: deduplicate test detail row rendering

### DIFF
--- a/pkg/spyglass/lenses/junit/junit.css
+++ b/pkg/spyglass/lenses/junit/junit.css
@@ -45,17 +45,17 @@ td.skipped {
   color: #ffe62d;
 }
 
-.failed-layout, .group-layout, .flaky-layout {
+.detail-layout {
   width: 100%;
   border-collapse: collapse;
 }
 
-.failed-layout td, .group-layout td, .flaky-layout td {
+.detail-layout td {
   border: 0;
   padding: 0;
 }
 
-.failure-name, .group-name, .flaky-name {
+.detail-name {
   cursor: pointer;
 }
 
@@ -68,19 +68,11 @@ td {
   background-color: unset !important;
 }
 
-table.failed-layout tbody tr.failure-text:hover {
+table.detail-layout tbody tr.detail-text:hover {
   background-color: unset !important;
 }
 
-table.group-layout tbody tr.group-text:hover {
-  background-color: unset !important;
-}
-
-table.flaky-layout tbody tr.flaky-text:hover {
-  background-color: unset !important;
-}
-
-.failure-text div, .group-text div, .flaky-text div {
+.detail-text div {
   padding-left: 20px;
   padding-right: 20px;
   white-space: pre-wrap;
@@ -88,7 +80,7 @@ table.flaky-layout tbody tr.flaky-text:hover {
   padding-bottom: 10px;
 }
 
-.failure-text td, .group-text td, .flaky-text td {
+.detail-text td {
   padding-bottom: 15px;
 }
 

--- a/pkg/spyglass/lenses/junit/lens.ts
+++ b/pkg/spyglass/lenses/junit/lens.ts
@@ -17,7 +17,7 @@ const addSectionExpanders = (): void => {
 };
 
 const addTestExpanders = (): void => {
-  const rows = document.querySelectorAll<HTMLTableRowElement>('.failure-name,.group-name,.flaky-name');
+  const rows = document.querySelectorAll<HTMLTableRowElement>('.detail-name');
   for (const row of Array.from(rows)) {
     row.onclick = () => {
       const sibling = row.nextElementSibling;

--- a/pkg/spyglass/lenses/junit/lens_test.go
+++ b/pkg/spyglass/lenses/junit/lens_test.go
@@ -1234,7 +1234,7 @@ func TestTemplate(t *testing.T) {
 				`Informing`,
 				`1/2 Failed.`,
 				`1/2 Passed.`,
-				`group-layout`,
+				`detail-layout`,
 				`fake_class: informing_fail`,
 				`hidden-tests`,
 			},

--- a/pkg/spyglass/lenses/junit/template.html
+++ b/pkg/spyglass/lenses/junit/template.html
@@ -1,3 +1,76 @@
+{{define "test-detail-rows"}}
+  {{range $ix, $test := .}}
+    {{$numTest := len $test.Junit}}
+    {{$firstTest := index $test.Junit 0}}
+    {{if eq $numTest 1}}
+    <tr>
+      <td colspan="2" style="padding: 0;">
+        <table class="detail-layout">
+          <tr class="detail-name">
+            <td class="mdl-data-table__cell--non-numeric test-name">{{$firstTest.ClassName}}: {{$firstTest.Name}}&nbsp;<i class="icon-button material-icons arrow-icon">expand_more</i></td>
+            <td class="mdl-data-table__cell--non-numeric" style="text-align: right;">{{$firstTest.Duration}}</td>
+          </tr>
+          <tr class="hidden detail-text">
+            <td colspan="2" class="mdl-data-table__cell--non-numeric">
+              <div>{{$firstTest.Failure}}</div>
+              {{if $firstTest.Output}}
+              <a href="#" class="open-stdout-stderr">open stdout<i class="material-icons" style="font-size: 1em; vertical-align: middle; padding-left: 3px;">open_in_new</i></a>
+              <pre style="display: none;">{{$firstTest.Output}}</pre>
+              {{end}}
+              {{if $firstTest.Error}}
+              <a href="#" class="open-stdout-stderr">open stderr<i class="material-icons" style="font-size: 1em; vertical-align: middle; padding-left: 3px;">open_in_new</i></a>
+              <pre style="display: none;">{{$firstTest.Error}}</pre>
+              {{end}}
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+    {{else}}
+    <tr>
+      <td colspan="2" style="padding: 0;">
+        <table class="detail-layout">
+          <tr class="detail-name">
+            <td class="mdl-data-table__cell--non-numeric test-name">{{$firstTest.ClassName}}: {{$firstTest.Name}}&nbsp;<i class="icon-button material-icons arrow-icon">expand_more</i></td>
+          </tr>
+          <tr class="hidden">
+            <td>
+              <table  class="detail-layout">
+                {{range $ixt, $indTest := $test.Junit}}
+                <tr  class="detail-text">
+                  <td colspan="2" style="padding: 0;">
+                    <table class="detail-layout">
+                      <tr class="detail-name">
+                        <td class="mdl-data-table__cell--non-numeric test-name">Run #{{$ixt}}: {{$indTest.Status}}&nbsp;<i class="icon-button material-icons arrow-icon">expand_more</i></td>
+                        <td class="mdl-data-table__cell--non-numeric" style="text-align: right;">{{$indTest.Duration}}</td>
+                      </tr>
+                      <tr class="hidden detail-text">
+                        <td colspan="2" class="mdl-data-table__cell--non-numeric">
+                          <div>{{$indTest.Failure}}</div>
+                          {{if $indTest.Output}}
+                          <a href="#" class="open-stdout-stderr">open stdout<i class="material-icons" style="font-size: 1em; vertical-align: middle; padding-left: 3px;">open_in_new</i></a>
+                          <pre style="display: none;">{{$indTest.Output}}</pre>
+                          {{end}}
+                          {{if $indTest.Error}}
+                          <a href="#" class="open-stdout-stderr">open stderr<i class="material-icons" style="font-size: 1em; vertical-align: middle; padding-left: 3px;">open_in_new</i></a>
+                          <pre style="display: none;">{{$indTest.Error}}</pre>
+                          {{end}}
+                        </td>
+                      </tr>
+                    </table>
+                  </td>
+                </tr>
+                {{end}}
+              </table>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+    {{end}}
+  {{end}}
+{{end}}
+
 {{define "header"}}
 <link rel="stylesheet" type="text/css" href="junit.css">
 <script type="text/javascript" src="script_bundle.min.js"></script>
@@ -21,76 +94,7 @@
     <td class="mdl-data-table__cell--non-numeric expander"><i id="failed-expander" class="icon-button material-icons arrow-icon noselect">expand_less</i></td>
   </tr>
   <tbody id="failed-tbody">
-    {{range $ix, $test := .Failed}}
-      {{$numTest := len $test.Junit}}
-      {{$firstTest := index $test.Junit 0}}
-      {{if eq $numTest 1}}
-      <tr>
-        <td colspan="2" style="padding: 0;">
-          <table class="failed-layout">
-            <tr class="failure-name">
-              <td class="mdl-data-table__cell--non-numeric test-name">{{$firstTest.ClassName}}: {{$firstTest.Name}}&nbsp;<i class="icon-button material-icons arrow-icon">expand_more</i></td>
-              <td class="mdl-data-table__cell--non-numeric" style="text-align: right;">{{$firstTest.Duration}}</td>
-            </tr>
-            <tr class="hidden failure-text">
-              <td colspan="2" class="mdl-data-table__cell--non-numeric">
-                <div>{{$firstTest.Failure}}</div>
-                {{if $firstTest.Output}}
-                <a href="#" class="open-stdout-stderr">open stdout<i class="material-icons" style="font-size: 1em; vertical-align: middle; padding-left: 3px;">open_in_new</i></a>
-                <pre style="display: none;">{{$firstTest.Output}}</pre>
-                {{end}}
-                {{if $firstTest.Error}}
-                <a href="#" class="open-stdout-stderr">open stderr<i class="material-icons" style="font-size: 1em; vertical-align: middle; padding-left: 3px;">open_in_new</i></a>
-                <pre style="display: none;">{{$firstTest.Error}}</pre>
-                {{end}}
-              </td>
-            </tr>
-          </table>
-        </td>
-      </tr>
-      {{else}}
-      <tr>
-        <td colspan="2" style="padding: 0;">
-          <table class="failed-layout">
-            <tr class="failure-name">
-              <td class="mdl-data-table__cell--non-numeric test-name">{{$firstTest.ClassName}}: {{$firstTest.Name}}&nbsp;<i class="icon-button material-icons arrow-icon">expand_more</i></td>
-            </tr>
-            <tr class="hidden">
-              <td>
-                <table  class="failed-layout">
-                  {{range $ixt, $indTest := $test.Junit}}
-                  <tr  class="failure-text">
-                    <td colspan="2" style="padding: 0;">
-                      <table class="failed-layout">
-                        <tr class="failure-name">
-                          <td class="mdl-data-table__cell--non-numeric test-name">Run #{{$ixt}}: {{$indTest.Status}}&nbsp;<i class="icon-button material-icons arrow-icon">expand_more</i></td>
-                          <td class="mdl-data-table__cell--non-numeric" style="text-align: right;">{{$indTest.Duration}}</td>
-                        </tr>
-                        <tr class="hidden failure-text">
-                          <td colspan="2" class="mdl-data-table__cell--non-numeric">
-                            <div>{{$indTest.Failure}}</div>
-                            {{if $indTest.Output}}
-                            <a href="#" class="open-stdout-stderr">open stdout<i class="material-icons" style="font-size: 1em; vertical-align: middle; padding-left: 3px;">open_in_new</i></a>
-                            <pre style="display: none;">{{$indTest.Output}}</pre>
-                            {{end}}
-                            {{if $indTest.Error}}
-                            <a href="#" class="open-stdout-stderr">open stderr<i class="material-icons" style="font-size: 1em; vertical-align: middle; padding-left: 3px;">open_in_new</i></a>
-                            <pre style="display: none;">{{$indTest.Error}}</pre>
-                            {{end}}
-                          </td>
-                        </tr>
-                      </table>
-                    </td>
-                  </tr>
-                  {{end}}
-                </table>
-              </td>
-            </tr>
-          </table>
-        </td>
-      </tr>
-      {{end}}
-    {{end}}
+    {{template "test-detail-rows" .Failed}}
   </tbody>
   {{end}}
   {{if gt $numFlk 0}}
@@ -99,49 +103,7 @@
     <td class="mdl-data-table__cell--non-numeric expander"><i id="flaky-expander" class="icon-button material-icons arrow-icon noselect">expand_less</i></td>
   </tr>
   <tbody id="flaky-tbody">
-    {{range $ix, $test := .Flaky}}
-      {{$firstTest := index $test.Junit 0}}
-      <tr>
-        <td colspan="2" style="padding: 0;">
-          <table class="flaky-layout">
-            <tr class="flaky-name">
-              <td class="mdl-data-table__cell--non-numeric test-name">{{$firstTest.ClassName}}: {{$firstTest.Name}}&nbsp;<i class="icon-button material-icons arrow-icon">expand_more</i></td>
-            </tr>
-            <tr class="hidden">
-              <td>
-                <table class="flaky-layout">
-                  {{range $ixt, $indTest := $test.Junit}}
-                  <tr  class="flaky-text">
-                    <td colspan="2" style="padding: 0;">
-                      <table class="flaky-layout">
-                        <tr class="flaky-name">
-                          <td class="mdl-data-table__cell--non-numeric test-name">Run #{{$ixt}}: {{$indTest.Status}}&nbsp;<i class="icon-button material-icons arrow-icon">expand_more</i></td>
-                          <td class="mdl-data-table__cell--non-numeric" style="text-align: right;">{{$indTest.Duration}}</td>
-                        </tr>
-                        <tr class="hidden flaky-text">
-                          <td colspan="2" class="mdl-data-table__cell--non-numeric">
-                            <div>{{$indTest.Failure}}</div>
-                            {{if $indTest.Output}}
-                            <a href="#" class="open-stdout-stderr">open stdout<i class="material-icons" style="font-size: 1em; vertical-align: middle; padding-left: 3px;">open_in_new</i></a>
-                            <pre style="display: none;">{{$indTest.Output}}</pre>
-                            {{end}}
-                            {{if $indTest.Error}}
-                            <a href="#" class="open-stdout-stderr">open stderr<i class="material-icons" style="font-size: 1em; vertical-align: middle; padding-left: 3px;">open_in_new</i></a>
-                            <pre style="display: none;">{{$indTest.Error}}</pre>
-                            {{end}}
-                          </td>
-                        </tr>
-                      </table>
-                    </td>
-                  </tr>
-                  {{end}}
-                </table>
-              </td>
-            </tr>
-          </table>
-        </td>
-      </tr>
-    {{end}}
+    {{template "test-detail-rows" .Flaky}}
   </tbody>
   {{end}}
   {{if gt $numP 0}}
@@ -193,76 +155,7 @@
     <td class="mdl-data-table__cell--non-numeric expander"><i class="icon-button material-icons arrow-icon noselect">{{if $group.Collapsed}}expand_more{{else}}expand_less{{end}}</i></td>
   </tr>
   <tbody class="group-tbody{{if $group.Collapsed}} hidden-tests{{end}}">
-    {{range $ix, $test := $group.Failed}}
-      {{$numTest := len $test.Junit}}
-      {{$firstTest := index $test.Junit 0}}
-      {{if eq $numTest 1}}
-      <tr>
-        <td colspan="2" style="padding: 0;">
-          <table class="group-layout">
-            <tr class="group-name">
-              <td class="mdl-data-table__cell--non-numeric test-name">{{$firstTest.ClassName}}: {{$firstTest.Name}}&nbsp;<i class="icon-button material-icons arrow-icon">expand_more</i></td>
-              <td class="mdl-data-table__cell--non-numeric" style="text-align: right;">{{$firstTest.Duration}}</td>
-            </tr>
-            <tr class="hidden group-text">
-              <td colspan="2" class="mdl-data-table__cell--non-numeric">
-                <div>{{$firstTest.Failure}}</div>
-                {{if $firstTest.Output}}
-                <a href="#" class="open-stdout-stderr">open stdout<i class="material-icons" style="font-size: 1em; vertical-align: middle; padding-left: 3px;">open_in_new</i></a>
-                <pre style="display: none;">{{$firstTest.Output}}</pre>
-                {{end}}
-                {{if $firstTest.Error}}
-                <a href="#" class="open-stdout-stderr">open stderr<i class="material-icons" style="font-size: 1em; vertical-align: middle; padding-left: 3px;">open_in_new</i></a>
-                <pre style="display: none;">{{$firstTest.Error}}</pre>
-                {{end}}
-              </td>
-            </tr>
-          </table>
-        </td>
-      </tr>
-      {{else}}
-      <tr>
-        <td colspan="2" style="padding: 0;">
-          <table class="group-layout">
-            <tr class="group-name">
-              <td class="mdl-data-table__cell--non-numeric test-name">{{$firstTest.ClassName}}: {{$firstTest.Name}}&nbsp;<i class="icon-button material-icons arrow-icon">expand_more</i></td>
-            </tr>
-            <tr class="hidden">
-              <td>
-                <table class="group-layout">
-                  {{range $ixt, $indTest := $test.Junit}}
-                  <tr class="group-text">
-                    <td colspan="2" style="padding: 0;">
-                      <table class="group-layout">
-                        <tr class="group-name">
-                          <td class="mdl-data-table__cell--non-numeric test-name">Run #{{$ixt}}: {{$indTest.Status}}&nbsp;<i class="icon-button material-icons arrow-icon">expand_more</i></td>
-                          <td class="mdl-data-table__cell--non-numeric" style="text-align: right;">{{$indTest.Duration}}</td>
-                        </tr>
-                        <tr class="hidden group-text">
-                          <td colspan="2" class="mdl-data-table__cell--non-numeric">
-                            <div>{{$indTest.Failure}}</div>
-                            {{if $indTest.Output}}
-                            <a href="#" class="open-stdout-stderr">open stdout<i class="material-icons" style="font-size: 1em; vertical-align: middle; padding-left: 3px;">open_in_new</i></a>
-                            <pre style="display: none;">{{$indTest.Output}}</pre>
-                            {{end}}
-                            {{if $indTest.Error}}
-                            <a href="#" class="open-stdout-stderr">open stderr<i class="material-icons" style="font-size: 1em; vertical-align: middle; padding-left: 3px;">open_in_new</i></a>
-                            <pre style="display: none;">{{$indTest.Error}}</pre>
-                            {{end}}
-                          </td>
-                        </tr>
-                      </table>
-                    </td>
-                  </tr>
-                  {{end}}
-                </table>
-              </td>
-            </tr>
-          </table>
-        </td>
-      </tr>
-      {{end}}
-    {{end}}
+    {{template "test-detail-rows" $group.Failed}}
   </tbody>
   {{end}}
   {{if gt $gNumFlk 0}}
@@ -271,49 +164,7 @@
     <td class="mdl-data-table__cell--non-numeric expander"><i class="icon-button material-icons arrow-icon noselect">{{if $group.Collapsed}}expand_more{{else}}expand_less{{end}}</i></td>
   </tr>
   <tbody class="group-tbody{{if $group.Collapsed}} hidden-tests{{end}}">
-    {{range $ix, $test := $group.Flaky}}
-      {{$firstTest := index $test.Junit 0}}
-      <tr>
-        <td colspan="2" style="padding: 0;">
-          <table class="group-layout">
-            <tr class="group-name">
-              <td class="mdl-data-table__cell--non-numeric test-name">{{$firstTest.ClassName}}: {{$firstTest.Name}}&nbsp;<i class="icon-button material-icons arrow-icon">expand_more</i></td>
-            </tr>
-            <tr class="hidden">
-              <td>
-                <table class="group-layout">
-                  {{range $ixt, $indTest := $test.Junit}}
-                  <tr class="group-text">
-                    <td colspan="2" style="padding: 0;">
-                      <table class="group-layout">
-                        <tr class="group-name">
-                          <td class="mdl-data-table__cell--non-numeric test-name">Run #{{$ixt}}: {{$indTest.Status}}&nbsp;<i class="icon-button material-icons arrow-icon">expand_more</i></td>
-                          <td class="mdl-data-table__cell--non-numeric" style="text-align: right;">{{$indTest.Duration}}</td>
-                        </tr>
-                        <tr class="hidden group-text">
-                          <td colspan="2" class="mdl-data-table__cell--non-numeric">
-                            <div>{{$indTest.Failure}}</div>
-                            {{if $indTest.Output}}
-                            <a href="#" class="open-stdout-stderr">open stdout<i class="material-icons" style="font-size: 1em; vertical-align: middle; padding-left: 3px;">open_in_new</i></a>
-                            <pre style="display: none;">{{$indTest.Output}}</pre>
-                            {{end}}
-                            {{if $indTest.Error}}
-                            <a href="#" class="open-stdout-stderr">open stderr<i class="material-icons" style="font-size: 1em; vertical-align: middle; padding-left: 3px;">open_in_new</i></a>
-                            <pre style="display: none;">{{$indTest.Error}}</pre>
-                            {{end}}
-                          </td>
-                        </tr>
-                      </table>
-                    </td>
-                  </tr>
-                  {{end}}
-                </table>
-              </td>
-            </tr>
-          </table>
-        </td>
-      </tr>
-    {{end}}
+    {{template "test-detail-rows" $group.Flaky}}
   </tbody>
   {{end}}
   {{if gt $gNumP 0}}
@@ -356,4 +207,3 @@
 </div>
 {{end}}
 {{end}}
-


### PR DESCRIPTION
Extract a shared "test-detail-rows" sub-template for the expandable test result rows that were duplicated four times across the default failed/flaky and group failed/flaky sections. Unify the CSS class names (failure-*/flaky-*/group-* -> detail-*) and collapse the redundant selectors in junit.css.

Assisted by Claude Code

