### PR TITLE
fix(deck): replace gorilla/csrf with net/http.CrossOriginProtection

### DIFF
--- a/cmd/deck/main.go
+++ b/cmd/deck/main.go
@@ -19,7 +19,6 @@ package main
 import (
 	"bytes"
 	"context"
-	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
@@ -42,7 +41,6 @@ import (
 	"sigs.k8s.io/prow/pkg/tide"
 
 	"github.com/NYTimes/gziphandler"
-	"github.com/gorilla/csrf"
 	"github.com/gorilla/sessions"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
@@ -92,10 +90,10 @@ import (
 	_ "sigs.k8s.io/prow/pkg/spyglass/lenses/html"
 	_ "sigs.k8s.io/prow/pkg/spyglass/lenses/junit"
 	_ "sigs.k8s.io/prow/pkg/spyglass/lenses/links"
+	_ "sigs.k8s.io/prow/pkg/spyglass/lenses/markdown"
 	_ "sigs.k8s.io/prow/pkg/spyglass/lenses/metadata"
 	_ "sigs.k8s.io/prow/pkg/spyglass/lenses/podinfo"
 	_ "sigs.k8s.io/prow/pkg/spyglass/lenses/restcoverage"
-	_ "sigs.k8s.io/prow/pkg/spyglass/lenses/markdown"
 )
 
 // Omittable ProwJob fields.
@@ -185,7 +183,7 @@ func gatherOptions(fs *flag.FlagSet, args ...string) options {
 	fs.StringVar(&o.templateFilesLocation, "template-files-location", fmt.Sprintf("%s%s", os.Getenv("KO_DATA_PATH"), defaultTemplateFilesLocation), "Path to the template files")
 	fs.BoolVar(&o.gcsCookieAuth, "gcs-cookie-auth", false, "Use storage.cloud.google.com instead of signed URLs")
 	fs.BoolVar(&o.rerunCreatesJob, "rerun-creates-job", false, "Change the re-run option in Deck to actually create the job. **WARNING:** Only use this with non-public deck instances, otherwise strangers can DOS your Prow instance")
-	fs.BoolVar(&o.allowInsecure, "allow-insecure", false, "Allows insecure requests for CSRF and GitHub oauth.")
+	fs.BoolVar(&o.allowInsecure, "allow-insecure", false, "Allows insecure requests for GitHub oauth.")
 	fs.BoolVar(&o.dryRun, "dry-run", false, "Whether or not to make mutating API calls to GitHub.")
 	fs.Var(&o.tenantIDs, "tenant-id", "The tenantID(s) used by the ProwJobs that should be displayed by this instance of Deck. This flag can be repeated.")
 	o.config.AddFlags(fs)
@@ -466,50 +464,8 @@ func main() {
 		mux = prodOnlyMain(cfg, pluginAgent, authCfgGetter, githubClient, o, mux)
 	}
 
-	// cookie secret will be used for CSRF protection and should be exactly 32 bytes
-	// we sometimes accept different lengths to stay backwards compatible
-	var csrfToken []byte
-	if o.cookieSecretFile != "" {
-		cookieSecretRaw, err := loadToken(o.cookieSecretFile)
-		if err != nil {
-			logrus.WithError(err).Fatal("Could not read cookie secret file")
-		}
-		decodedSecret, err := base64.StdEncoding.DecodeString(string(cookieSecretRaw))
-		if err != nil {
-			logrus.WithError(err).Fatal("Error decoding cookie secret")
-		}
-		if len(decodedSecret) == 32 {
-			csrfToken = decodedSecret
-		}
-		if len(decodedSecret) > 32 {
-			logrus.Warning("Cookie secret should be exactly 32 bytes. Consider truncating the existing cookie to that length")
-			hash := sha256.Sum256(decodedSecret)
-			csrfToken = hash[:]
-		}
-		if len(decodedSecret) < 32 {
-			if o.rerunCreatesJob {
-				logrus.Fatal("Cookie secret must be exactly 32 bytes")
-				return
-			}
-			logrus.Warning("Cookie secret should be exactly 32 bytes")
-		}
-	}
-
-	// if we allow direct reruns, we must protect against CSRF in all post requests using the cookie secret as a token
-	// for more information about CSRF, see https://docs.prow.k8s.io/docs/components/core/deck/csrf/
-	empty := prowapi.ProwJobSpec{}
-	if o.rerunCreatesJob && csrfToken == nil && !authCfgGetter(&empty).IsAllowAnyone() {
-		logrus.Fatal("Rerun creates job cannot be enabled without CSRF protection, which requires --cookie-secret to be exactly 32 bytes")
-		return
-	}
-
-	var server *http.Server
-	if csrfToken != nil {
-		CSRF := csrf.Protect(csrfToken, csrf.Path("/"), csrf.Secure(!o.allowInsecure))
-		server = &http.Server{Addr: ":8080", Handler: CSRF(traceHandler(mux))}
-	} else {
-		server = &http.Server{Addr: ":8080", Handler: traceHandler(mux)}
-	}
+	cop := http.NewCrossOriginProtection()
+	server := &http.Server{Addr: ":8080", Handler: cop.Handler(traceHandler(mux))}
 
 	health.ServeReady()
 	interrupts.ListenAndServe(server, 5*time.Second)
@@ -1028,8 +984,7 @@ func handleRequestJobViews(sg *spyglass.Spyglass, cfg config.Getter, o options, 
 		setHeadersNoCaching(w)
 		src := strings.TrimPrefix(r.URL.Path, "/view/")
 
-		csrfToken := csrf.Token(r)
-		page, err := renderSpyglass(r.Context(), sg, cfg, src, o, csrfToken, log)
+		page, err := renderSpyglass(r.Context(), sg, cfg, src, o, log)
 		if err != nil {
 			msg := fmt.Sprintf("error rendering spyglass page: %v", err)
 			if shouldLogHTTPErrors(err) {
@@ -1050,7 +1005,7 @@ func handleRequestJobViews(sg *spyglass.Spyglass, cfg config.Getter, o options, 
 }
 
 // renderSpyglass returns a pre-rendered Spyglass page from the given source string
-func renderSpyglass(ctx context.Context, sg *spyglass.Spyglass, cfg config.Getter, src string, o options, csrfToken string, log *logrus.Entry) (string, error) {
+func renderSpyglass(ctx context.Context, sg *spyglass.Spyglass, cfg config.Getter, src string, o options, log *logrus.Entry) (string, error) {
 	renderStart := time.Now()
 
 	src = strings.TrimSuffix(src, "/")
@@ -1242,7 +1197,7 @@ lensesLoop:
 	}
 	t := template.New("spyglass.html")
 
-	if _, err := prepareBaseTemplate(o, cfg, csrfToken, t); err != nil {
+	if _, err := prepareBaseTemplate(o, cfg, t); err != nil {
 		return "", fmt.Errorf("error preparing base template: %w", err)
 	}
 	t, err = t.ParseFiles(path.Join(o.templateFilesLocation, "spyglass.html"))

--- a/cmd/deck/static/common/abort.ts
+++ b/cmd/deck/static/common/abort.ts
@@ -1,7 +1,7 @@
 import {ProwJobState} from "../api/prow";
 import {showAlert, showToast, State} from "./common";
 
-export function createAbortProwJobIcon(modal: HTMLElement, parentEl: Element, job: string, state: ProwJobState, prowjob: string, csrfToken: string): HTMLElement {
+export function createAbortProwJobIcon(modal: HTMLElement, parentEl: Element, job: string, state: ProwJobState, prowjob: string): HTMLElement {
   const url = `${location.protocol}//${location.host}/abort?prowjob=${prowjob}`;
   const abortButton = document.createElement('button');
   abortButton.classList.add('mdl-button', 'mdl-js-button', 'mdl-button--icon');
@@ -55,7 +55,6 @@ export function createAbortProwJobIcon(modal: HTMLElement, parentEl: Element, jo
         const result = await fetch(url, {
           headers: {
             'Content-type': 'application/x-www-form-urlencoded; charset=UTF-8',
-            'X-CSRF-Token': csrfToken,
           },
           method: 'post',
         });

--- a/cmd/deck/static/common/rerun.ts
+++ b/cmd/deck/static/common/rerun.ts
@@ -1,7 +1,7 @@
 import {copyToClipboard, icon, showAlert, showToast} from "./common";
 import {relativeURL} from "./urls";
 
-export function createRerunProwJobIcon(modal: HTMLElement, parentEl: Element, prowjob: string, showRerunButton: boolean, csrfToken: string): HTMLElement {
+export function createRerunProwJobIcon(modal: HTMLElement, parentEl: Element, prowjob: string, showRerunButton: boolean): HTMLElement {
   const LATEST_JOB = 'latest';
   const ORIGINAL_JOB = 'original';
   const inrepoconfigURL = 'https://docs.prow.k8s.io/docs/inrepoconfig/';
@@ -136,7 +136,6 @@ export function createRerunProwJobIcon(modal: HTMLElement, parentEl: Element, pr
           const result = await fetch(commandURL, {
             headers: {
               "Content-type": "application/x-www-form-urlencoded; charset=UTF-8",
-              "X-CSRF-Token": csrfToken,
             },
             method: 'post',
           });

--- a/cmd/deck/static/pr/pr.ts
+++ b/cmd/deck/static/pr/pr.ts
@@ -9,7 +9,6 @@ import {parseQuery, relativeURL} from "../common/urls";
 
 declare const tideData: TideData;
 declare const allBuilds: ProwJobList;
-declare const csrfToken: string;
 
 type UnifiedState = ProwJobState | "expected";
 
@@ -122,7 +121,6 @@ function createXMLHTTPRequest(fulfillFn: (request: XMLHttpRequest) => any, error
   request.withCredentials = true;
   request.open("POST", url, true);
   request.setRequestHeader("Content-type", "application/x-www-form-urlencoded");
-  request.setRequestHeader("X-CSRF-Token", csrfToken);
 
   return request;
 }

--- a/cmd/deck/static/prow/prow.ts
+++ b/cmd/deck/static/prow/prow.ts
@@ -10,7 +10,6 @@ import {JobHistogram, JobSample} from './histogram';
 declare const allBuilds: ProwJobList;
 declare const spyglass: boolean;
 declare const rerunCreatesJob: boolean;
-declare const csrfToken: string;
 
 function genShortRefKey(baseRef: string, pulls: Pull[] = []) {
   return [baseRef, ...pulls.map((p) => p.number)].filter((n) => n).join(",");
@@ -735,13 +734,13 @@ function redraw(fz: FuzzySearch, pushState = true): void {
 
 function createAbortCell(modal: HTMLElement, modalContent: Element, job: string, state: ProwJobState, prowjob: string): HTMLTableCellElement {
   const c = document.createElement("td");
-  c.appendChild(createAbortProwJobIcon(modal, modalContent, job, state, prowjob, csrfToken));
+  c.appendChild(createAbortProwJobIcon(modal, modalContent, job, state, prowjob));
   return c;
 }
 
 function createRerunCell(modal: HTMLElement, rerunElement: Element, prowjob: string): HTMLTableDataCellElement {
   const c = document.createElement("td");
-  c.appendChild(createRerunProwJobIcon(modal, rerunElement, prowjob, rerunCreatesJob, csrfToken));
+  c.appendChild(createRerunProwJobIcon(modal, rerunElement, prowjob, rerunCreatesJob));
   return c;
 }
 

--- a/cmd/deck/static/spyglass/spyglass.ts
+++ b/cmd/deck/static/spyglass/spyglass.ts
@@ -7,7 +7,6 @@ import {isTransitMessage, serialiseHashes} from "./common";
 declare const src: string;
 declare const lensArtifacts: {[index: string]: string[]};
 declare const lensIndexes: number[];
-declare const csrfToken: string;
 declare const rerunCreatesJob: boolean;
 declare const prowJob: string;
 declare const prowJobName: string;
@@ -74,7 +73,7 @@ function parseHash(): {[index: string]: string} {
 }
 
 function getLensRequestOptions(reqBody: string): RequestInit {
-  return {body: reqBody, method: 'POST', headers: {'X-CSRF-Token': csrfToken}, credentials: 'same-origin'};
+  return {body: reqBody, method: 'POST', credentials: 'same-origin'};
 }
 
 window.addEventListener('message', async (e) => {
@@ -184,7 +183,7 @@ function handleRerunButton() {
 
   const r = document.getElementById("header-title")!;
   const c = document.createElement("div");
-  c.appendChild(createRerunProwJobIcon(modal, modalContent, prowJobName, rerunCreatesJob, csrfToken));
+  c.appendChild(createRerunProwJobIcon(modal, modalContent, prowJobName, rerunCreatesJob));
   r.appendChild(c);
 
   if (rerunStatus === "gh_redirect") {
@@ -204,6 +203,6 @@ function handleAbortButton(): void {
 
   const r = document.getElementById("header-title")!;
   const c = document.createElement("div");
-  c.appendChild(createAbortProwJobIcon(modal, modalContent, prowJob, prowJobState, prowJobName, csrfToken));
+  c.appendChild(createAbortProwJobIcon(modal, modalContent, prowJob, prowJobState, prowJobName));
   r.appendChild(c);
 }

--- a/cmd/deck/template/base.html
+++ b/cmd/deck/template/base.html
@@ -3,9 +3,6 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <script type="text/javascript">
-    var csrfToken = {{csrfToken}};
-  </script>
   {{if googleAnalytics}}
   <!-- Global site tag (gtag.js) - Google Analytics -->
   <script async src="https://www.googletagmanager.com/gtag/js?id={{googleAnalytics}}"></script>

--- a/cmd/deck/templates.go
+++ b/cmd/deck/templates.go
@@ -21,7 +21,6 @@ import (
 	"net/http"
 	"path"
 
-	"github.com/gorilla/csrf"
 	"github.com/sirupsen/logrus"
 	"sigs.k8s.io/prow/pkg/config"
 	"sigs.k8s.io/prow/pkg/version"
@@ -62,7 +61,7 @@ func getConcreteSectionFunction(o options) func() baseTemplateSections {
 	}
 }
 
-func prepareBaseTemplate(o options, cfg config.Getter, csrfToken string, t *template.Template) (*template.Template, error) {
+func prepareBaseTemplate(o options, cfg config.Getter, t *template.Template) (*template.Template, error) {
 	return t.Funcs(map[string]any{
 		"settings":         makeBaseTemplateSettings,
 		"branding":         getConcreteBrandingFunction(cfg),
@@ -73,14 +72,13 @@ func prepareBaseTemplate(o options, cfg config.Getter, csrfToken string, t *temp
 		"lightMode":        func() bool { return false },
 		"deckVersion":      func() string { return version.Version },
 		"googleAnalytics":  func() string { return cfg().Deck.GoogleAnalytics },
-		"csrfToken":        func() string { return csrfToken },
 	}).ParseFiles(path.Join(o.templateFilesLocation, "base.html"))
 }
 
 func handleSimpleTemplate(o options, cfg config.Getter, templateName string, param any) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		t := template.New(templateName) // the name matters, and must match the filename.
-		if _, err := prepareBaseTemplate(o, cfg, csrf.Token(r), t); err != nil {
+		if _, err := prepareBaseTemplate(o, cfg, t); err != nil {
 			logrus.WithError(err).Error("error preparing base template")
 			http.Error(w, "error preparing base template", http.StatusInternalServerError)
 			return

--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,6 @@ require (
 	github.com/google/go-cmp v0.7.0
 	github.com/google/gofuzz v1.2.1-0.20210504230335-f78f29fc09ea
 	github.com/google/uuid v1.6.0
-	github.com/gorilla/csrf v1.7.3
 	github.com/gorilla/mux v1.8.1
 	github.com/gorilla/securecookie v1.1.2
 	github.com/gorilla/sessions v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -373,8 +373,6 @@ github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/googleapis/gax-go/v2 v2.23.0 h1:Tchl7qkvE7Ip3y+ztvNufYFvkfqTe7NfLTYGIdJRLuE=
 github.com/googleapis/gax-go/v2 v2.23.0/go.mod h1:rBQKOVJCdb8IFEzg+FCwlt1LP/xMDGuqUXhUG+XMXEg=
-github.com/gorilla/csrf v1.7.3 h1:BHWt6FTLZAb2HtWT5KDBf6qgpZzvtbp9QWDRKZMXJC0=
-github.com/gorilla/csrf v1.7.3/go.mod h1:F1Fj3KG23WYHE6gozCmBAezKookxbIvUJT+121wTuLk=
 github.com/gorilla/handlers v1.4.2 h1:0QniY0USkHQ1RGCLfKxeNHK9bkDHGRYGNDFBCS+YARg=
 github.com/gorilla/handlers v1.4.2/go.mod h1:Qkdc/uu4tH4g6mTK6auzZ766c4CA0Ng8+o/OAirnOIQ=
 github.com/gorilla/mux v1.7.4/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=

--- a/site/content/en/docs/components/core/deck/csrf.md
+++ b/site/content/en/docs/components/core/deck/csrf.md
@@ -12,30 +12,18 @@ and performing one of these protected actions on their behalf.
 
 ## Protection
 
-If `--cookie-secret` is 32 or more bytes long, CSRF protection is automatically enabled.
-If `--rerun-creates-job` is specified, CSRF protection is required, and accordingly, 
-`--cookie-secret` must be 32 bytes long. 
+CSRF protection is always enabled in Deck using Go's standard library
+[`net/http.CrossOriginProtection`](https://pkg.go.dev/net/http#CrossOriginProtection), which validates
+the `Sec-Fetch-Site` and `Origin` headers on incoming requests. No configuration is required.
 
-We protect against CSRF attacks using the [gorilla CSRF](https://github.com/gorilla/csrf) library, implemented 
-in [#13323](https://github.com/kubernetes/test-infra/pull/13323). Broadly, this protection works by ensuring that 
-any `POST` request originates from our site, rather than from an outside link. 
-We do so by requiring that every `POST` request made to Deck includes a secret token either in the request header 
-or in the form itself as a hidden input. 
+This protection works by ensuring that any `POST` request originates from the same origin as Deck,
+rather than from a cross-origin site. Safe methods (`GET`, `HEAD`, `OPTIONS`) are always allowed.
+Non-browser requests (those without `Sec-Fetch-Site` or `Origin` headers) are also allowed, so API
+clients like `curl` and CI scripts continue to work.
 
-We cryptographically generate the CSRF token using the `--cookie-secret` and a user session value and 
-include it as a header in every `POST` request made from Deck. 
-If you are adding a new `POST` request, you must include the CSRF token as described in the gorilla 
-[documentation](https://github.com/gorilla/csrf).
-
-The gorilla library expects a 32-byte CSRF token. If `--cookie-secret` is sufficiently long, 
-direct job reruns will be enabled via the `/rerun` endpoint. Otherwise, if `--cookie-secret` is less 
-than 32 bytes and `--rerun-creates-job` is enabled, Deck will refuse to start. Longer values will 
-work but should be truncated. 
-
-By default, gorilla CSRF requires that all `POST` requests are made over HTTPS. If developing locally
-over HTTP, you must specify `--allow-insecure` to Deck, which will configure both gorilla CSRF 
-and GitHub oauth to allow HTTP requests. 
+If you are adding a new `POST` endpoint, no additional CSRF handling is needed — the middleware
+protects all routes automatically.
 
 CSRF can also be executed by tricking a user into making a state-mutating `GET` request. All 
-state-mutating requests must therefore be `POST` requests, as gorilla CSRF does not secure `GET`
-requests.
+state-mutating requests must therefore be `POST` requests, as the CSRF middleware does not restrict
+`GET` requests.

--- a/site/content/en/docs/components/core/deck/github-oauth-setup.md
+++ b/site/content/en/docs/components/core/deck/github-oauth-setup.md
@@ -38,7 +38,7 @@ The following steps will show you how to set up an OAuth app.
     - repo
     ```
     
-3. Create another secret file for the cookie store. This cookie secret will also be used for CSRF protection.
+3. Create another secret file for the OAuth cookie store.
   The file should contain a random 32-byte length base64 key. For example, you can use `openssl` to generate the key
     
     ```


### PR DESCRIPTION
## Summary

- Replace `github.com/gorilla/csrf` v1.7.3 ([CVE-2025-47909](https://github.com/kubernetes-sigs/prow/security/dependabot/64), medium severity) with Go stdlib `net/http.CrossOriginProtection` (available since Go 1.25)
- Remove all CSRF token plumbing: cookie-secret derivation for CSRF, token injection into HTML templates, `X-CSRF-Token` headers in TypeScript, and the `csrfToken` JS global
- CSRF protection is now always-on and requires no configuration — it validates `Sec-Fetch-Site` and `Origin` headers server-side instead of using the Synchronizer Token Pattern

Note: This PR was created with the use of AI assisted tooling

## Test plan

- [x] `go build ./cmd/deck/...` compiles clean
- [x] `go test ./cmd/deck/...` passes
- [x] `go mod tidy` removes `gorilla/csrf`, retains `gorilla/sessions` and `gorilla/securecookie`
- [x] No remaining `csrfToken` or `gorilla/csrf` references in the codebase
- [x] CI passes
- [x] Verify POST requests from Deck UI work (same-origin) and cross-origin POSTs are rejected with 403
