### PR TITLE
testfreeze: allow kind/bug PRs during code freeze with release team notification

### DIFF
--- a/pkg/plugins/testfreeze/testfreeze.go
+++ b/pkg/plugins/testfreeze/testfreeze.go
@@ -19,6 +19,7 @@ package testfreeze
 import (
 	"fmt"
 	"html/template"
+	"slices"
 	"strings"
 	"time"
 
@@ -35,12 +36,16 @@ const (
 	PluginName                  = "testfreeze"
 	defaultKubernetesBranch     = "master"
 	defaultKubernetesRepoAndOrg = "kubernetes"
+	labelKindBug                = "kind/bug"
 	templateString              = `{{ if .InCodeFreeze }}Please note that we're already in [Code Freeze](https://github.com/kubernetes/sig-release/blob/master/releases/release_phases.md#code-freeze) for the upcoming {{ .Tag }} release.
 
-**Adding the milestone to this PR is strictly prohibited without proper approval.** If this PR needs to be included in the {{ .Tag }} release:
+{{ if .IsBugFix }}This PR is labeled ` + "`kind/bug`" + `, so it **may** be included in the {{ .Tag }} release as a bug fix. Please make sure to:
 1. Technical review: get the PR reviewed and approved as usual (` + "`/lgtm`" + ` and ` + "`/approve`" + `)
-2. Inclusion in release: ping ` + "`@sig-release-leads`" + ` on the [#sig-release Slack channel](https://kubernetes.slack.com/archives/C2C40FMNF) and suggest to add the ` + "`{{ .Tag }}`" + ` milestone to the PR
-{{ end }}
+2. Release team awareness: tag ` + "`@kubernetes/sig-release-leads`" + ` on this PR so the release team is aware of the fix going in. You can also ping the [#sig-release Slack channel](https://kubernetes.slack.com/archives/C2C40FMNF) for time-sensitive cases.
+{{ else }}**Adding the milestone to this PR is strictly prohibited without proper approval.** If this PR needs to be included in the {{ .Tag }} release:
+1. Technical review: get the PR reviewed and approved as usual (` + "`/lgtm`" + ` and ` + "`/approve`" + `)
+2. Inclusion in release: tag ` + "`@kubernetes/sig-release-leads`" + ` on this PR and ping the [#sig-release Slack channel](https://kubernetes.slack.com/archives/C2C40FMNF) to request adding the ` + "`{{ .Tag }}`" + ` milestone
+{{ end }}{{ end }}
 {{ if .InTestFreeze }}
 ---
 
@@ -66,6 +71,10 @@ func helpProvider(*plugins.Configuration, []config.OrgRepo) (*pluginhelp.PluginH
 func handlePullRequestEvent(p plugins.Agent, e github.PullRequestEvent) error {
 	h := newHandler()
 	log := p.Logger
+	labels := make([]string, 0, len(e.PullRequest.Labels))
+	for _, l := range e.PullRequest.Labels {
+		labels = append(labels, l.Name)
+	}
 	if err := h.handle(
 		log,
 		p.GitHubClient,
@@ -74,6 +83,7 @@ func handlePullRequestEvent(p plugins.Agent, e github.PullRequestEvent) error {
 		e.Repo.Owner.Login,
 		e.Repo.Name,
 		e.PullRequest.Base.Ref,
+		labels,
 	); err != nil {
 		log.WithError(err).Error("skipping")
 	}
@@ -118,6 +128,7 @@ func (h *handler) handle(
 	action github.PullRequestEventAction,
 	number int,
 	org, repo, branch string,
+	labels []string,
 ) error {
 	funcStart := time.Now()
 	defer func() {
@@ -148,12 +159,18 @@ func (h *handler) handle(
 		return nil
 	}
 
+	isBugFix := slices.Contains(labels, labelKindBug)
+
 	comment := &strings.Builder{}
 	tpl, err := template.New(PluginName).Parse(templateString)
 	if err != nil {
 		return fmt.Errorf("parse template: %w", err)
 	}
-	if err := tpl.Execute(comment, result); err != nil {
+	data := struct {
+		*checker.Result
+		IsBugFix bool
+	}{result, isBugFix}
+	if err := tpl.Execute(comment, data); err != nil {
 		return fmt.Errorf("execute template: %w", err)
 	}
 

--- a/pkg/plugins/testfreeze/testfreeze.go
+++ b/pkg/plugins/testfreeze/testfreeze.go
@@ -41,10 +41,10 @@ const (
 
 {{ if .IsBugFix }}This PR is labeled ` + "`kind/bug`" + `, so it **may** be included in the {{ .Tag }} release as a bug fix. Please make sure to:
 1. Technical review: get the PR reviewed and approved as usual (` + "`/lgtm`" + ` and ` + "`/approve`" + `)
-2. Release team awareness: tag ` + "`@kubernetes/sig-release-leads`" + ` on this PR so the release team is aware of the fix going in. You can also ping the [#sig-release Slack channel](https://kubernetes.slack.com/archives/C2C40FMNF) for time-sensitive cases.
+2. Release team awareness: tag ` + "`@kubernetes/release-team-leads`" + ` on this PR so the release team is aware of the fix going in. You can also ping the [#sig-release Slack channel](https://kubernetes.slack.com/archives/C2C40FMNF) for time-sensitive cases.
 {{ else }}**Adding the milestone to this PR is strictly prohibited without proper approval.** If this PR needs to be included in the {{ .Tag }} release:
 1. Technical review: get the PR reviewed and approved as usual (` + "`/lgtm`" + ` and ` + "`/approve`" + `)
-2. Inclusion in release: tag ` + "`@kubernetes/sig-release-leads`" + ` on this PR and ping the [#sig-release Slack channel](https://kubernetes.slack.com/archives/C2C40FMNF) to request adding the ` + "`{{ .Tag }}`" + ` milestone
+2. Inclusion in release: tag ` + "`@kubernetes/release-team-leads`" + ` on this PR and ping the [#sig-release Slack channel](https://kubernetes.slack.com/archives/C2C40FMNF) to request adding the ` + "`{{ .Tag }}`" + ` milestone
 {{ end }}{{ end }}
 {{ if .InTestFreeze }}
 ---

--- a/pkg/plugins/testfreeze/testfreeze.go
+++ b/pkg/plugins/testfreeze/testfreeze.go
@@ -41,10 +41,10 @@ const (
 
 {{ if .IsBugFix }}This PR is labeled ` + "`kind/bug`" + `, so it **may** be included in the {{ .Tag }} release as a bug fix. Please make sure to:
 1. Technical review: get the PR reviewed and approved as usual (` + "`/lgtm`" + ` and ` + "`/approve`" + `)
-2. Release team awareness: tag ` + "`@kubernetes/release-team-leads`" + ` on this PR so the release team is aware of the fix going in. You can also ping the [#sig-release Slack channel](https://kubernetes.slack.com/archives/C2C40FMNF) for time-sensitive cases.
+2. Release team awareness: tag ` + "`@kubernetes/sig-release-leads`" + ` on this PR so the release team is aware of the fix going in. You can also ping the [#sig-release Slack channel](https://kubernetes.slack.com/archives/C2C40FMNF) for time-sensitive cases.
 {{ else }}**Adding the milestone to this PR is strictly prohibited without proper approval.** If this PR needs to be included in the {{ .Tag }} release:
 1. Technical review: get the PR reviewed and approved as usual (` + "`/lgtm`" + ` and ` + "`/approve`" + `)
-2. Inclusion in release: tag ` + "`@kubernetes/release-team-leads`" + ` on this PR and ping the [#sig-release Slack channel](https://kubernetes.slack.com/archives/C2C40FMNF) to request adding the ` + "`{{ .Tag }}`" + ` milestone
+2. Inclusion in release: tag ` + "`@kubernetes/sig-release-leads`" + ` on this PR and ping the [#sig-release Slack channel](https://kubernetes.slack.com/archives/C2C40FMNF) to request adding the ` + "`{{ .Tag }}`" + ` milestone
 {{ end }}{{ end }}
 {{ if .InTestFreeze }}
 ---

--- a/pkg/plugins/testfreeze/testfreeze_test.go
+++ b/pkg/plugins/testfreeze/testfreeze_test.go
@@ -37,6 +37,7 @@ func TestHandle(t *testing.T) {
 		name              string
 		action            github.PullRequestEventAction
 		org, repo, branch string
+		labels            []string
 		prepare           func(*testfreezefakes.FakeVerifier)
 		assert            func(*testfreezefakes.FakeVerifier, error)
 	}{
@@ -65,6 +66,7 @@ func TestHandle(t *testing.T) {
 				assert.Contains(t, comment, "Technical review")
 				assert.Contains(t, comment, "Inclusion in release")
 				assert.Contains(t, comment, "#sig-release Slack channel")
+				assert.Contains(t, comment, "@kubernetes/sig-release-leads")
 				assert.Contains(t, comment, "Test Freeze")
 				assert.Contains(t, comment, "for the `release-1.23` branch")
 				assert.Contains(t, comment, "Fast forwards are scheduled to happen every 6 hours, whereas the most recent run was: Wed May  4 16:15:37 CEST 2022")
@@ -93,6 +95,32 @@ func TestHandle(t *testing.T) {
 				assert.Contains(t, comment, "Adding the milestone to this PR is strictly prohibited")
 				assert.NotContains(t, comment, "Test Freeze")
 				assert.NotContains(t, comment, "Fast forwards")
+			},
+		},
+		{
+			name:   "kind/bug in code freeze gets softer message",
+			action: github.PullRequestActionOpened,
+			org:    defaultKubernetesRepoAndOrg,
+			repo:   defaultKubernetesRepoAndOrg,
+			branch: defaultKubernetesBranch,
+			labels: []string{"kind/bug"},
+			prepare: func(mock *testfreezefakes.FakeVerifier) {
+				mock.CheckInTestFreezeReturns(&checker.Result{
+					InCodeFreeze:    true,
+					InTestFreeze:    false,
+					Tag:             "v1.23.0",
+					Branch:          "release-1.23",
+					LastFastForward: "",
+				}, nil)
+			},
+			assert: func(mock *testfreezefakes.FakeVerifier, err error) {
+				assert.Nil(t, err)
+				assert.Equal(t, 1, mock.CreateCommentCallCount())
+				_, _, _, _, comment := mock.CreateCommentArgsForCall(0)
+				assert.Contains(t, comment, "Code Freeze")
+				assert.Contains(t, comment, "kind/bug")
+				assert.Contains(t, comment, "@kubernetes/sig-release-leads")
+				assert.NotContains(t, comment, "strictly prohibited")
 			},
 		},
 		{
@@ -224,7 +252,7 @@ func TestHandle(t *testing.T) {
 			sut.verifier = mock
 
 			entry := logrus.NewEntry(logrus.StandardLogger())
-			err := sut.handle(entry, nil, tc.action, 0, tc.org, tc.repo, tc.branch)
+			err := sut.handle(entry, nil, tc.action, 0, tc.org, tc.repo, tc.branch, tc.labels)
 			tc.assert(mock, err)
 		})
 	}

--- a/pkg/plugins/testfreeze/testfreeze_test.go
+++ b/pkg/plugins/testfreeze/testfreeze_test.go
@@ -66,7 +66,7 @@ func TestHandle(t *testing.T) {
 				assert.Contains(t, comment, "Technical review")
 				assert.Contains(t, comment, "Inclusion in release")
 				assert.Contains(t, comment, "#sig-release Slack channel")
-				assert.Contains(t, comment, "@kubernetes/sig-release-leads")
+				assert.Contains(t, comment, "@kubernetes/release-team-leads")
 				assert.Contains(t, comment, "Test Freeze")
 				assert.Contains(t, comment, "for the `release-1.23` branch")
 				assert.Contains(t, comment, "Fast forwards are scheduled to happen every 6 hours, whereas the most recent run was: Wed May  4 16:15:37 CEST 2022")
@@ -119,7 +119,7 @@ func TestHandle(t *testing.T) {
 				_, _, _, _, comment := mock.CreateCommentArgsForCall(0)
 				assert.Contains(t, comment, "Code Freeze")
 				assert.Contains(t, comment, "kind/bug")
-				assert.Contains(t, comment, "@kubernetes/sig-release-leads")
+				assert.Contains(t, comment, "@kubernetes/release-team-leads")
 				assert.NotContains(t, comment, "strictly prohibited")
 			},
 		},

--- a/pkg/plugins/testfreeze/testfreeze_test.go
+++ b/pkg/plugins/testfreeze/testfreeze_test.go
@@ -66,7 +66,7 @@ func TestHandle(t *testing.T) {
 				assert.Contains(t, comment, "Technical review")
 				assert.Contains(t, comment, "Inclusion in release")
 				assert.Contains(t, comment, "#sig-release Slack channel")
-				assert.Contains(t, comment, "@kubernetes/release-team-leads")
+				assert.Contains(t, comment, "@kubernetes/sig-release-leads")
 				assert.Contains(t, comment, "Test Freeze")
 				assert.Contains(t, comment, "for the `release-1.23` branch")
 				assert.Contains(t, comment, "Fast forwards are scheduled to happen every 6 hours, whereas the most recent run was: Wed May  4 16:15:37 CEST 2022")
@@ -119,7 +119,7 @@ func TestHandle(t *testing.T) {
 				_, _, _, _, comment := mock.CreateCommentArgsForCall(0)
 				assert.Contains(t, comment, "Code Freeze")
 				assert.Contains(t, comment, "kind/bug")
-				assert.Contains(t, comment, "@kubernetes/release-team-leads")
+				assert.Contains(t, comment, "@kubernetes/sig-release-leads")
 				assert.NotContains(t, comment, "strictly prohibited")
 			},
 		},


### PR DESCRIPTION
## Summary

- `kind/bug` PRs during Code Freeze now get a softer message: they **may** be included in the release, but must tag `@kubernetes/sig-release-leads` on the PR so the release team has a record
- Non-bug PRs keep the strict prohibition, but the message now instructs tagging on GitHub (in addition to Slack), matching the explicit request from release team leads
- Adds a `kind/bug` test case verifying the new message path

## Context

Per the sig-release policy discussion in #release-management (July 2025):
- Bug fixes have consistently been allowed to target a milestone during freeze
- Release team leads (Kat Cosgrove, Dipesh) confirmed: tag `@kubernetes/sig-release-leads` on the PR, Slack for time-sensitive cases
- The existing "strictly prohibited" message was overly broad and conflicted with established practice

## Test plan
- [x] Existing tests updated and passing
- [x] New test case: `kind/bug in code freeze gets softer message`
- [x] `go test ./pkg/plugins/testfreeze/...` passes