### PR TITLE
fix(trigger): verify [bot] suffix before trimming trusted app name

### DIFF
--- a/pkg/plugins/trigger/trigger.go
+++ b/pkg/plugins/trigger/trigger.go
@@ -277,9 +277,9 @@ func TrustedUser(ghc trustedUserClient, onlyOrgMembers bool, trustedApps []strin
 	// Determine if user is on trusted_apps list.
 	// This allows automatic tests execution for GitHub automations that cannot be added as collaborators.
 	for _, trustedApp := range trustedApps {
-		if tUser := strings.TrimSuffix(user, "[bot]"); tUser == trustedApp {
-			return okResponse, nil
-		}
+		if strings.HasSuffix(user, "[bot]") && strings.TrimSuffix(user, "[bot]") == trustedApp {
+        	return okResponse, nil
+    	}
 	}
 
 	// Determine if there is a second org to check. If there is no secondary org or they are the same, the result

--- a/pkg/plugins/trigger/trigger_test.go
+++ b/pkg/plugins/trigger/trigger_test.go
@@ -431,6 +431,20 @@ func TestTrustedUser(t *testing.T) {
 			expectedTrusted: false,
 			expectedReason:  (notMember | notCollaborator).String(),
 		},
+		{
+			name:            "github-app (no bot suffix) matches trusted app name, should not be trusted",
+			user:            "github-app",
+			trustedApps:     []string{"github-app"},
+			expectedTrusted: false,
+			expectedReason:  (notMember | notCollaborator).String(),
+		},
+		{
+			name:            "github-app[bot]suffix (bot not as suffix) matches trusted app name, should not be trusted",
+			user:            "github-app[bot]suffix",
+			trustedApps:     []string{"github-app"},
+			expectedTrusted: false,
+			expectedReason:  (notMember | notCollaborator).String(),
+		},
 	}
 
 	for _, tc := range testcases {


### PR DESCRIPTION
Ensure that the incoming username actually has the `[bot]` suffix before trimming it and verifying it against the `trusted_apps` list. 