### PR TITLE
fix: status-reconciler track own config state for dropped deltas

### DIFF
--- a/pkg/config/agent.go
+++ b/pkg/config/agent.go
@@ -415,6 +415,7 @@ func (ca *Agent) Set(c *Config) {
 			select {
 			case sub <- delta:
 			case <-end.C:
+				logrus.Warn("Failed to deliver config delta to subscriber within 1 minute, delta dropped. Subscriber may miss config changes if it does not track its own state.")
 			}
 			if !end.Stop() { // prevent new events
 				<-end.C // drain the pending event

--- a/pkg/statusreconciler/controller.go
+++ b/pkg/statusreconciler/controller.go
@@ -165,14 +165,35 @@ func (c *Controller) Run(ctx context.Context) {
 		return
 	}
 
+	// lastProcessed tracks the config we last reconciled against. We maintain
+	// this ourselves rather than trusting the delta's Before field, because
+	// config.Agent.Set() silently drops deltas when the subscriber channel is
+	// blocked for over a minute. When that happens, ca.c advances but we never
+	// receive the delta, so subsequent deltas have a Before that already
+	// includes the dropped changes. By diffing against our own lastProcessed,
+	// the next delta that does get through captures everything we missed.
+	var lastProcessed *config.Config
+
 	for {
 		select {
 		case change := <-changes:
 			start := time.Now()
-			log := logrus.WithField("old_config_revision", change.Before.ConfigVersionSHA).WithField("config_revision", change.After.ConfigVersionSHA)
-			if err := c.reconcile(change, log); err != nil {
+
+			if lastProcessed == nil {
+				// First notification: use the delta's Before (the saved state
+				// from --status-path, or empty config if none was configured).
+				lastProcessed = &change.Before
+			}
+
+			current := c.statusClient.Config()
+			delta := config.Delta{Before: *lastProcessed, After: *current}
+
+			log := logrus.WithField("config_revision", current.ConfigVersionSHA)
+			if err := c.reconcile(delta, log); err != nil {
 				log.WithError(err).Error("Error reconciling statuses.")
 			}
+			cp := *current
+			lastProcessed = &cp
 			log.WithField("duration", fmt.Sprintf("%v", time.Since(start))).Info("Statuses reconciled")
 			c.statusClient.Save()
 		case <-ctx.Done():

--- a/pkg/statusreconciler/status.go
+++ b/pkg/statusreconciler/status.go
@@ -36,6 +36,7 @@ type storedState struct {
 type statusClient interface {
 	Load() (chan config.Delta, error)
 	Save() error
+	Config() *config.Config
 }
 
 // opener has methods to read and write paths


### PR DESCRIPTION
## Summary

- `config.Agent.Set()` silently drops deltas when the subscriber channel is blocked for over a minute. When this happens, the agent's config advances but the subscriber never sees the notification, making those changes permanently invisible to `status-reconciler`.
- Fix `status-reconciler` to diff against its own `lastProcessed` config rather than trusting the delta's `Before` field, so the next delivered delta captures all missed changes.
- Add a warning log in the config agent when a delta delivery times out.

Fixes #848


Generated with the help of AI (Claude Code)