### PR TITLE
feat(label): support configurable exclusive label sets

### DIFF
--- a/pkg/plugins/config.go
+++ b/pkg/plugins/config.go
@@ -454,6 +454,11 @@ type Label struct {
 	// defines to which repos this applies and can be `*` for global, an org
 	// or a repo in org/repo notation.
 	RestrictedLabels map[string][]RestrictedLabel `json:"restricted_labels,omitempty"`
+
+	// ExclusiveLabelPrefixes is a list of label prefixes that should be treated
+	// as mutually exclusive. When a label matching one of these prefixes is added,
+	// any existing labels with the same prefix on the issue or PR are removed.
+	ExclusiveLabelPrefixes []string `json:"exclusive_label_prefixes,omitempty"`
 }
 
 func (l Label) RestrictedLabelsFor(org, repo string) map[string]RestrictedLabel {
@@ -2380,6 +2385,7 @@ func (l *Label) mergeFrom(other *Label) error {
 		return nil
 	}
 	l.AdditionalLabels = append(l.AdditionalLabels, other.AdditionalLabels...)
+	l.ExclusiveLabelPrefixes = append(l.ExclusiveLabelPrefixes, other.ExclusiveLabelPrefixes...)
 
 	var errs []error
 	for key, labelConfigs := range other.RestrictedLabels {

--- a/pkg/plugins/config_test.go
+++ b/pkg/plugins/config_test.go
@@ -2197,7 +2197,7 @@ func TestHasConfigFor(t *testing.T) {
 			name: "Any config with label.restricted_labels is considered to be for the org and repos references there",
 			resultGenerator: func(fuzzedConfig *Configuration) (toCheck *Configuration, expectGlobal bool, expectOrgs sets.Set[string], expectRepos sets.Set[string]) {
 				fuzzedConfig = &Configuration{Label: fuzzedConfig.Label}
-				if len(fuzzedConfig.Label.AdditionalLabels) > 0 {
+				if len(fuzzedConfig.Label.AdditionalLabels) > 0 || len(fuzzedConfig.Label.ExclusiveLabelPrefixes) > 0 {
 					expectGlobal = true
 				}
 

--- a/pkg/plugins/label/label.go
+++ b/pkg/plugins/label/label.go
@@ -37,13 +37,14 @@ const (
 )
 
 var (
-	defaultLabels          = []string{"kind", "priority", "area"}
-	needsLabels            = []string{"kind", "priority", "sig", "triage"} // "needs-*"
-	commentRegex           = regexp.MustCompile(`(?s)<!--(.*?)-->`)
-	labelRegex             = regexp.MustCompile(`(?m)^/(area|committee|kind|language|priority|sig|triage|wg)\s*(.*?)\s*$`)
-	removeLabelRegex       = regexp.MustCompile(`(?m)^/remove-(area|committee|kind|language|priority|sig|triage|wg)\s*(.*?)\s*$`)
-	customLabelRegex       = regexp.MustCompile(`(?m)^/label\s*(.*?)\s*$`)
-	customRemoveLabelRegex = regexp.MustCompile(`(?m)^/remove-label\s*(.*?)\s*$`)
+	defaultLabels                 = []string{"kind", "priority", "area"}
+	defaultExclusiveLabelPrefixes = []string{"priority/", "lifecycle/", "tracked/"}
+	needsLabels                   = []string{"kind", "priority", "sig", "triage"} // "needs-*"
+	commentRegex                  = regexp.MustCompile(`(?s)<!--(.*?)-->`)
+	labelRegex                    = regexp.MustCompile(`(?m)^/(area|committee|kind|language|priority|sig|triage|wg)\s*(.*?)\s*$`)
+	removeLabelRegex              = regexp.MustCompile(`(?m)^/remove-(area|committee|kind|language|priority|sig|triage|wg)\s*(.*?)\s*$`)
+	customLabelRegex              = regexp.MustCompile(`(?m)^/label\s*(.*?)\s*$`)
+	customRemoveLabelRegex        = regexp.MustCompile(`(?m)^/remove-label\s*(.*?)\s*$`)
 )
 
 func init() {
@@ -202,6 +203,7 @@ func handleComment(gc githubClient, log *logrus.Entry, config plugins.Label, e *
 	// Get labels to add and labels to remove from regexp matches
 	labelsToAdd = append(getLabelsFromREMatches(labelMatches), getLabelsFromGenericMatches(customLabelMatches, labelFilter, &nonexistent)...)
 	labelsToRemove = append(getLabelsFromREMatches(removeLabelMatches), getLabelsFromGenericMatches(customRemoveLabelMatches, labelFilter, &nonexistent)...)
+	exclusiveLabelPrefixes := uniqueExclusiveLabelPrefixes(append(defaultExclusiveLabelPrefixes, config.ExclusiveLabelPrefixes...))
 
 	for _, needsCategory := range needsLabels {
 		needsLabel := fmt.Sprintf("needs-%s", needsCategory)
@@ -255,7 +257,9 @@ func handleComment(gc githubClient, log *logrus.Entry, config plugins.Label, e *
 
 		if err := gc.AddLabel(org, repo, e.Number, labelToAdd); err != nil {
 			log.WithError(err).WithField("label", labelToAdd).Error("GitHub failed to add the label")
+			continue
 		}
+		labelsToRemove = append(labelsToRemove, conflictingExclusiveLabels(issueLabels, labelToAdd, exclusiveLabelPrefixes)...)
 	}
 
 	// Remove labels
@@ -369,6 +373,60 @@ func handleLabelAdd(gc githubClient, log *logrus.Entry, config plugins.Label, e 
 		}
 	}
 	return nil
+}
+
+func conflictingExclusiveLabels(issueLabels []string, labelToAdd string, exclusiveLabelPrefixes []string) []string {
+	var conflicting []string
+	if len(exclusiveLabelPrefixes) == 0 {
+		return conflicting
+	}
+	matchingPrefix := exclusiveLabelPrefix(labelToAdd, exclusiveLabelPrefixes)
+	if matchingPrefix == "" {
+		return conflicting
+	}
+	for _, existingLabel := range issueLabels {
+		if existingLabel == labelToAdd || !hasExclusiveLabelPrefix(existingLabel, []string{matchingPrefix}) {
+			continue
+		}
+		conflicting = append(conflicting, existingLabel)
+	}
+	return conflicting
+}
+
+func uniqueExclusiveLabelPrefixes(prefixes []string) []string {
+	seen := sets.New[string]()
+	var unique []string
+	for _, prefix := range prefixes {
+		prefix = strings.ToLower(strings.TrimSpace(prefix))
+		if prefix == "" || seen.Has(prefix) {
+			continue
+		}
+		seen.Insert(prefix)
+		unique = append(unique, prefix)
+	}
+	return unique
+}
+
+func exclusiveLabelPrefix(label string, prefixes []string) string {
+	label = strings.ToLower(strings.TrimSpace(label))
+	for _, prefix := range prefixes {
+		prefix = strings.ToLower(strings.TrimSpace(prefix))
+		if prefix != "" && strings.HasPrefix(label, prefix) {
+			return prefix
+		}
+	}
+	return ""
+}
+
+func hasExclusiveLabelPrefix(label string, prefixes []string) bool {
+	label = strings.ToLower(strings.TrimSpace(label))
+	for _, prefix := range prefixes {
+		prefix = strings.ToLower(strings.TrimSpace(prefix))
+		if prefix != "" && strings.HasPrefix(label, prefix) {
+			return true
+		}
+	}
+	return false
 }
 
 func labelsWithCategory(labels []string, category string) sets.Set[string] {

--- a/pkg/plugins/label/label_test.go
+++ b/pkg/plugins/label/label_test.go
@@ -52,19 +52,20 @@ func formatWithPRInfo(labels ...string) []string {
 
 func TestHandleComment(t *testing.T) {
 	type testCase struct {
-		name                  string
-		body                  string
-		commenter             string
-		extraLabels           []string
-		restrictedLabels      map[string][]plugins.RestrictedLabel
-		expectedNewLabels     []string
-		expectedRemovedLabels []string
-		expectedBotComment    bool
-		repoLabels            []string
-		issueLabels           []string
-		expectedCommentText   string
-		action                github.GenericCommentEventAction
-		teams                 map[string]map[string]fakegithub.TeamWithMembers
+		name                   string
+		body                   string
+		commenter              string
+		extraLabels            []string
+		restrictedLabels       map[string][]plugins.RestrictedLabel
+		exclusiveLabelPrefixes []string
+		expectedNewLabels      []string
+		expectedRemovedLabels  []string
+		expectedBotComment     bool
+		repoLabels             []string
+		issueLabels            []string
+		expectedCommentText    string
+		action                 github.GenericCommentEventAction
+		teams                  map[string]map[string]fakegithub.TeamWithMembers
 	}
 	testcases := []testCase{
 		{
@@ -116,6 +117,17 @@ func TestHandleComment(t *testing.T) {
 			expectedRemovedLabels: []string{},
 			commenter:             orgMember,
 			action:                github.GenericCommentActionCreated,
+		},
+		{
+			name:                   "Exclusive label prefixes remove conflicting labels",
+			body:                   "/priority critical",
+			repoLabels:             []string{"area/infra", "priority/critical", "priority/urgent"},
+			issueLabels:            []string{"priority/urgent"},
+			expectedNewLabels:      formatWithPRInfo("priority/critical"),
+			expectedRemovedLabels:  formatWithPRInfo("priority/urgent"),
+			commenter:              orgMember,
+			action:                 github.GenericCommentActionCreated,
+			exclusiveLabelPrefixes: []string{"priority/"},
 		},
 		{
 			name:                  "Add Single Kind Label",
@@ -806,7 +818,7 @@ func TestHandleComment(t *testing.T) {
 				Repo:   github.Repo{Owner: github.User{Login: "org"}, Name: "repo"},
 				User:   github.User{Login: tc.commenter},
 			}
-			err := handleComment(fakeClient, logrus.WithField("plugin", PluginName), plugins.Label{AdditionalLabels: tc.extraLabels, RestrictedLabels: tc.restrictedLabels}, e)
+			err := handleComment(fakeClient, logrus.WithField("plugin", PluginName), plugins.Label{AdditionalLabels: tc.extraLabels, RestrictedLabels: tc.restrictedLabels, ExclusiveLabelPrefixes: tc.exclusiveLabelPrefixes}, e)
 			if err != nil {
 				t.Fatalf("didn't expect error from handle comment test: %v", err)
 			}

--- a/pkg/plugins/plugin-config-documented.yaml
+++ b/pkg/plugins/plugin-config-documented.yaml
@@ -460,6 +460,11 @@ label:
     # or a repo in org/repo notation.
     restricted_labels:
         "": null
+    # ExclusiveLabelPrefixes is a list of label prefixes that should be treated
+    # as mutually exclusive. When a label matching one of these prefixes is added,
+    # any existing labels with the same prefix on the issue or PR are removed.
+    exclusive_label_prefixes:
+        - ""
 lgtm:
     - # Repos is either of the form org/repos or just org.
       repos:


### PR DESCRIPTION
#179   

## What this PR does

This PR adds support for configurable exclusive label prefixes in the label plugin.

When a label matching an exclusive prefix is added, any existing label with the same prefix on the issue or PR is automatically removed.

### Example

**Current labels:**
priority/backlog
kind/bug

**User adds:**
/priority important-soon

↓

**Automatically remove:**

priority/backlog

↓

**Final labels:**

priority/important-soon
kind/bug



### Changes

- Add `ExclusiveLabelPrefixes` to the label plugin configuration.
- Merge exclusive label prefixes during config merging.
- Remove conflicting labels before applying a new exclusive label.
- Add unit tests for the new behavior.
- Document the new configuration option.

### Testing

```bash
go test ./pkg/plugins/label
go test ./pkg/plugins
