### PR TITLE
chore: label dependabot PRs with area/dependency and ok-to-test

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -7,6 +7,9 @@ updates:
       - "/site"
     schedule:
       interval: "weekly"
+    labels:
+      - "area/dependency"
+      - "ok-to-test"
     groups:
       kubernetes:
         patterns:


### PR DESCRIPTION
- Add a `labels:` key to the `gomod` update entry in `.github/dependabot.yaml` so Dependabot PRs open with `area/dependency` and `ok-to-test`.
- `area/dependency` categorizes the PR consistently with the k8s ecosystem's `area/*` labels.
- `ok-to-test` present at open time lets Prow's trigger plugin treat the bot PR as trusted and run CI without a manual `/ok-to-test` comment.