### PR TITLE
append the release note if there is no release note block

### DIFF
--- a/pkg/plugins/releasenote/releasenote.go
+++ b/pkg/plugins/releasenote/releasenote.go
@@ -493,23 +493,41 @@ func editReleaseNote(gc githubClient, log *logrus.Entry, ic github.IssueCommentE
 			plugins.FormatResponseRaw(ic.Comment.Body, ic.Comment.HTMLURL, user, "/release-note-edit must be used with a release note block."),
 		)
 	}
+	if len(noteMatcherRE.FindAllStringSubmatchIndex(ic.Comment.Body, -1)) != 1 {
+		return gc.CreateComment(
+			org, repo, ic.Issue.Number,
+			plugins.FormatResponseRaw(ic.Comment.Body, ic.Comment.HTMLURL, user, "/release-note-edit must be used with a single release note block."),
+		)
+	}
 
 	// 0: start of release note block
 	// 1: end of release note block
 	// 2: start of release note content
 	// 3: end of release note content
 	i := noteMatcherRE.FindStringSubmatchIndex(ic.Issue.Body)
-	if len(i) != 4 {
-		return gc.CreateComment(
-			org, repo, ic.Issue.Number,
-			plugins.FormatResponseRaw(ic.Comment.Body, ic.Comment.HTMLURL, user, "/release-note-edit must be used with a single release note block."),
-		)
+	if len(i) == 0 {
+		// If the PR body does not contain a release note block, append one instead.
+		// Preserve the body's line ending style and leave a blank line before the block.
+		lineEnding := "\n"
+		if strings.Contains(ic.Issue.Body, "\r\n") {
+			lineEnding = "\r\n"
+		}
+		separator := lineEnding + lineEnding
+		if ic.Issue.Body == "" {
+			separator = ""
+		} else if strings.HasSuffix(ic.Issue.Body, lineEnding+lineEnding) {
+			separator = ""
+		} else if strings.HasSuffix(ic.Issue.Body, lineEnding) {
+			separator = lineEnding
+		}
+		ic.Issue.Body += separator + "```release-note" + lineEnding + strings.TrimSpace(newNote) + lineEnding + "```" + lineEnding
+	} else {
+		// Splice in the contents of the new release note block to the top level comment.
+		// This accounts for all older regex matches.
+		b := []byte(ic.Issue.Body)
+		replaced := append(b[:i[2]], append([]byte("\r\n"+strings.TrimSpace(newNote)+"\r\n"), b[i[3]:]...)...)
+		ic.Issue.Body = string(replaced)
 	}
-	// Splice in the contents of the new release note block to the top level comment
-	// This accounts for all older regex matches
-	b := []byte(ic.Issue.Body)
-	replaced := append(b[:i[2]], append([]byte("\r\n"+strings.TrimSpace(newNote)+"\r\n"), b[i[3]:]...)...)
-	ic.Issue.Body = string(replaced)
 
 	_, err = gc.EditIssue(ic.Repo.Owner.Login, ic.Repo.Name, ic.Issue.Number, &ic.Issue)
 	if err != nil {

--- a/pkg/plugins/releasenote/releasenote_test.go
+++ b/pkg/plugins/releasenote/releasenote_test.go
@@ -765,6 +765,40 @@ func Test_editReleaseNote(t *testing.T) {
 			},
 		},
 		{
+			name: "append to body without release note block",
+			event: github.IssueCommentEvent{
+				Action: github.IssueCommentActionCreated,
+				Issue:  github.Issue{Number: issueNum, User: github.User{Login: "user"}, Body: "Top\nBelow"},
+				Comment: github.IssueComment{
+					Body: "/release-note-edit\r\n```release-note\r\nThe new note\r\n```\r\n",
+					User: github.User{Login: "user"},
+				},
+				Repo: github.Repo{Owner: github.User{Login: "org"}},
+			},
+			fcFunc: func(fc *fakegithub.FakeClient) {
+				fc.OrgMembers["org"] = []string{"user"}
+				fc.Issues[issueNum] = &github.Issue{Number: issueNum, User: github.User{Login: "user"}, Body: "Top\nBelow"}
+			},
+			expectedNote: "Top\nBelow\n\n```release-note\nThe new note\n```\n",
+		},
+		{
+			name: "append to empty body",
+			event: github.IssueCommentEvent{
+				Action: github.IssueCommentActionCreated,
+				Issue:  github.Issue{Number: issueNum, User: github.User{Login: "user"}},
+				Comment: github.IssueComment{
+					Body: "/release-note-edit\r\n```release-note\r\nThe new note\r\n```\r\n",
+					User: github.User{Login: "user"},
+				},
+				Repo: github.Repo{Owner: github.User{Login: "org"}},
+			},
+			fcFunc: func(fc *fakegithub.FakeClient) {
+				fc.OrgMembers["org"] = []string{"user"}
+				fc.Issues[issueNum] = &github.Issue{Number: issueNum, User: github.User{Login: "user"}}
+			},
+			expectedNote: "```release-note\nThe new note\n```\n",
+		},
+		{
 			name: "happy path",
 			event: github.IssueCommentEvent{
 				Action: github.IssueCommentActionCreated,


### PR DESCRIPTION
Here is an example: https://github.com/kubernetes/kubernetes/pull/140600#issuecomment-4999451986.

This PR help to support `/release-note-edit` on no release-note block PR description.