### PR TITLE
verify_boilerplate: use current year instead of hardcoded range

### DIFF
--- a/hack/boilerplate/verify_boilerplate.py
+++ b/hack/boilerplate/verify_boilerplate.py
@@ -215,7 +215,7 @@ def get_files(extensions):
 
 
 def get_dates():
-    year_alternatives = '|'.join((str(year) for year in range(2014, 2026)))
+    year_alternatives = '|'.join((str(year) for year in range(2014, datetime.date.today().year + 1)))
     return r'Copyright (?:(?:%s) )?' % year_alternatives
 
 
@@ -223,7 +223,7 @@ def get_regexs():
     regexs = {}
     # Search for "YEAR" which exists in the boilerplate, but shouldn't in the real thing
     regexs["year"] = re.compile('YEAR')
-    # dates can be any year between 2014 and the current year, company holder names can be anything
+    # dates can be any year between 2014 and the current year (inclusive), company holder names can be anything
     regexs["date"] = re.compile(get_dates())
     # strip // +build \n\n build constraints
     regexs["go_build_constraints"] = re.compile(r"^(//( \+build|go:build).*\n)+\n",


### PR DESCRIPTION
## Summary
- The copyright year range in `verify_boilerplate.py` was hardcoded to `range(2014, 2026)`, which excluded 2026 and would need a manual bump every January.
- Changed to `range(2014, datetime.date.today().year + 1)` so the checker automatically accepts the current year.

## Test plan
- [x] Verified a file with `Copyright 2026` passes the checker after this change
- [x] Verified existing files still pass