### PR TITLE
[WIP] slackevents: alert on merged PRs with cncf-cla: no label

### DIFF
--- a/pkg/plugins/config.go
+++ b/pkg/plugins/config.go
@@ -629,6 +629,9 @@ type BranchToMilestone map[string]string
 type Slack struct {
 	MentionChannels []string       `json:"mentionchannels,omitempty"`
 	MergeWarnings   []MergeWarning `json:"mergewarnings,omitempty"`
+	// CLAAlerts configures Slack notifications for merged PRs carrying
+	// the cncf-cla: no label.
+	CLAAlerts []CLAAlert `json:"claalerts,omitempty"`
 }
 
 // ConfigMapSpec contains configuration options for the configMap being updated
@@ -847,6 +850,15 @@ type MergeWarning struct {
 	ExemptUsers []string `json:"exempt_users,omitempty"`
 	// A slack event is published if the user is not on the exempt branches.
 	ExemptBranches map[string][]string `json:"exempt_branches,omitempty"`
+}
+
+// CLAAlert configures Slack notifications for merged PRs carrying
+// the cncf-cla: no label.
+type CLAAlert struct {
+	// Repos is either of the form org/repo or just org.
+	Repos []string `json:"repos,omitempty"`
+	// Channels is the list of Slack channels to notify.
+	Channels []string `json:"channels,omitempty"`
 }
 
 // Welcome is config for the welcome plugin.

--- a/pkg/plugins/slackevents/slackevents.go
+++ b/pkg/plugins/slackevents/slackevents.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/prow/pkg/config"
 	"sigs.k8s.io/prow/pkg/github"
+	"sigs.k8s.io/prow/pkg/labels"
 	"sigs.k8s.io/prow/pkg/pluginhelp"
 	"sigs.k8s.io/prow/pkg/plugins"
 )
@@ -54,6 +55,7 @@ type client struct {
 func init() {
 	plugins.RegisterPushEventHandler(pluginName, handlePush, helpProvider)
 	plugins.RegisterGenericCommentHandler(pluginName, handleComment, helpProvider)
+	plugins.RegisterPullRequestHandler(pluginName, handlePullRequest, helpProvider)
 }
 
 func helpProvider(config *plugins.Configuration, enabledRepos []config.OrgRepo) (*pluginhelp.PluginHelp, error) {
@@ -101,6 +103,12 @@ func helpProvider(config *plugins.Configuration, enabledRepos []config.OrgRepo) 
 					},
 				},
 			},
