### PR TITLE
plank: enforce pending timeout when build cluster is unreachable

### DIFF
--- a/pkg/plank/controller_test.go
+++ b/pkg/plank/controller_test.go
@@ -862,6 +862,7 @@ func TestSyncPendingJob(t *testing.T) {
 		ExpectedPodRunningTimeout     *metav1.Duration
 		ExpectedPodPendingTimeout     *metav1.Duration
 		ExpectedPodUnscheduledTimeout *metav1.Duration
+		ExpectError                   bool
 	}
 	testcases := []testCase{
 		{
@@ -1336,6 +1337,52 @@ func TestSyncPendingJob(t *testing.T) {
 			ExpectedURL:      "jose/error",
 		},
 		{
+			Name: "build cluster unreachable, pending timeout exceeded",
+			PJ: prowapi.ProwJob{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cluster-down",
+					Namespace: "prowjobs",
+				},
+				Spec: prowapi.ProwJobSpec{
+					Job:     "boop",
+					Type:    prowapi.PostsubmitJob,
+					PodSpec: &v1.PodSpec{Containers: []v1.Container{{Name: "test-name", Env: []v1.EnvVar{}}}},
+					Refs:    &prowapi.Refs{Org: "fejtaverse"},
+				},
+				Status: prowapi.ProwJobStatus{
+					State:       prowapi.PendingState,
+					PendingTime: startTime(time.Now().Add(-2 * time.Hour)),
+				},
+			},
+			Err:              errors.New("connection refused"),
+			ExpectedState:    prowapi.ErrorState,
+			ExpectedComplete: true,
+			ExpectedNumPods:  0,
+		},
+		{
+			Name: "build cluster unreachable, pending timeout not yet exceeded",
+			PJ: prowapi.ProwJob{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cluster-down-fresh",
+					Namespace: "prowjobs",
+				},
+				Spec: prowapi.ProwJobSpec{
+					Job:     "boop",
+					Type:    prowapi.PostsubmitJob,
+					PodSpec: &v1.PodSpec{Containers: []v1.Container{{Name: "test-name", Env: []v1.EnvVar{}}}},
+					Refs:    &prowapi.Refs{Org: "fejtaverse"},
+				},
+				Status: prowapi.ProwJobStatus{
+					State:       prowapi.PendingState,
+					PendingTime: startTime(time.Now().Add(-time.Minute)),
+				},
+			},
+			Err:             errors.New("connection refused"),
+			ExpectError:     true,
+			ExpectedState:   prowapi.PendingState,
+			ExpectedNumPods: 0,
+		},
+		{
 			Name: "stale pending prow job",
 			PJ: prowapi.ProwJob{
 				ObjectMeta: metav1.ObjectMeta{
@@ -1765,8 +1812,15 @@ func TestSyncPendingJob(t *testing.T) {
 				clock:        clock.RealClock{},
 			}
 			reconcileResult, err := r.syncPendingJob(ctx, &tc.PJ)
+			if (err != nil) != tc.ExpectError {
+				if tc.ExpectError {
+					t.Fatalf("expected an error from syncPendingJob, but got none")
+				} else {
+					t.Fatalf("syncPendingJob failed: %v", err)
+				}
+			}
 			if err != nil {
-				t.Fatalf("syncPendingJob failed: %v", err)
+				return
 			}
 			if reconcileResult != nil {
 				// Round this to minutes so we can compare the value without risking flaky tests

--- a/pkg/plank/reconciler.go
+++ b/pkg/plank/reconciler.go
@@ -465,12 +465,20 @@ func (r *reconciler) syncPendingJob(ctx context.Context, pj *prowv1.ProwJob) (*r
 		id, pn, err := r.startPod(ctx, pj)
 		if err != nil {
 			if !isRequestError(err) {
-				return nil, fmt.Errorf("error starting pod for PJ %s: %w", pj.Name, err)
+				if pj.Status.PendingTime != nil && r.clock.Since(pj.Status.PendingTime.Time) >= r.maxPodPendingTimeout(pj) {
+					pj.SetComplete()
+					pj.Status.State = prowv1.ErrorState
+					pj.Status.Description = fmt.Sprintf("Pod pending timeout: failed to create pod in build cluster: %v", err)
+					r.log.WithFields(pjutil.ProwJobFields(pj)).WithError(err).Info("Marked job as errored: pod creation failed and pending timeout exceeded.")
+				} else {
+					return nil, fmt.Errorf("error starting pod for PJ %s: %w", pj.Name, err)
+				}
+			} else {
+				pj.Status.State = prowv1.ErrorState
+				pj.SetComplete()
+				pj.Status.Description = fmt.Sprintf("Pod can not be created: %v", err)
+				r.log.WithFields(pjutil.ProwJobFields(pj)).WithError(err).Warning("Unprocessable pod.")
 			}
-			pj.Status.State = prowv1.ErrorState
-			pj.SetComplete()
-			pj.Status.Description = fmt.Sprintf("Pod can not be created: %v", err)
-			r.log.WithFields(pjutil.ProwJobFields(pj)).WithError(err).Warning("Unprocessable pod.")
 		} else {
 			pj.Status.BuildID = id
 			pj.Status.PodName = pn
@@ -548,10 +556,7 @@ func (r *reconciler) syncPendingJob(ctx context.Context, pj *prowv1.ProwJob) (*r
 
 		case corev1.PodPending:
 			var requeueAfter time.Duration
-			maxPodPending := r.config().Plank.PodPendingTimeout.Duration
-			if pj.Spec.DecorationConfig != nil && pj.Spec.DecorationConfig.PodPendingTimeout != nil {
-				maxPodPending = pj.Spec.DecorationConfig.PodPendingTimeout.Duration
-			}
+			maxPodPending := r.maxPodPendingTimeout(pj)
 			maxPodUnscheduled := r.config().Plank.PodUnscheduledTimeout.Duration
 			if pj.Spec.DecorationConfig != nil && pj.Spec.DecorationConfig.PodUnscheduledTimeout != nil {
 				maxPodUnscheduled = pj.Spec.DecorationConfig.PodUnscheduledTimeout.Duration
@@ -849,6 +854,14 @@ func (r *reconciler) deletePod(ctx context.Context, pj *prowv1.ProwJob) error {
 
 	r.log.WithFields(pjutil.ProwJobFields(pj)).Info("Deleted stale running pod.")
 	return nil
+}
+
+func (r *reconciler) maxPodPendingTimeout(pj *prowv1.ProwJob) time.Duration {
+	maxPodPending := r.config().Plank.PodPendingTimeout.Duration
+	if pj.Spec.DecorationConfig != nil && pj.Spec.DecorationConfig.PodPendingTimeout != nil {
+		maxPodPending = pj.Spec.DecorationConfig.PodPendingTimeout.Duration
+	}
+	return maxPodPending
 }
 
 func (r *reconciler) startPod(ctx context.Context, pj *prowv1.ProwJob) (string, string, error) {


### PR DESCRIPTION
## Summary

When a build cluster becomes unreachable, `syncPendingJob` enters a retry loop that never terminates:

1. `r.pod()` does an informer cache lookup — pod not found (cache is empty after plank restart while the cluster was down)
2. Enters `!podExists` branch → calls `startPod()` → `client.Create()` (direct API write)
3. Cluster unreachable → network error (e.g. connection refused)
4. `isRequestError()` returns `false` — it only matches 4xx API responses, not raw network errors
5. Returns error → controller-runtime requeues with backoff → repeats forever

The `pod_pending_timeout` is never evaluated because the timeout check only runs after the pod is found in the informer cache and observed in a PodPending phase. When the pod is missing from the cache entirely, neither the scheduling nor the pending timeout code paths are reached.

**Fix:** In the `!podExists` path, when `startPod()` fails with a non-request error, check the ProwJob's `pendingTime` against the configured `pod_pending_timeout`. If the timeout has been exceeded, mark the job as errored instead of retrying forever. If the timeout hasn't elapsed yet, continue retrying (the cluster may recover).

Also extracts `maxPodPendingTimeout` helper to deduplicate the timeout resolution logic between the pod-missing and pod-pending code paths (addresses review feedback from the previous revision).

**Example:** https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-build-farm-canary-build06/2080695972983214080 — this canary job was stuck in pending state since July 24 because build06 was temporarily unreachable. Despite `pod_pending_timeout: 30m` being configured globally, it was never enforced. The prowjob.json confirms: `state: "pending"`, `pod_name` set (pod was originally created), no `finished.json` or `build-log.txt`.

### Why the informer cache read doesn't help

As confirmed in review discussion: `buildClient.Get()` reads from the informer cache — a purely in-memory lookup that never fails with network errors. When a build cluster goes down:
- If plank keeps running: the stale pod stays in cache, existing timeout logic works
- If plank restarts: fresh cache can't list from the unreachable cluster → pod is missing → `startPod()` network error loop (this fix)

## Changes

- **`pkg/plank/reconciler.go`**: Add pending timeout check in the `!podExists` + `startPod` failure path for non-request errors. Extract `maxPodPendingTimeout` helper.
- **`pkg/plank/controller_test.go`**: Add `ExpectError` field to test struct. Add two test cases: "build cluster unreachable, pending timeout exceeded" (expects ErrorState) and "build cluster unreachable, pending timeout not yet exceeded" (expects retry error).