### PR TITLE
autobump prow base images

### DIFF
--- a/hack/autobump.yaml
+++ b/hack/autobump.yaml
@@ -1,0 +1,19 @@
+---
+gitHubLogin: "k8s-infra-ci-robot"
+gitHubToken: "/etc/github-token/token"
+gitName: "Kubernetes Prow Robot"
+gitEmail: "75457971+k8s-infra-ci-robot@users.noreply.github.com"
+skipPullRequest: false
+gitHubOrg: "kubernetes-sigs"
+gitHubRepo: "prow"
+remoteName: "prow"
+upstreamURLBase: "https://raw.githubusercontent.com/kubernetes-sigs/prow/main"
+targetVersion: "latest"
+extraFiles:
+  - ".ko.yaml"
+prefixes:
+  - name: "k8s-staging-test-infra GCR images"
+    prefix: "gcr.io/k8s-staging-test-infra"
+    repo: "https://github.com/kubernetes/test-infra"
+    summarise: false
+    consistentImages: false


### PR DESCRIPTION
Fixes: #559 

`gcr.io/k8s-staging-test-infra` images expire after 6 months now, so this bumper should fix it