+			CLAAlerts: []plugins.CLAAlert{
+				{
+					Repos:    []string{"org/repo1", "org/repo2"},
+					Channels: []string{"channel5"},
+				},
+			},
 		},
 	})
 	if err != nil {
@@ -108,8 +116,11 @@ func helpProvider(config *plugins.Configuration, enabledRepos []config.OrgRepo) 
 	}
 	return &pluginhelp.PluginHelp{
 			Description: `The slackevents plugin reacts to various GitHub events by commenting in Slack channels.
-<ol><li>The plugin can create comments to alert on manual merges. Manual merges are merges made by a normal user instead of a bot or trusted user.</li>
-<li>The plugin can create comments to reiterate SIG mentions like '@kubernetes/sig-testing-bugs' from GitHub.</li></ol>`,
+<ol>
+<li>The plugin can create comments to alert on manual merges. Manual merges are merges made by a normal user instead of a bot or trusted user.</li>
+<li>The plugin can send Slack alerts when a PR carrying the "cncf-cla: no" label is merged.</li>
+<li>The plugin can create comments to reiterate SIG mentions like '@kubernetes/sig-testing-bugs' from GitHub.</li>
+</ol>`,
 			Config:  configInfo,
 			Snippet: yamlSnippet,
 		},
@@ -132,6 +143,15 @@ func handlePush(pc plugins.Agent, pe github.PushEvent) error {
 		SlackClient:  pc.SlackClient,
 	}
 	return notifyOnSlackIfManualMerge(c, pe)
+}
+
+func handlePullRequest(pc plugins.Agent, pre github.PullRequestEvent) error {
+	c := client{
+		GitHubClient: pc.GitHubClient,
+		SlackConfig:  pc.PluginConfig.Slack,
+		SlackClient:  pc.SlackClient,
+	}
+	return notifyOnCLAIfMerged(c, pre)
 }
 
 func notifyOnSlackIfManualMerge(pc client, pe github.PushEvent) error {
@@ -215,6 +235,64 @@ func echoToSlack(pc client, e github.GenericCommentEvent) error {
 		msg := fmt.Sprintf("%s was mentioned by %s (<@%s>) on GitHub. (%s)\n>>>%s", sig, e.User.Login, e.User.Login, e.HTMLURL, e.Body)
 		if err := pc.SlackClient.WriteMessage(msg, sig); err != nil {
 			return fmt.Errorf("Failed to send message on slack channel: %q with message %q. Err: %w", sig, msg, err)
+		}
+	}
+	return nil
+}
+
+// notifyOnCLAIfMerged sends a Slack alert to all configured channels when a
+// PR carrying the "cncf-cla: no" label is merged. It reads labels directly
+// from the PullRequestEvent payload, which works regardless of merge strategy
+// (merge, squash, or rebase).
+func notifyOnCLAIfMerged(pc client, pre github.PullRequestEvent) error {
+	// Only act on PRs that were actually merged, not just closed.
+	if pre.Action != github.PullRequestActionClosed || !pre.PullRequest.Merged {
+		return nil
+	}
+
+	// Find the configured CLAAlert for this repository (exact org/repo match first,
+	// then org-level fallback).
+	ca := getCLAAlert(pc.SlackConfig.CLAAlerts, config.OrgRepo{
+		Org:  pre.Repo.Owner.Login,
+		Repo: pre.Repo.Name,
+	})
+	if ca == nil {
+		return nil
+	}
+
+	// Check whether the merged PR carries the "cncf-cla: no" label.
+	for _, l := range pre.PullRequest.Labels {
+		if l.Name != labels.ClaNo {
+			continue
+		}
+		msg := fmt.Sprintf(
+			"*Alert:* PR #%d merged with %q label by %s — %s",
+			pre.Number,
+			labels.ClaNo,
+			pre.PullRequest.User.Login,
+			pre.PullRequest.HTMLURL,
+		)
+		for _, ch := range ca.Channels {
+			if err := pc.SlackClient.WriteMessage(msg, ch); err != nil {
+				return fmt.Errorf("failed to post CLA alert to %s: %w", ch, err)
+			}
+		}
+		break
+	}
+	return nil
+}
+
+// getCLAAlert returns the CLAAlert config for the given repo.
+// It checks for an exact org/repo match first, then falls back to org-level.
+func getCLAAlert(alerts []plugins.CLAAlert, repo config.OrgRepo) *plugins.CLAAlert {
+	for _, a := range alerts {
+		if sets.NewString(a.Repos...).Has(repo.String()) {
+			return &a
+		}
+	}
+	for _, a := range alerts {
+		if sets.NewString(a.Repos...).Has(repo.Org) {
+			return &a
 		}
 	}
 	return nil

--- a/pkg/plugins/slackevents/slackevents_test.go
+++ b/pkg/plugins/slackevents/slackevents_test.go
@@ -24,6 +24,7 @@ import (
 	"sigs.k8s.io/prow/pkg/config"
 	"sigs.k8s.io/prow/pkg/github"
 	"sigs.k8s.io/prow/pkg/github/fakegithub"
+	"sigs.k8s.io/prow/pkg/labels"
 	"sigs.k8s.io/prow/pkg/plugins"
 	"sigs.k8s.io/prow/pkg/slack"
 )
@@ -349,6 +350,12 @@ func TestHelpProvider(t *testing.T) {
 							},
 						},
 					},
+					CLAAlerts: []plugins.CLAAlert{
+						{
+							Repos:    []string{"org2/repo"},
+							Channels: []string{"cla-alerts"},
+						},
+					},
 				},
 			},
 			enabledRepos: enabledRepos,
@@ -359,6 +366,189 @@ func TestHelpProvider(t *testing.T) {
 			_, err := helpProvider(c.config, c.enabledRepos)
 			if err != nil && !c.err {
 				t.Fatalf("helpProvider error: %v", err)
+			}
+		})
+	}
+}
+
+func TestNotifyOnCLAIfMerged(t *testing.T) {
+	const (
+		org    = "kubernetes"
+		repo   = "test-repo"
+		prURL  = "https://github.com/kubernetes/test-repo/pull/42"
+		merger = "contributor"
+	)
+
+	basePR := github.PullRequestEvent{
+		Action: github.PullRequestActionClosed,
+		Number: 42,
+		PullRequest: github.PullRequest{
+			Number:  42,
+			Merged:  true,
+			HTMLURL: prURL,
+			User:    github.User{Login: merger},
+			Labels:  []github.Label{{Name: labels.ClaNo}},
+		},
+		Repo: github.Repo{
+			Name:  repo,
+			Owner: github.User{Login: org},
+		},
+	}
+
+	expectedMsg := `*Alert:* PR #42 merged with "cncf-cla: no" label by contributor — https://github.com/kubernetes/test-repo/pull/42`
+
+	testcases := []struct {
+		name             string
+		event            github.PullRequestEvent
+		claAlerts        []plugins.CLAAlert
+		expectedMessages map[string][]string
+	}{
+		{
+			name:  "merged PR with cncf-cla: no sends alert",
+			event: basePR,
+			claAlerts: []plugins.CLAAlert{
+				{Repos: []string{"kubernetes/test-repo"}, Channels: []string{"cla-alerts"}},
+			},
+			expectedMessages: map[string][]string{
+				"cla-alerts": {expectedMsg},
+			},
+		},
+		{
+			name: "closed but not merged PR sends no alert",
+			event: func() github.PullRequestEvent {
+				e := basePR
+				e.PullRequest.Merged = false
+				return e
+			}(),
+			claAlerts: []plugins.CLAAlert{
+				{Repos: []string{"kubernetes/test-repo"}, Channels: []string{"cla-alerts"}},
+			},
+			expectedMessages: map[string][]string{},
+		},
+		{
+			name: "non-closed action sends no alert",
+			event: func() github.PullRequestEvent {
+				e := basePR
+				e.Action = github.PullRequestActionOpened
+				return e
+			}(),
+			claAlerts: []plugins.CLAAlert{
+				{Repos: []string{"kubernetes/test-repo"}, Channels: []string{"cla-alerts"}},
+			},
+			expectedMessages: map[string][]string{},
+		},
+		{
+			name: "merged PR without cncf-cla: no sends no alert",
+			event: func() github.PullRequestEvent {
+				e := basePR
+				e.PullRequest.Labels = []github.Label{{Name: "approved"}, {Name: "lgtm"}}
+				return e
+			}(),
+			claAlerts: []plugins.CLAAlert{
+				{Repos: []string{"kubernetes/test-repo"}, Channels: []string{"cla-alerts"}},
+			},
+			expectedMessages: map[string][]string{},
+		},
+		{
+			name:  "repo not in config sends no alert",
+			event: basePR,
+			claAlerts: []plugins.CLAAlert{
+				{Repos: []string{"kubernetes/other-repo"}, Channels: []string{"cla-alerts"}},
+			},
+			expectedMessages: map[string][]string{},
+		},
+		{
+			name:             "no CLAAlerts configured sends no alert",
+			event:            basePR,
+			claAlerts:        []plugins.CLAAlert{},
+			expectedMessages: map[string][]string{},
+		},
+		{
+			name:  "org-level config matches all repos in org",
+			event: basePR,
+			claAlerts: []plugins.CLAAlert{
+				{Repos: []string{"kubernetes"}, Channels: []string{"cla-alerts"}},
+			},
+			expectedMessages: map[string][]string{
+				"cla-alerts": {expectedMsg},
+			},
+		},
+		{
+			name:  "alert sent to multiple channels",
+			event: basePR,
+			claAlerts: []plugins.CLAAlert{
+				{Repos: []string{"kubernetes/test-repo"}, Channels: []string{"cla-alerts", "sig-contribex"}},
+			},
+			expectedMessages: map[string][]string{
+				"cla-alerts":    {expectedMsg},
+				"sig-contribex": {expectedMsg},
+			},
+		},
+		{
+			name: "cncf-cla: no among multiple labels still triggers alert",
+			event: func() github.PullRequestEvent {
+				e := basePR
+				e.PullRequest.Labels = []github.Label{
+					{Name: "approved"},
+					{Name: labels.ClaNo},
+					{Name: "lgtm"},
+				}
+				return e
+			}(),
+			claAlerts: []plugins.CLAAlert{
+				{Repos: []string{"kubernetes/test-repo"}, Channels: []string{"cla-alerts"}},
+			},
+			expectedMessages: map[string][]string{
+				"cla-alerts": {expectedMsg},
+			},
+		},
+		{
+			name:  "exact repo match takes precedence over org-level",
+			event: basePR,
+			claAlerts: []plugins.CLAAlert{
+				{Repos: []string{"kubernetes/test-repo"}, Channels: []string{"exact-channel"}},
+				{Repos: []string{"kubernetes"}, Channels: []string{"org-channel"}},
+			},
+			expectedMessages: map[string][]string{
+				"exact-channel": {expectedMsg},
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			slackClient := &FakeClient{SentMessages: make(map[string][]string)}
+			pc := client{
+				SlackConfig: plugins.Slack{CLAAlerts: tc.claAlerts},
+				SlackClient: slackClient,
+			}
+
+			if err := notifyOnCLAIfMerged(pc, tc.event); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if len(slackClient.SentMessages) != len(tc.expectedMessages) {
+				t.Errorf("channel count mismatch: expected %d, got %d\nExpected: %v\nGot:      %v",
+					len(tc.expectedMessages), len(slackClient.SentMessages),
+					tc.expectedMessages, slackClient.SentMessages)
+				return
+			}
+			for ch, wantMsgs := range tc.expectedMessages {
+				gotMsgs, ok := slackClient.SentMessages[ch]
+				if !ok {
+					t.Errorf("expected message to channel %q but none sent", ch)
+					continue
+				}
+				if len(gotMsgs) != len(wantMsgs) {
+					t.Errorf("channel %q: expected %d messages, got %d", ch, len(wantMsgs), len(gotMsgs))
+					continue
+				}
+				for i := range wantMsgs {
+					if gotMsgs[i] != wantMsgs[i] {
+						t.Errorf("channel %q message %d mismatch:\nExpected: %q\nGot:      %q",
+							ch, i, wantMsgs[i], gotMsgs[i])
+					}
+				}
 			}
 		})
 	}


### PR DESCRIPTION
Fixes #279
This PR adds Slack notifications for merged pull requests carrying the `cncf-cla: no` label.

The implementation introduces `CLAAlert` configuration, handles pull request merge events in the `slackevents` plugin, supports both repository and organization-level configuration, and includes unit tests.