### PR TITLE
peribolos: add --ignore-repos flag for team repo reconciliation

### DIFF
--- a/cmd/peribolos/main.go
+++ b/cmd/peribolos/main.go
@@ -62,6 +62,9 @@ type options struct {
 	ignoreInvitees        bool
 	ignoreSecretTeams     bool
 	ignoreEnterpriseTeams bool
+	ignoreRepos           flagutil.Strings
+	ignorePrivateRepos    bool
+	ignoreInternalRepos   bool
 	allowRepoArchival     bool
 	allowRepoPublish      bool
 	github                flagutil.GitHubOptions
@@ -90,6 +93,10 @@ func (o *options) parseArgs(flags *flag.FlagSet, args []string) error {
 	flags.BoolVar(&o.ignoreInvitees, "ignore-invitees", false, "Do not compare missing members with active invitations (compatibility for GitHub Enterprise)")
 	flags.BoolVar(&o.ignoreSecretTeams, "ignore-secret-teams", false, "Do not dump or update secret teams if set")
 	flags.BoolVar(&o.ignoreEnterpriseTeams, "ignore-enterprise-teams", false, "Skip enterprise teams and their members during reconciliation")
+	o.ignoreRepos = flagutil.NewStrings()
+	flags.Var(&o.ignoreRepos, "ignore-repos", "Comma-separated list of repositories to skip while reconciling team repo permissions")
+	flags.BoolVar(&o.ignorePrivateRepos, "ignore-private-repos", false, "Skip private repositories while reconciling team repo permissions")
+	flags.BoolVar(&o.ignoreInternalRepos, "ignore-internal-repos", false, "Skip internal repositories while reconciling team repo permissions")
 	flags.BoolVar(&o.fixOrg, "fix-org", false, "Change org metadata if set")
 	flags.BoolVar(&o.fixOrgMembers, "fix-org-members", false, "Add/remove org members if set")
 	flags.BoolVar(&o.fixTeams, "fix-teams", false, "Create/delete/update teams if set")
@@ -151,6 +158,19 @@ func (o *options) parseArgs(flags *flag.FlagSet, args []string) error {
 	}
 
 	return nil
+}
+
+func ignoredRepos(values []string) sets.Set[string] {
+	repos := sets.Set[string]{}
+	for _, value := range values {
+		for _, repo := range strings.Split(value, ",") {
+			repo = strings.TrimSpace(repo)
+			if repo != "" {
+				repos.Insert(strings.ToLower(repo))
+			}
+		}
+	}
+	return repos
 }
 
 func main() {
@@ -997,6 +1017,7 @@ func configureOrg(opt options, client github.Client, orgName string, orgConfig o
 	if err != nil {
 		return fmt.Errorf("failed to configure %s teams: %w", orgName, err)
 	}
+	ignoreRepos := ignoredRepos(opt.ignoreRepos.Strings())
 
 	for name, team := range orgConfig.Teams {
 		err := configureTeamAndMembers(opt, client, githubTeams, name, orgName, team, nil)
@@ -1008,7 +1029,7 @@ func configureOrg(opt options, client github.Client, orgName string, orgConfig o
 			logrus.Infof("Skipping team repo permissions configuration")
 			continue
 		}
-		if err := configureTeamRepos(client, githubTeams, name, orgName, team); err != nil {
+		if err := configureTeamRepos(client, githubTeams, name, orgName, team, ignoreRepos, opt.ignorePrivateRepos, opt.ignoreInternalRepos); err != nil {
 			return fmt.Errorf("failed to configure %s team %s repos: %w", orgName, name, err)
 		}
 	}
@@ -1466,7 +1487,7 @@ type teamRepoClient interface {
 }
 
 // configureTeamRepos updates the list of repos that the team has permissions for when necessary
-func configureTeamRepos(client teamRepoClient, githubTeams map[string]github.Team, name, orgName string, team org.Team) error {
+func configureTeamRepos(client teamRepoClient, githubTeams map[string]github.Team, name, orgName string, team org.Team, ignoreRepos sets.Set[string], ignorePrivateRepos bool, ignoreInternalRepos bool) error {
 	gt, ok := githubTeams[name]
 	if !ok { // configureTeams is buggy if this is the case
 		return fmt.Errorf("%s not found in id list", name)
@@ -1474,16 +1495,34 @@ func configureTeamRepos(client teamRepoClient, githubTeams map[string]github.Tea
 
 	want := team.Repos
 	have := map[string]github.RepoPermissionLevel{}
+	privateRepos := sets.Set[string]{}
+	internalRepos := sets.Set[string]{}
 	repos, err := client.ListTeamReposBySlug(orgName, gt.Slug)
 	if err != nil {
 		return fmt.Errorf("failed to list team %d(%s) repos: %w", gt.ID, name, err)
 	}
 	for _, repo := range repos {
+		repoName := strings.ToLower(repo.Name)
+		if ignorePrivateRepos && repo.Private {
+			privateRepos.Insert(repoName)
+			continue
+		}
+		if ignoreInternalRepos && repo.Visibility == "internal" {
+			internalRepos.Insert(repoName)
+			continue
+		}
+		if ignoreRepos.Has(repoName) {
+			continue
+		}
 		have[repo.Name] = github.LevelFromPermissions(repo.Permissions)
 	}
 
 	actions := map[string]github.RepoPermissionLevel{}
 	for wantRepo, wantPermission := range want {
+		repoName := strings.ToLower(wantRepo)
+		if ignoreRepos.Has(repoName) || privateRepos.Has(repoName) || internalRepos.Has(repoName) {
+			continue
+		}
 		if havePermission, haveRepo := have[wantRepo]; haveRepo && havePermission == wantPermission {
 			// nothing to do
 			continue
@@ -1523,7 +1562,7 @@ func configureTeamRepos(client teamRepoClient, githubTeams map[string]github.Tea
 	}
 
 	for childName, childTeam := range team.Children {
-		if err := configureTeamRepos(client, githubTeams, childName, orgName, childTeam); err != nil {
+		if err := configureTeamRepos(client, githubTeams, childName, orgName, childTeam, ignoreRepos, ignorePrivateRepos, ignoreInternalRepos); err != nil {
 			updateErrors = append(updateErrors, fmt.Errorf("failed to configure %s child team %s repos: %w", orgName, childName, err))
 		}
 	}

--- a/cmd/peribolos/main_test.go
+++ b/cmd/peribolos/main_test.go
@@ -133,18 +133,33 @@ func TestOptions(t *testing.T) {
 		},
 		{
 			name: "full",
-			args: []string{"--config-path=foo", "--github-token-path=bar", "--github-endpoint=weird://url", "--confirm=true", "--require-self=false", "--dump=", "--fix-org", "--fix-org-members", "--fix-teams", "--fix-team-members", "--log-level=debug"},
+			args: []string{"--config-path=foo", "--github-token-path=bar", "--github-endpoint=weird://url", "--confirm=true", "--require-self=false", "--dump=", "--fix-org", "--fix-org-members", "--fix-teams", "--fix-team-members", "--ignore-repos=repo-a,repo-b", "--ignore-private-repos", "--ignore-internal-repos", "--log-level=debug"},
 			expected: &options{
-				config:         "foo",
-				confirm:        true,
-				requireSelf:    false,
-				minAdmins:      defaultMinAdmins,
-				maximumDelta:   defaultDelta,
-				fixOrg:         true,
-				fixOrgMembers:  true,
-				fixTeams:       true,
-				fixTeamMembers: true,
-				logLevel:       "debug",
+				config:              "foo",
+				confirm:             true,
+				requireSelf:         false,
+				minAdmins:           defaultMinAdmins,
+				maximumDelta:        defaultDelta,
+				fixOrg:              true,
+				fixOrgMembers:       true,
+				fixTeams:            true,
+				fixTeamMembers:      true,
+				ignoreRepos:         flagutil.NewStringsBeenSet("repo-a,repo-b"),
+				ignorePrivateRepos:  true,
+				ignoreInternalRepos: true,
+				logLevel:            "debug",
+			},
+		},
+		{
+			name: "repeated ignore repos",
+			args: []string{"--config-path=foo", "--ignore-repos=repo-a", "--ignore-repos=repo-b,repo-c"},
+			expected: &options{
+				config:       "foo",
+				minAdmins:    defaultMinAdmins,
+				requireSelf:  true,
+				maximumDelta: defaultDelta,
+				ignoreRepos:  flagutil.NewStringsBeenSet("repo-a", "repo-b,repo-c"),
+				logLevel:     "info",
 			},
 		},
 	}
@@ -164,6 +179,20 @@ func TestOptions(t *testing.T) {
 				t.Errorf("%s: got incorrect options: %v", tc.name, cmp.Diff(actual, *tc.expected, cmp.AllowUnexported(options{}, flagutil.Strings{}, flagutil.GitHubOptions{})))
 			}
 		})
+	}
+}
+
+func TestIgnoredRepos(t *testing.T) {
+	actual := ignoredRepos([]string{
+		"repo-a,repo-b",
+		"repo-c",
+		" repo-d , ",
+		"Repo-E",
+		"",
+	})
+	expected := sets.New[string]("repo-a", "repo-b", "repo-c", "repo-d", "repo-e")
+	if diff := cmp.Diff(actual, expected); diff != "" {
+		t.Errorf("got incorrect ignored repos: %s", diff)
 	}
 }
 
@@ -2679,16 +2708,19 @@ func (c *fakeTeamRepoClient) RemoveTeamRepoBySlug(org, teamSlug, repo string) er
 
 func TestConfigureTeamRepos(t *testing.T) {
 	var testCases = []struct {
-		name          string
-		githubTeams   map[string]github.Team
-		teamName      string
-		team          org.Team
-		existingRepos map[string][]github.Repo
-		failList      bool
-		failUpdate    bool
-		failRemove    bool
-		expected      map[string][]github.Repo
-		expectedErr   bool
+		name                string
+		githubTeams         map[string]github.Team
+		teamName            string
+		team                org.Team
+		existingRepos       map[string][]github.Repo
+		failList            bool
+		failUpdate          bool
+		failRemove          bool
+		ignoreRepos         sets.Set[string]
+		ignorePrivateRepos  bool
+		ignoreInternalRepos bool
+		expected            map[string][]github.Repo
+		expectedErr         bool
 	}{
 		{
 			name:        "githubTeams cache not containing team errors",
@@ -2798,6 +2830,96 @@ func TestConfigureTeamRepos(t *testing.T) {
 			}},
 		},
 		{
+			name:        "ignored repos are not removed or updated",
+			githubTeams: map[string]github.Team{"team": {ID: 1, Slug: "team"}},
+			teamName:    "team",
+			team: org.Team{
+				Repos: map[string]github.RepoPermissionLevel{
+					"managed":        github.Write,
+					"ignored-update": github.Admin,
+					"ignored-add":    github.Read,
+				},
+			},
+			existingRepos: map[string][]github.Repo{"team": {
+				{Name: "managed", Permissions: github.RepoPermissions{Pull: true}},
+				{Name: "ignored-update", Permissions: github.RepoPermissions{Pull: true}},
+				{Name: "ignored-remove", Permissions: github.RepoPermissions{Pull: true}},
+				{Name: "remove", Permissions: github.RepoPermissions{Pull: true}},
+			}},
+			ignoreRepos: sets.New[string]("ignored-add", "ignored-update", "ignored-remove"),
+			expected: map[string][]github.Repo{"team": {
+				{Name: "managed", Permissions: github.RepoPermissions{Pull: true, Triage: true, Push: true}},
+				{Name: "ignored-update", Permissions: github.RepoPermissions{Pull: true}},
+				{Name: "ignored-remove", Permissions: github.RepoPermissions{Pull: true}},
+			}},
+		},
+		{
+			name:        "ignored repo matching is case-insensitive",
+			githubTeams: map[string]github.Team{"team": {ID: 1, Slug: "team"}},
+			teamName:    "team",
+			team: org.Team{
+				Repos: map[string]github.RepoPermissionLevel{
+					"Ignored-Add":    github.Read,
+					"Ignored-Update": github.Admin,
+				},
+			},
+			existingRepos: map[string][]github.Repo{"team": {
+				{Name: "ignored-update", Permissions: github.RepoPermissions{Pull: true}},
+				{Name: "Ignored-Remove", Permissions: github.RepoPermissions{Pull: true}},
+			}},
+			ignoreRepos: sets.New[string]("ignored-add", "ignored-update", "ignored-remove"),
+			expected: map[string][]github.Repo{"team": {
+				{Name: "ignored-update", Permissions: github.RepoPermissions{Pull: true}},
+				{Name: "Ignored-Remove", Permissions: github.RepoPermissions{Pull: true}},
+			}},
+		},
+		{
+			name:        "private repos are not removed or updated when ignored",
+			githubTeams: map[string]github.Team{"team": {ID: 1, Slug: "team"}},
+			teamName:    "team",
+			team: org.Team{
+				Repos: map[string]github.RepoPermissionLevel{
+					"managed":        github.Write,
+					"private-update": github.Admin,
+				},
+			},
+			existingRepos: map[string][]github.Repo{"team": {
+				{Name: "managed", Permissions: github.RepoPermissions{Pull: true}},
+				{Name: "private-update", Private: true, Permissions: github.RepoPermissions{Pull: true}},
+				{Name: "private-remove", Private: true, Permissions: github.RepoPermissions{Pull: true}},
+				{Name: "public-remove", Permissions: github.RepoPermissions{Pull: true}},
+			}},
+			ignorePrivateRepos: true,
+			expected: map[string][]github.Repo{"team": {
+				{Name: "managed", Permissions: github.RepoPermissions{Pull: true, Triage: true, Push: true}},
+				{Name: "private-update", Private: true, Permissions: github.RepoPermissions{Pull: true}},
+				{Name: "private-remove", Private: true, Permissions: github.RepoPermissions{Pull: true}},
+			}},
+		},
+		{
+			name:        "internal repos are not removed or updated when ignored",
+			githubTeams: map[string]github.Team{"team": {ID: 1, Slug: "team"}},
+			teamName:    "team",
+			team: org.Team{
+				Repos: map[string]github.RepoPermissionLevel{
+					"managed":         github.Write,
+					"internal-update": github.Admin,
+				},
+			},
+			existingRepos: map[string][]github.Repo{"team": {
+				{Name: "managed", Permissions: github.RepoPermissions{Pull: true}},
+				{Name: "internal-update", Visibility: "internal", Permissions: github.RepoPermissions{Pull: true}},
+				{Name: "internal-remove", Visibility: "internal", Permissions: github.RepoPermissions{Pull: true}},
+				{Name: "public-remove", Permissions: github.RepoPermissions{Pull: true}},
+			}},
+			ignoreInternalRepos: true,
+			expected: map[string][]github.Repo{"team": {
+				{Name: "managed", Permissions: github.RepoPermissions{Pull: true, Triage: true, Push: true}},
+				{Name: "internal-update", Visibility: "internal", Permissions: github.RepoPermissions{Pull: true}},
+				{Name: "internal-remove", Visibility: "internal", Permissions: github.RepoPermissions{Pull: true}},
+			}},
+		},
+		{
 			name:        "failed update errors",
 			failUpdate:  true,
 			githubTeams: map[string]github.Team{"team": {ID: 1}},
@@ -2856,6 +2978,76 @@ func TestConfigureTeamRepos(t *testing.T) {
 			}},
 		},
 		{
+			name:        "ignored repos propagate to child teams",
+			githubTeams: map[string]github.Team{"team": {ID: 1, Slug: "team"}, "child": {ID: 2, Slug: "child"}},
+			teamName:    "team",
+			team: org.Team{
+				Children: map[string]org.Team{
+					"child": {
+						Repos: map[string]github.RepoPermissionLevel{
+							"ignored-add":    github.Read,
+							"ignored-update": github.Admin,
+						},
+					},
+				},
+			},
+			existingRepos: map[string][]github.Repo{"child": {
+				{Name: "ignored-update", Permissions: github.RepoPermissions{Pull: true}},
+				{Name: "ignored-remove", Permissions: github.RepoPermissions{Pull: true}},
+			}},
+			ignoreRepos: sets.New[string]("ignored-add", "ignored-update", "ignored-remove"),
+			expected: map[string][]github.Repo{"child": {
+				{Name: "ignored-update", Permissions: github.RepoPermissions{Pull: true}},
+				{Name: "ignored-remove", Permissions: github.RepoPermissions{Pull: true}},
+			}},
+		},
+		{
+			name:        "private repo ignore propagates to child teams",
+			githubTeams: map[string]github.Team{"team": {ID: 1, Slug: "team"}, "child": {ID: 2, Slug: "child"}},
+			teamName:    "team",
+			team: org.Team{
+				Children: map[string]org.Team{
+					"child": {
+						Repos: map[string]github.RepoPermissionLevel{
+							"private-update": github.Admin,
+						},
+					},
+				},
+			},
+			existingRepos: map[string][]github.Repo{"child": {
+				{Name: "private-update", Private: true, Permissions: github.RepoPermissions{Pull: true}},
+				{Name: "private-remove", Private: true, Permissions: github.RepoPermissions{Pull: true}},
+			}},
+			ignorePrivateRepos: true,
+			expected: map[string][]github.Repo{"child": {
+				{Name: "private-update", Private: true, Permissions: github.RepoPermissions{Pull: true}},
+				{Name: "private-remove", Private: true, Permissions: github.RepoPermissions{Pull: true}},
+			}},
+		},
+		{
+			name:        "internal repo ignore propagates to child teams",
+			githubTeams: map[string]github.Team{"team": {ID: 1, Slug: "team"}, "child": {ID: 2, Slug: "child"}},
+			teamName:    "team",
+			team: org.Team{
+				Children: map[string]org.Team{
+					"child": {
+						Repos: map[string]github.RepoPermissionLevel{
+							"internal-update": github.Admin,
+						},
+					},
+				},
+			},
+			existingRepos: map[string][]github.Repo{"child": {
+				{Name: "internal-update", Visibility: "internal", Permissions: github.RepoPermissions{Pull: true}},
+				{Name: "internal-remove", Visibility: "internal", Permissions: github.RepoPermissions{Pull: true}},
+			}},
+			ignoreInternalRepos: true,
+			expected: map[string][]github.Repo{"child": {
+				{Name: "internal-update", Visibility: "internal", Permissions: github.RepoPermissions{Pull: true}},
+				{Name: "internal-remove", Visibility: "internal", Permissions: github.RepoPermissions{Pull: true}},
+			}},
+		},
+		{
 			name:        "failure in a child errors",
 			failRemove:  true,
 			githubTeams: map[string]github.Team{"team": {ID: 1, Slug: "team"}, "child": {ID: 2, Slug: "child"}},
@@ -2885,7 +3077,7 @@ func TestConfigureTeamRepos(t *testing.T) {
 			failUpdate: testCase.failUpdate,
 			failRemove: testCase.failRemove,
 		}
-		err := configureTeamRepos(&client, testCase.githubTeams, testCase.teamName, "org", testCase.team)
+		err := configureTeamRepos(&client, testCase.githubTeams, testCase.teamName, "org", testCase.team, testCase.ignoreRepos, testCase.ignorePrivateRepos, testCase.ignoreInternalRepos)
 		if err == nil && testCase.expectedErr {
 			t.Errorf("%s: expected an error but got none", testCase.name)
 		}

--- a/pkg/github/types.go
+++ b/pkg/github/types.go
@@ -332,6 +332,7 @@ type Repo struct {
 	DefaultBranch string `json:"default_branch"`
 	Archived      bool   `json:"archived"`
 	Private       bool   `json:"private"`
+	Visibility    string `json:"visibility"`
 	Description   string `json:"description"`
 	Homepage      string `json:"homepage"`
 	HasIssues     bool   `json:"has_issues"`


### PR DESCRIPTION
## Summary

- add `--ignore-repos` for excluding repositories from Peribolos team repo reconciliation
- support comma-separated values while preserving repeated flag compatibility through `flagutil.Strings`
- match ignored repository names case-insensitively, consistent with GitHub repository-name behavior
- skip ignored repos on both sides of the diff so Peribolos does not add, update, or remove them
- add tests for parsing, top-level team behavior, and child team propagation

Fixes #737

## Testing

- `go test -count=1 ./cmd/peribolos`
- `go test -count=20 -shuffle=on ./cmd/peribolos -run 'TestOptions|TestIgnoredRepos|TestConfigureTeamRepos'`
- `go test -race -count=1 ./cmd/peribolos`
- `go test ./...`
- `go vet ./cmd/peribolos`
- `semgrep scan --config p/default --error --quiet cmd/peribolos/main.go cmd/peribolos/main_test.go`
- `semgrep scan --config p/security-audit --error --quiet cmd/peribolos/main.go cmd/peribolos/main_test.go`
- `gitleaks git --log-opts origin/main..HEAD --no-banner --redact`
- `go run ./cmd/peribolos --help 2>&1 | rg -n -- 'ignore-repos|fix-team-repos'`
- `git diff --check origin/main...HEAD`
