### PR TITLE
spyglass/junit: add copy-to-clipboard widget for test names

### DIFF
--- a/pkg/spyglass/lenses/junit/junit.css
+++ b/pkg/spyglass/lenses/junit/junit.css
@@ -96,6 +96,19 @@ table.flaky-layout tbody tr.flaky-text:hover {
   vertical-align: middle;
 }
 
+.copy-test-name {
+  cursor: pointer;
+  font-size: 1em;
+  vertical-align: middle;
+  /* Kept in the layout at all times so revealing it doesn't shift the row. */
+  opacity: 0;
+  transition: opacity 0.1s;
+}
+
+tr:hover .copy-test-name {
+  opacity: 1;
+}
+
 .group-header {
   margin: 20px 0 5px 16px;
   color: #e8e8e8;

--- a/pkg/spyglass/lenses/junit/lens.ts
+++ b/pkg/spyglass/lenses/junit/lens.ts
@@ -51,8 +51,41 @@ const addStdoutStderrOpeners = (): void => {
   }
 };
 
+// Delegated to the container instead of one listener per icon: a run can have
+// thousands of tests, so thousands of copy icons.
+const addCopyTestNameButtons = (): void => {
+  const container = document.getElementById('junit-container');
+  if (!container) {
+    return;
+  }
+  // Capture phase: the expand/collapse handlers in addTestExpanders are bound
+  // directly to the row, which sits between the icon and this container, so a
+  // bubble-phase listener here would run after the row's handler already
+  // toggled it. Capturing runs top-down and lets us stop the click before it
+  // gets there.
+  container.addEventListener('click', (e) => {
+    const button = (e.target as HTMLElement).closest<HTMLElement>('i.copy-test-name');
+    if (!button) {
+      return;
+    }
+    e.stopPropagation();
+    navigator.clipboard.writeText(button.dataset.testName!).then(() => {
+      button.innerText = 'check';
+      setTimeout(() => {
+        button.innerText = 'content_copy';
+      }, 1000);
+    }, () => {
+      button.innerText = 'error_outline';
+      setTimeout(() => {
+        button.innerText = 'content_copy';
+      }, 1000);
+    });
+  }, true);
+};
+
 const loaded = (): void => {
   addTestExpanders();
+  addCopyTestNameButtons();
   addStdoutStderrOpeners();
   addSectionExpanders();
 };

