### PR TITLE
Add nil guard to publisher.Commit and set GitUser in GithubOptions.GitClientFactory

### DIFF
--- a/pkg/flagutil/github.go
+++ b/pkg/flagutil/github.go
@@ -356,6 +356,7 @@ func (o *GitHubOptions) GitClientFactory(cookieFilePath string, cacheDir *string
 			return nil, fmt.Errorf("failed to get git authentication: %w", err)
 		}
 		opts.Username = func() (string, error) { return user, nil }
+		opts.GitUser = func() (string, string, error) { return user, "", nil } // pass empty email, git allows this
 		opts.Token = generator
 	}
 	// If the client is for Gerrit we're already set with the cookie filepath.

--- a/pkg/git/v2/publisher.go
+++ b/pkg/git/v2/publisher.go
@@ -52,6 +52,9 @@ type publisher struct {
 // Commit adds all of the current content to the index and creates a commit
 func (p *publisher) Commit(title, body string) error {
 	p.logger.Infof("Committing changes with title %q", title)
+	if p.info == nil {
+		return fmt.Errorf("error committing %q: GitUser is not set", title)
+	}
 	name, email, err := p.info()
 	if err != nil {
 		return err


### PR DESCRIPTION
as described in #800 here is a proposed modification that would close #800.

*What does this pr do?*
- Adds a nil guard to pkg/git/v2/publisher.go publisher.Commit: p.info previously was directly called, if GitUser was not set p.info would be nil and a nil pointer dereference panic occured. I inserted a nil guard.
- in pkg/flagutil/github.go: now also sets the GitUser when using the GitClientFactory, username is the same as opts.Username and the email is left empty.