### PR TITLE
checkconfig: include branch-protection branches in tide context policy validation

### DIFF
--- a/cmd/checkconfig/main.go
+++ b/cmd/checkconfig/main.go
@@ -1195,6 +1195,18 @@ func validateTideContextPolicy(cfg *config.Config) error {
 		}
 	}
 
+	for orgName, org := range cfg.BranchProtection.Orgs {
+		for repoName, repo := range org.Repos {
+			orgRepo := orgName + "/" + repoName
+			if _, ok := allKnownOrgRepoBranches[orgRepo]; !ok {
+				allKnownOrgRepoBranches[orgRepo] = sets.Set[string]{}
+			}
+			for branchName := range repo.Branches {
+				allKnownOrgRepoBranches[orgRepo].Insert(branchName)
+			}
+		}
+	}
+
 	// We have to disableInRepoConfig for this check, else we will
 	// attempt to clone the repo if its enabled
 	originalInRepoConfig := cfg.InRepoConfig

--- a/cmd/checkconfig/main_test.go
+++ b/cmd/checkconfig/main_test.go
@@ -1684,6 +1684,35 @@ func TestValidateTideContextPolicy(t *testing.T) {
 			}),
 		},
 		{
+			name: "bp required context collides with conditionally-triggered job via from-branch-protection",
+			cfg: cfg(func(c *config.Config) {
+				c.PresubmitsStatic["a/b"] = []config.Presubmit{
+					{
+						Reporter:           config.Reporter{Context: "ci/prow/test"},
+						Brancher:           config.Brancher{Branches: []string{`^master$`}},
+						RegexpChangeMatcher: config.RegexpChangeMatcher{SkipIfOnlyChanged: `\.md$`},
+					},
+				}
+				yes := true
+				c.Tide.ContextOptions.FromBranchProtection = &yes
+				c.BranchProtection = config.BranchProtection{
+					Orgs: map[string]config.Org{
+						"a": {Repos: map[string]config.Repo{
+							"b": {Branches: map[string]config.Branch{
+								"master": {Policy: config.Policy{
+									Protect: &yes,
+									RequiredStatusChecks: &config.ContextPolicy{
+										Contexts: []string{"ci/prow/test"},
+									},
+								}},
+							}},
+						}},
+					},
+				}
+			}),
+			expectedError: "context policy for master branch in a/b is invalid: contexts ci/prow/test are defined as required and required if present",
+		},
+		{
 			name: "repo key is not in org/repo format, no error",
 			cfg: cfg(func(c *config.Config) {
 				c.PresubmitsStatic["https://kunit-review.googlesource.com/linux"] = []config.Presubmit{


### PR DESCRIPTION
`validateTideContextPolicy` collects branches from job `Brancher.Branches` fields, which contain regexes (e.g. `^master$`). It passes these as literal branch names to `GetTideContextPolicy`, which looks up BP config by literal branch name. Since `^master$` ≠ `master`, BP-related context policy collisions were never detected at config time.

Now also collects branches from `BranchProtection.Orgs[org].Repos[repo].Branches`, which are literal names that match BP lookups correctly. This closes a gap where `checkconfig --strict --warnings tide-context-policy` would pass clean even when the config had a collision that breaks Tide at runtime (contexts appearing in both `RequiredContexts` via BP and `RequiredIfPresentContexts` via conditionally-triggered jobs).

Verified against a real config with `from-branch-protection: true`: the fix detects collisions in 7 repos that were previously missed.

Ref: #777