### PR TITLE
checkconfig: include tide context_options branches in tide context policy validation

### DIFF
--- a/cmd/checkconfig/main.go
+++ b/cmd/checkconfig/main.go
@@ -1207,6 +1207,18 @@ func validateTideContextPolicy(cfg *config.Config) error {
 		}
 	}
 
+	for orgName, org := range cfg.Tide.ContextOptions.Orgs {
+		for repoName, repo := range org.Repos {
+			orgRepo := orgName + "/" + repoName
+			if _, ok := allKnownOrgRepoBranches[orgRepo]; !ok {
+				allKnownOrgRepoBranches[orgRepo] = sets.Set[string]{}
+			}
+			for branchName := range repo.Branches {
+				allKnownOrgRepoBranches[orgRepo].Insert(branchName)
+			}
+		}
+	}
+
 	// We have to disableInRepoConfig for this check, else we will
 	// attempt to clone the repo if its enabled
 	originalInRepoConfig := cfg.InRepoConfig

--- a/cmd/checkconfig/main_test.go
+++ b/cmd/checkconfig/main_test.go
@@ -1713,6 +1713,27 @@ func TestValidateTideContextPolicy(t *testing.T) {
 			expectedError: "context policy for master branch in a/b is invalid: contexts ci/prow/test are defined as required and required if present",
 		},
 		{
+			name: "tide context_options required-if-present collides with optional job",
+			cfg: cfg(func(c *config.Config) {
+				c.PresubmitsStatic["a/b"] = []config.Presubmit{
+					{
+						Optional:            true,
+						Reporter:            config.Reporter{Context: "ci/prow/coverage"},
+						Brancher:            config.Brancher{Branches: []string{`^master$`}},
+						RegexpChangeMatcher: config.RegexpChangeMatcher{SkipIfOnlyChanged: `\.md$`},
+					},
+				}
+				c.Tide.ContextOptions.Orgs = map[string]config.TideOrgContextPolicy{
+					"a": {Repos: map[string]config.TideRepoContextPolicy{
+						"b": {Branches: map[string]config.TideContextPolicy{
+							"master": {RequiredIfPresentContexts: []string{"ci/prow/coverage"}},
+						}},
+					}},
+				}
+			}),
+			expectedError: "context policy for master branch in a/b is invalid: contexts ci/prow/coverage are defined as optional and required if present",
+		},
+		{
 			name: "repo key is not in org/repo format, no error",
 			cfg: cfg(func(c *config.Config) {
 				c.PresubmitsStatic["https://kunit-review.googlesource.com/linux"] = []config.Presubmit{


### PR DESCRIPTION
Branches explicitly configured in `tide context_options` were not included in the set of branches validated by `validateTideContextPolicy`. This meant a conflict between an optional job and a `required-if-present` context defined in `context_options` for that branch would go undetected at checkconfig time, only surfacing as a runtime policy error like:

```
{"branch":"master","component":"unset","controller":"status-update","error":"failed to set up context register: contexts ci/prow/coverage, ci/prow/e2e-binary-build-success, ci/prow/lint, ci/prow/test, ci/prow/validate are defined as optional and required if present","file":"/src/pkg/tide/status.go:457","func":"sigs.k8s.io/prow/pkg/tide.(*statusController).setStatuses.func1","level":"error","msg":"getting expected status","org":"openshift","pr":302,"repo":"ocm-agent-operator","severity":"error","sha":"4d120838d170ab322cbd1dae97e665fd6bc5ae4c","time":"2026-07-02T09:18:07Z"}
```

This extends the branch collection to also walk `cfg.Tide.ContextOptions.Orgs[org].Repos[repo].Branches` — following the same pattern used for branch-protection branches added in #791.

A new test case covers the scenario: an optional presubmit whose context appears as `required-if-present-contexts` in `context_options` for the same branch now produces a validation error.