--- a/pkg/spyglass/lenses/junit/lens_test.go
+++ b/pkg/spyglass/lenses/junit/lens_test.go
@@ -1237,6 +1237,8 @@ func TestTemplate(t *testing.T) {
 				`group-layout`,
 				`fake_class: informing_fail`,
 				`hidden-tests`,
+				`class="icon-button material-icons copy-test-name noselect" data-test-name="informing_fail"`,
+				`class="icon-button material-icons copy-test-name noselect" data-test-name="informing_pass"`,
 			},
 		},
 		{

--- a/pkg/spyglass/lenses/junit/template.html
+++ b/pkg/spyglass/lenses/junit/template.html
@@ -3,6 +3,9 @@
 <script type="text/javascript" src="script_bundle.min.js"></script>
 {{end}}
 
+{{/* Renders a test's name plus a widget that copies the bare test name to the clipboard. */}}
+{{define "testname"}}{{.ClassName}}: {{.Name}}&nbsp;<i class="icon-button material-icons copy-test-name noselect" data-test-name="{{.Name}}" title="Copy test name">content_copy</i>{{end}}
+
 {{define "body"}}
 {{$numF := len .Failed}}
 {{$numFlk := len .Flaky}}
@@ -29,7 +32,7 @@
         <td colspan="2" style="padding: 0;">
           <table class="failed-layout">
             <tr class="failure-name">
-              <td class="mdl-data-table__cell--non-numeric test-name">{{$firstTest.ClassName}}: {{$firstTest.Name}}&nbsp;<i class="icon-button material-icons arrow-icon">expand_more</i></td>
+              <td class="mdl-data-table__cell--non-numeric test-name">{{template "testname" $firstTest}}&nbsp;<i class="icon-button material-icons arrow-icon">expand_more</i></td>
               <td class="mdl-data-table__cell--non-numeric" style="text-align: right;">{{$firstTest.Duration}}</td>
             </tr>
             <tr class="hidden failure-text">
@@ -53,7 +56,7 @@
         <td colspan="2" style="padding: 0;">
           <table class="failed-layout">
             <tr class="failure-name">
-              <td class="mdl-data-table__cell--non-numeric test-name">{{$firstTest.ClassName}}: {{$firstTest.Name}}&nbsp;<i class="icon-button material-icons arrow-icon">expand_more</i></td>
+              <td class="mdl-data-table__cell--non-numeric test-name">{{template "testname" $firstTest}}&nbsp;<i class="icon-button material-icons arrow-icon">expand_more</i></td>
             </tr>
             <tr class="hidden">
               <td>
@@ -105,7 +108,7 @@
         <td colspan="2" style="padding: 0;">
           <table class="flaky-layout">
             <tr class="flaky-name">
-              <td class="mdl-data-table__cell--non-numeric test-name">{{$firstTest.ClassName}}: {{$firstTest.Name}}&nbsp;<i class="icon-button material-icons arrow-icon">expand_more</i></td>
+              <td class="mdl-data-table__cell--non-numeric test-name">{{template "testname" $firstTest}}&nbsp;<i class="icon-button material-icons arrow-icon">expand_more</i></td>
             </tr>
             <tr class="hidden">
               <td>
@@ -153,7 +156,7 @@
       {{range .Passed}}
         {{$firstTest := index .Junit 0}}
         <tr>
-          <td class="mdl-data-table__cell--non-numeric test-name">{{$firstTest.ClassName}}: {{$firstTest.Name}}</td>
+          <td class="mdl-data-table__cell--non-numeric test-name">{{template "testname" $firstTest}}</td>
           <td class="mdl-data-table__cell--non-numeric">{{$firstTest.Duration}}</td>
         </tr>
       {{end}}
@@ -169,9 +172,9 @@
         {{$firstTest := index .Junit 0}}
         <tr>
 	   {{if eq $firstTest.SkippedReason "" }}
-	   <td class="mdl-data-table__cell--non-numeric test-name">{{$firstTest.ClassName}}: {{$firstTest.Name}}</td>
+	   <td class="mdl-data-table__cell--non-numeric test-name">{{template "testname" $firstTest}}</td>
 	   {{else}}
-	   <td class="mdl-data-table__cell--non-numeric test-name">{{$firstTest.ClassName}}: {{$firstTest.Name}}</br> </br><b>Reason:</b> {{$firstTest.SkippedReason}}</td>
+	   <td class="mdl-data-table__cell--non-numeric test-name">{{template "testname" $firstTest}}</br> </br><b>Reason:</b> {{$firstTest.SkippedReason}}</td>
 	   {{end}}
           <td class="mdl-data-table__cell--non-numeric">{{$firstTest.Duration}}</td>
         </tr>
@@ -201,7 +204,7 @@
         <td colspan="2" style="padding: 0;">
           <table class="group-layout">
             <tr class="group-name">
-              <td class="mdl-data-table__cell--non-numeric test-name">{{$firstTest.ClassName}}: {{$firstTest.Name}}&nbsp;<i class="icon-button material-icons arrow-icon">expand_more</i></td>
+              <td class="mdl-data-table__cell--non-numeric test-name">{{template "testname" $firstTest}}&nbsp;<i class="icon-button material-icons arrow-icon">expand_more</i></td>
               <td class="mdl-data-table__cell--non-numeric" style="text-align: right;">{{$firstTest.Duration}}</td>
             </tr>
             <tr class="hidden group-text">
@@ -225,7 +228,7 @@
         <td colspan="2" style="padding: 0;">
           <table class="group-layout">
             <tr class="group-name">
-              <td class="mdl-data-table__cell--non-numeric test-name">{{$firstTest.ClassName}}: {{$firstTest.Name}}&nbsp;<i class="icon-button material-icons arrow-icon">expand_more</i></td>
+              <td class="mdl-data-table__cell--non-numeric test-name">{{template "testname" $firstTest}}&nbsp;<i class="icon-button material-icons arrow-icon">expand_more</i></td>
             </tr>
             <tr class="hidden">
               <td>
@@ -277,7 +280,7 @@
         <td colspan="2" style="padding: 0;">
           <table class="group-layout">
             <tr class="group-name">
-              <td class="mdl-data-table__cell--non-numeric test-name">{{$firstTest.ClassName}}: {{$firstTest.Name}}&nbsp;<i class="icon-button material-icons arrow-icon">expand_more</i></td>
+              <td class="mdl-data-table__cell--non-numeric test-name">{{template "testname" $firstTest}}&nbsp;<i class="icon-button material-icons arrow-icon">expand_more</i></td>
             </tr>
             <tr class="hidden">
               <td>
@@ -325,7 +328,7 @@
       {{range $group.Passed}}
         {{$firstTest := index .Junit 0}}
         <tr>
-          <td class="mdl-data-table__cell--non-numeric test-name">{{$firstTest.ClassName}}: {{$firstTest.Name}}</td>
+          <td class="mdl-data-table__cell--non-numeric test-name">{{template "testname" $firstTest}}</td>
           <td class="mdl-data-table__cell--non-numeric">{{$firstTest.Duration}}</td>
         </tr>
       {{end}}
@@ -341,9 +344,9 @@
         {{$firstTest := index .Junit 0}}
         <tr>
 	   {{if eq $firstTest.SkippedReason "" }}
-	   <td class="mdl-data-table__cell--non-numeric test-name">{{$firstTest.ClassName}}: {{$firstTest.Name}}</td>
+	   <td class="mdl-data-table__cell--non-numeric test-name">{{template "testname" $firstTest}}</td>
 	   {{else}}
-	   <td class="mdl-data-table__cell--non-numeric test-name">{{$firstTest.ClassName}}: {{$firstTest.Name}}</br> </br><b>Reason:</b> {{$firstTest.SkippedReason}}</td>
+	   <td class="mdl-data-table__cell--non-numeric test-name">{{template "testname" $firstTest}}</br> </br><b>Reason:</b> {{$firstTest.SkippedReason}}</td>
 	   {{end}}
           <td class="mdl-data-table__cell--non-numeric">{{$firstTest.Duration}}</td>
         </tr>


### PR DESCRIPTION
Test names in the JUnit lens are rendered as "ClassName: Name", which is awkward to select by hand and yields a string that needs editing before it can be used as a test filter or a search term.

 Add a small copy icon next to every test name that puts the bare test name on the clipboard. The name is carried in a data attribute rather than scraped from the cell, since the cell also holds the expander arrow and, for skipped tests, the skip reason. The icon only appears on row hover.

Click handling is delegated to a single listener on the container, since a run can have thousands of tests and thus thousands of copy icons. It runs in the capture phase: the row's own expand/collapse handler is bound directly to the row, which sits between the icon and the container, so a bubble-phase listener here would run after the row's handler already fired. Capturing lets us stop the click before it gets there.

Assisted by Claude Code
