### PR TITLE
Add dependabot config for dep grouping

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,23 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directories:
+      - "/"
+      - "/hack/tools"
+      - "/site"
+    schedule:
+      interval: "weekly"
+    groups:
+      kubernetes:
+        patterns:
+          - "*k8s.io*"
+      prometheus:
+        patterns:
+          - "*github.com/prometheus*"
+      aws:
+        patterns:
+          - "*github.com/aws*"
+      golang-x:
+        patterns:
+          - "*golang.org/x*"
+


### PR DESCRIPTION
We use dependabot for keeping our Go dependencies up to date. By default this will propose a PR for each dependency update it finds. There are some sets of dependencies, like the regularly generated AWS clients and the golang.org/x deps, that are usually released at the same time. With the default setting of proposing a single PR for each update, this will often lead to the first PR in the group causing a merge conflict with any others in the group, resulting in a lot of extra churn.

This adds the dependabot config to group some of these common sets of libraries so dependabot will collect all updates within the group and propose them as a single PR, avoiding merge conflicts and reducing review and CI overhead.