### PR TITLE
deck: drop stale Prow-managed contexts with no matching ProwJob

### DIFF
--- a/cmd/deck/static/pr/pr.ts
+++ b/cmd/deck/static/pr/pr.ts
@@ -332,7 +332,7 @@ function createSearchCard(): HTMLElement {
  * all pr contexts and only replaces contexts that have existing Prow Jobs. Tide
  * context will be omitted from the list.
  */
-function getFullPRContext(builds: ProwJob[], contexts: Context[]): UnifiedContext[] {
+export function getFullPRContext(builds: ProwJob[], contexts: Context[]): UnifiedContext[] {
   const contextMap: Map<string, UnifiedContext> = new Map();
   if (contexts) {
     for (const context of contexts) {
@@ -348,6 +348,7 @@ function getFullPRContext(builds: ProwJob[], contexts: Context[]): UnifiedContex
     }
   }
 
+  const buildContextNames = new Set<string>();
   for (const build of builds) {
     const {
       spec: {
@@ -357,6 +358,7 @@ function getFullPRContext(builds: ProwJob[], contexts: Context[]): UnifiedContex
         url = "", description = "", state = "",
       },
     } = build;
+    buildContextNames.add(context);
 
     let discrepancy = null;
     // If GitHub context exits, check if mismatch or not.
@@ -375,6 +377,16 @@ function getFullPRContext(builds: ProwJob[], contexts: Context[]): UnifiedContex
       state,
       url,
     });
+  }
+
+  // Drop stale Prow contexts (renamed/removed jobs) that GitHub still
+  // reports but have no current ProwJob. Only touch names matching
+  // Prow's convention so we don't hide non-Prow checks.
+  const prowJobNamePattern = /^(pull-|branch-ci-|ci-)/;
+  for (const [name] of contextMap) {
+    if (!buildContextNames.has(name) && prowJobNamePattern.test(name)) {
+      contextMap.delete(name);
+    }
   }
 
   return Array.from(contextMap.values());


### PR DESCRIPTION

This PR drops such stale contexts when the name matches Prow's job naming convention (pull-, branch-ci-, ci- prefixes), so non-Prow checks are never touched.

getFullPRContext merges GitHub's reported contexts with Prow's live ProwJob list, but never drops a context GitHub still reports if no matching ProwJob exists for it. This happens when a Prow job is renamed or removed. GitHub keeps the old context indefinitely since nothing tells it to retract it.

Known limitation: this matches by naming convention, not by comparing against Prow's actual job config, so it won't catch a renamed job with a non-standard name. Happy to follow up with a config-based check if that's preferred.

Fixes #824
 
cc @BenTheElder @petr-muller