### PR TITLE
chore(deps): bump github.com/andygrunwald/go-gerrit from 0.0.0-20210709065208-9d38b0be0268 to 1.1.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	cloud.google.com/go/storage v1.50.0
 	github.com/GoogleCloudPlatform/testgrid v0.0.123
 	github.com/NYTimes/gziphandler v1.1.1
-	github.com/andygrunwald/go-gerrit v0.0.0-20210709065208-9d38b0be0268
+	github.com/andygrunwald/go-gerrit v1.1.1
 	github.com/andygrunwald/go-jira v1.17.0
 	github.com/aws/aws-sdk-go-v2 v1.43.5
 	github.com/aws/aws-sdk-go-v2/config v1.32.36

--- a/go.sum
+++ b/go.sum
@@ -105,8 +105,8 @@ github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRF
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
 github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137/go.mod h1:OMCwj8VM1Kc9e19TLln2VL61YJF0x1XFtfdL4JdbSyE=
-github.com/andygrunwald/go-gerrit v0.0.0-20210709065208-9d38b0be0268 h1:7gokoTWteZhP1t2f0OzrFFXlyL8o0+b0r4ZaRV9PXOs=
-github.com/andygrunwald/go-gerrit v0.0.0-20210709065208-9d38b0be0268/go.mod h1:aqcjwEnmLLSalFNYR0p2ttnEXOVVRctIzsUMHbEcruU=
+github.com/andygrunwald/go-gerrit v1.1.1 h1:U1Aw5WrwWIVc8PK+jMFmMGzGTYZFI8re8JS6DEGNYfA=
+github.com/andygrunwald/go-gerrit v1.1.1/go.mod h1:SeP12EkHZxEVjuJ2HZET304NBtHGG2X6w2Gzd0QXAZw=
 github.com/andygrunwald/go-jira v1.17.0 h1:bbu5H676l6MaNcV6A7VDIAjIOQVgzNGEhNAwNI/Cjgo=
 github.com/andygrunwald/go-jira v1.17.0/go.mod h1:tiZsPUu9824bwcI2BUXatE4hJbs9rUOif0nv1lkq1hQ=
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be h1:9AeTilPcZAjCFIImctFaOjnTIavg87rW78vTPkQqLI8=

--- a/pkg/gerrit/client/client.go
+++ b/pkg/gerrit/client/client.go
@@ -27,6 +27,7 @@ import (
 	"net/http"
 	"os"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -84,25 +85,25 @@ type gerritAuthentication interface {
 }
 
 type gerritAccount interface {
-	GetAccount(name string) (*gerrit.AccountInfo, *gerrit.Response, error)
-	SetUsername(accountID string, input *gerrit.UsernameInput) (*string, *gerrit.Response, error)
+	GetAccount(ctx context.Context, name string) (*gerrit.AccountInfo, *gerrit.Response, error)
+	SetUsername(ctx context.Context, accountID string, input *gerrit.UsernameInput) (*string, *gerrit.Response, error)
 }
 
 type gerritChange interface {
-	QueryChanges(opt *gerrit.QueryChangeOptions) (*[]gerrit.ChangeInfo, *gerrit.Response, error)
-	SetReview(changeID, revisionID string, input *gerrit.ReviewInput) (*gerrit.ReviewResult, *gerrit.Response, error)
-	ListChangeComments(changeID string) (*map[string][]gerrit.CommentInfo, *gerrit.Response, error)
-	GetChange(changeId string, opt *gerrit.ChangeOptions) (*ChangeInfo, *gerrit.Response, error)
-	SubmitChange(id string, opt *gerrit.SubmitInput) (*ChangeInfo, *gerrit.Response, error)
-	GetRelatedChanges(changeID string, revisionID string) (*gerrit.RelatedChangesInfo, *gerrit.Response, error)
+	QueryChanges(ctx context.Context, opt *gerrit.QueryChangeOptions) (*[]gerrit.ChangeInfo, *gerrit.Response, error)
+	SetReview(ctx context.Context, changeID, revisionID string, input *gerrit.ReviewInput) (*gerrit.ReviewResult, *gerrit.Response, error)
+	ListChangeComments(ctx context.Context, changeID string) (*map[string][]gerrit.CommentInfo, *gerrit.Response, error)
+	GetChange(ctx context.Context, changeId string, opt *gerrit.ChangeOptions) (*ChangeInfo, *gerrit.Response, error)
+	SubmitChange(ctx context.Context, id string, opt *gerrit.SubmitInput) (*ChangeInfo, *gerrit.Response, error)
+	GetRelatedChanges(ctx context.Context, changeID string, revisionID string) (*gerrit.RelatedChangesInfo, *gerrit.Response, error)
 }
 
 type gerritProjects interface {
-	GetBranch(projectName, branchID string) (*gerrit.BranchInfo, *gerrit.Response, error)
+	GetBranch(ctx context.Context, projectName, branchID string) (*gerrit.BranchInfo, *gerrit.Response, error)
 }
 
 type gerritRevision interface {
-	GetMergeable(changeID, revisionID string, opt *gerrit.MergableOptions) (*gerrit.MergeableInfo, *gerrit.Response, error)
+	GetMergeable(ctx context.Context, changeID, revisionID string, opt *gerrit.MergableOptions) (*gerrit.MergeableInfo, *gerrit.Response, error)
 }
 
 // gerritInstanceHandler holds all actual gerrit handlers
@@ -313,7 +314,7 @@ func (c *Client) Authenticate(cookiefilePath, tokenPath string) {
 }
 
 func (c *Client) newInstanceHandler(instance string, projects map[string]*config.GerritQueryFilter) (*gerritInstanceHandler, error) {
-	gc, err := gerrit.NewClient(instance, &c.httpClient)
+	gc, err := gerrit.NewClient(context.Background(), instance, &c.httpClient)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create gerrit client: %w", err)
 	}
@@ -422,7 +423,7 @@ func (c *Client) GetChange(instance, id string, additionalFields ...string) (*Ch
 		return nil, fmt.Errorf("not activated gerrit instance: %s", instance)
 	}
 
-	info, resp, err := h.changeService.GetChange(id, &gerrit.ChangeOptions{AdditionalFields: additionalFields})
+	info, resp, err := h.changeService.GetChange(context.Background(), id, &gerrit.ChangeOptions{AdditionalFields: additionalFields})
 
 	if err != nil {
 		return nil, fmt.Errorf("error getting current change: %w", responseBodyError(err, resp))
@@ -439,7 +440,7 @@ func (c *Client) SubmitChange(instance, id string, wait bool) (*ChangeInfo, erro
 		return nil, fmt.Errorf("not activated gerrit instance: %s", instance)
 	}
 
-	info, resp, err := h.changeService.SubmitChange(id, &gerrit.SubmitInput{WaitForMerge: wait})
+	info, resp, err := h.changeService.SubmitChange(context.Background(), id, &gerrit.SubmitInput{WaitForMerge: wait})
 
 	if err != nil {
 		return nil, fmt.Errorf("error submitting current change: %w", responseBodyError(err, resp))
@@ -456,7 +457,7 @@ func (c *Client) ChangeExist(instance, id string) (bool, error) {
 		return false, fmt.Errorf("not activated gerrit instance: %s", instance)
 	}
 
-	_, resp, err := h.changeService.GetChange(id, nil)
+	_, resp, err := h.changeService.GetChange(context.Background(), id, nil)
 
 	if err != nil {
 		if resp != nil && resp.StatusCode == http.StatusNotFound {
@@ -487,7 +488,21 @@ func (c *Client) SetReview(instance, id, revision, message string, labels map[st
 		return fmt.Errorf("not activated gerrit instance: %s", instance)
 	}
 
-	_, resp, err := h.changeService.SetReview(id, revision, &gerrit.ReviewInput{Message: message, Labels: labels})
+	// go-gerrit models label votes as ints, while callers pass the vote as it is
+	// written in Gerrit ("+1", "0", "-1").
+	var votes map[string]int
+	if len(labels) > 0 {
+		votes = make(map[string]int, len(labels))
+		for label, vote := range labels {
+			v, err := strconv.Atoi(vote)
+			if err != nil {
+				return fmt.Errorf("invalid vote %q for label %q: %w", vote, label, err)
+			}
+			votes[label] = v
+		}
+	}
+
+	_, resp, err := h.changeService.SetReview(context.Background(), id, revision, &gerrit.ReviewInput{Message: message, Labels: votes})
 
 	if err != nil {
 		return fmt.Errorf("cannot comment to gerrit: %w", responseBodyError(err, resp))
@@ -505,7 +520,7 @@ func (c *Client) GetBranchRevision(instance, project, branch string) (string, er
 		return "", fmt.Errorf("not activated gerrit instance: %s", instance)
 	}
 
-	res, resp, err := h.projectService.GetBranch(project, branch)
+	res, resp, err := h.projectService.GetBranch(context.Background(), project, branch)
 
 	if err != nil {
 		return "", responseBodyError(err, resp)
@@ -536,7 +551,7 @@ func (c *Client) Account(instance string) (*gerrit.AccountInfo, error) {
 		return nil, errors.New("no handlers found")
 	}
 
-	self, resp, err := handler.accountService.GetAccount("self")
+	self, resp, err := handler.accountService.GetAccount(context.Background(), "self")
 	if err != nil {
 		return nil, fmt.Errorf("GetAccount() failed with new authentication: %w", responseBodyError(err, resp))
 
@@ -553,7 +568,7 @@ func (c *Client) GetMergeableInfo(instance, changeID, revisionID string) (*gerri
 		return nil, fmt.Errorf("not activated Gerrit instance: %s", instance)
 	}
 
-	mergeableInfo, resp, err := h.revisionService.GetMergeable(changeID, revisionID, nil)
+	mergeableInfo, resp, err := h.revisionService.GetMergeable(context.Background(), changeID, revisionID, nil)
 
 	if err != nil {
 		return nil, responseBodyError(err, resp)
@@ -587,7 +602,7 @@ func parseStamp(value gerrit.Timestamp) time.Time {
 
 func (h *gerritInstanceHandler) injectPatchsetMessages(change *gerrit.ChangeInfo) error {
 
-	out, _, err := h.changeService.ListChangeComments(change.ID)
+	out, _, err := h.changeService.ListChangeComments(context.Background(), change.ID)
 
 	if err != nil {
 		return err
@@ -627,14 +642,14 @@ func queryStringsFromQueryFilter(filters *config.GerritQueryFilter) []string {
 		branchFilter = append(branchFilter, fmt.Sprintf("branch:%s", br))
 	}
 	if len(branchFilter) > 0 {
-		res = append(res, fmt.Sprintf("(%s)", strings.Join(branchFilter, "+OR+")))
+		res = append(res, fmt.Sprintf("(%s)", strings.Join(branchFilter, " OR ")))
 	}
 	var excludedBranchFilter []string
 	for _, br := range filters.ExcludedBranches {
 		excludedBranchFilter = append(excludedBranchFilter, fmt.Sprintf("-branch:%s", br))
 	}
 	if len(excludedBranchFilter) > 0 {
-		res = append(res, fmt.Sprintf("(%s)", strings.Join(excludedBranchFilter, "+AND+")))
+		res = append(res, fmt.Sprintf("(%s)", strings.Join(excludedBranchFilter, " AND ")))
 	}
 
 	return res
@@ -679,7 +694,9 @@ func (d *deduper) dedupeIntoResult(ci gerrit.ChangeInfo) {
 
 func (h *gerritInstanceHandler) queryChangesForProjectWithoutMetrics(log logrus.FieldLogger, project string, lastUpdate time.Time, rateLimit int, additionalFilters ...string) ([]gerrit.ChangeInfo, error) {
 	var opt gerrit.QueryChangeOptions
-	opt.Query = append(opt.Query, strings.Join(append(additionalFilters, "project:"+project), "+"))
+	// Gerrit query terms are separated by whitespace. go-gerrit percent-encodes
+	// a literal "+", so it can no longer be used as the separator.
+	opt.Query = append(opt.Query, strings.Join(append(additionalFilters, "project:"+project), " "))
 	opt.AdditionalFields = []string{"CURRENT_REVISION", "CURRENT_COMMIT", "CURRENT_FILES", "MESSAGES", "LABELS"}
 
 	log = log.WithFields(logrus.Fields{"query": opt.Query, "additional_fields": opt.AdditionalFields})
@@ -701,7 +718,7 @@ func (h *gerritInstanceHandler) queryChangesForProjectWithoutMetrics(log logrus.
 		// The change output is sorted by the last update time, most recently updated to oldest updated.
 		// Gerrit API docs: https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#list-changes
 
-		changes, resp, err := h.changeService.QueryChanges(&opt)
+		changes, resp, err := h.changeService.QueryChanges(context.Background(), &opt)
 
 		if err != nil {
 			// should not happen? Let next sync loop catch up
@@ -823,7 +840,7 @@ func (c *Client) HasRelatedChanges(instance, id, revision string) (bool, error) 
 		return false, fmt.Errorf("not activated gerrit instance: %s", instance)
 	}
 
-	info, resp, err := h.changeService.GetRelatedChanges(id, revision)
+	info, resp, err := h.changeService.GetRelatedChanges(context.Background(), id, revision)
 
 	if err != nil {
 		return false, fmt.Errorf("error getting related changes: %w", responseBodyError(err, resp))

--- a/pkg/gerrit/client/client_test.go
+++ b/pkg/gerrit/client/client_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"net/http/httptest"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -39,13 +40,16 @@ type fgc struct {
 	instance string
 	changes  map[string][]gerrit.ChangeInfo
 	comments map[string]map[string][]gerrit.CommentInfo
+
+	// lastReview records the input of the most recent SetReview call.
+	lastReview *gerrit.ReviewInput
 }
 
-func (f *fgc) GetRelatedChanges(changeID string, revisionID string) (*gerrit.RelatedChangesInfo, *gerrit.Response, error) {
+func (f *fgc) GetRelatedChanges(ctx context.Context, changeID string, revisionID string) (*gerrit.RelatedChangesInfo, *gerrit.Response, error) {
 	return &gerrit.RelatedChangesInfo{}, nil, nil
 }
 
-func (f *fgc) ListChangeComments(id string) (*map[string][]gerrit.CommentInfo, *gerrit.Response, error) {
+func (f *fgc) ListChangeComments(ctx context.Context, id string) (*map[string][]gerrit.CommentInfo, *gerrit.Response, error) {
 	comments := map[string][]gerrit.CommentInfo{}
 
 	val, ok := f.comments[id]
@@ -60,7 +64,7 @@ func (f *fgc) ListChangeComments(id string) (*map[string][]gerrit.CommentInfo, *
 	return &comments, nil, nil
 }
 
-func (f *fgc) SubmitChange(changeID string, input *gerrit.SubmitInput) (*ChangeInfo, *gerrit.Response, error) {
+func (f *fgc) SubmitChange(ctx context.Context, changeID string, input *gerrit.SubmitInput) (*ChangeInfo, *gerrit.Response, error) {
 	return nil, nil, nil
 }
 
@@ -170,6 +174,35 @@ func TestApplyGlobalConfigOnce(t *testing.T) {
 	}
 }
 
+// TestQueryTermsReachGerritSeparated checks that the query prow builds survives
+// go-gerrit's URL encoding and arrives at Gerrit as distinct search terms.
+// go-gerrit percent-encodes "+", so terms have to be separated by whitespace.
+func TestQueryTermsReachGerritSeparated(t *testing.T) {
+	var got string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got = r.URL.Query().Get("q")
+		// Gerrit prefixes JSON responses with a magic line.
+		w.Write([]byte(")]}'\n[]\n"))
+	}))
+	defer srv.Close()
+
+	c, err := NewClient(map[string]map[string]*config.GerritQueryFilter{
+		srv.URL: {"myproject": {Branches: []string{"foo", "bar"}}},
+	}, 1, 1)
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	if _, err := c.QueryChangesForProject(srv.URL, "myproject", time.Now(), 1); err != nil {
+		t.Fatalf("Failed to query changes: %v", err)
+	}
+
+	want := "(branch:foo OR branch:bar) project:myproject"
+	if got != want {
+		t.Errorf("Gerrit received query %q, want %q", got, want)
+	}
+}
+
 func TestQueryStringsFromQueryFilter(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
@@ -192,7 +225,7 @@ func TestQueryStringsFromQueryFilter(t *testing.T) {
 			filters: &config.GerritQueryFilter{
 				Branches: []string{"foo1", "foo2", "foo3"},
 			},
-			expected: []string{"(branch:foo1+OR+branch:foo2+OR+branch:foo3)"},
+			expected: []string{"(branch:foo1 OR branch:foo2 OR branch:foo3)"},
 		},
 		{
 			name: "branches-and-excluded",
@@ -201,8 +234,8 @@ func TestQueryStringsFromQueryFilter(t *testing.T) {
 				ExcludedBranches: []string{"bar1", "bar2", "bar3"},
 			},
 			expected: []string{
-				"(branch:foo1+OR+branch:foo2+OR+branch:foo3)",
-				"(-branch:bar1+AND+-branch:bar2+AND+-branch:bar3)",
+				"(branch:foo1 OR branch:foo2 OR branch:foo3)",
+				"(-branch:bar1 AND -branch:bar2 AND -branch:bar3)",
 			},
 		},
 	}
@@ -288,11 +321,11 @@ type fgcWithErr struct {
 	gerritChange
 }
 
-func (f *fgcWithErr) GetChange(changeId string, opt *gerrit.ChangeOptions) (*ChangeInfo, *gerrit.Response, error) {
+func (f *fgcWithErr) GetChange(ctx context.Context, changeId string, opt *gerrit.ChangeOptions) (*ChangeInfo, *gerrit.Response, error) {
 	return nil, f.resp, f.err
 }
 
-func (f *fgc) QueryChanges(opt *gerrit.QueryChangeOptions) (*[]gerrit.ChangeInfo, *gerrit.Response, error) {
+func (f *fgc) QueryChanges(ctx context.Context, opt *gerrit.QueryChangeOptions) (*[]gerrit.ChangeInfo, *gerrit.Response, error) {
 	changes := []gerrit.ChangeInfo{}
 
 	changeInfos, ok := f.changes[f.instance]
@@ -302,7 +335,7 @@ func (f *fgc) QueryChanges(opt *gerrit.QueryChangeOptions) (*[]gerrit.ChangeInfo
 
 	project := ""
 	for _, query := range opt.Query {
-		for q := range strings.SplitSeq(query, "+") {
+		for q := range strings.FieldsSeq(query) {
 			if strings.HasPrefix(q, "project:") {
 				project = q[8:]
 			}
@@ -320,11 +353,61 @@ func (f *fgc) QueryChanges(opt *gerrit.QueryChangeOptions) (*[]gerrit.ChangeInfo
 	return &changes, nil, nil
 }
 
-func (f *fgc) SetReview(changeID, revisionID string, input *gerrit.ReviewInput) (*gerrit.ReviewResult, *gerrit.Response, error) {
+func (f *fgc) SetReview(ctx context.Context, changeID, revisionID string, input *gerrit.ReviewInput) (*gerrit.ReviewResult, *gerrit.Response, error) {
+	f.lastReview = input
 	return nil, nil, nil
 }
 
-func (f *fgc) GetChange(changeId string, opt *gerrit.ChangeOptions) (*ChangeInfo, *gerrit.Response, error) {
+// Gerrit label votes are ints in go-gerrit, while callers pass them as they are
+// written in Gerrit ("+1", "0", "-1").
+func TestSetReviewLabelVotes(t *testing.T) {
+	tests := []struct {
+		name    string
+		labels  map[string]string
+		want    map[string]int
+		wantErr bool
+	}{
+		{
+			name:   "no labels",
+			labels: nil,
+		},
+		{
+			name:   "votes are converted",
+			labels: map[string]string{"Code-Review": "+1", "Verified": "-1", "Other": "0"},
+			want:   map[string]int{"Code-Review": 1, "Verified": -1, "Other": 0},
+		},
+		{
+			name:    "unparseable vote",
+			labels:  map[string]string{"Code-Review": "lgtm"},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			f := &fgc{}
+			cl := &Client{handlers: map[string]*gerritInstanceHandler{
+				"instance": {changeService: f},
+			}}
+
+			err := cl.SetReview("instance", "id", "revision", "message", tc.labels)
+			if gotErr := err != nil; gotErr != tc.wantErr {
+				t.Fatalf("SetReview() err = %v; wantErr = %t", err, tc.wantErr)
+			}
+			if tc.wantErr {
+				if f.lastReview != nil {
+					t.Errorf("SetReview() sent %v to gerrit, want no call", f.lastReview)
+				}
+				return
+			}
+			if diff := cmp.Diff(tc.want, f.lastReview.Labels); diff != "" {
+				t.Errorf("Labels mismatch. Want(-), got(+):\n%s", diff)
+			}
+		})
+	}
+}
+
+func (f *fgc) GetChange(ctx context.Context, changeId string, opt *gerrit.ChangeOptions) (*ChangeInfo, *gerrit.Response, error) {
 	return nil, nil, nil
 }
 

--- a/pkg/tide/gerrit.go
+++ b/pkg/tide/gerrit.go
@@ -53,20 +53,20 @@ const (
 	// ref:
 	// https://gerrit-review.googlesource.com/Documentation/user-search.html#_search_operators.
 	// Also good to know: `(repo:repo-A OR repo:repo-B)`
-	gerritDefaultQueryParam = "status:open+-is:wip+is:submittable"
+	gerritDefaultQueryParam = "status:open -is:wip is:submittable"
 )
 
 func gerritQueryParam(optInByDefault bool) string {
 	// Whenever a the `Prow-Auto-Submit` label is voted with -1 by anyone, the
 	// PR has to be excluded from Tide.
-	enablementLabelQueryParam := "+-label:" + tideEnablementLabel + "=-1"
+	enablementLabelQueryParam := " -label:" + tideEnablementLabel + "=-1"
 	// By default require `Prow-Auto-Submit` label.
 	// If the repo enabled optInByDefault, `Prow-Auto-Submit` is no longer
 	// required. But users can still temporarily opting out of merge automation
 	// by voting -1 on this label.
 	if !optInByDefault {
 		// We want `-label:Prow-Auto-Submit=-1 label:Prow-Auto-Submit`
-		enablementLabelQueryParam += "+label:" + tideEnablementLabel
+		enablementLabelQueryParam += " label:" + tideEnablementLabel
 	}
 	return gerritDefaultQueryParam + enablementLabelQueryParam
 }

--- a/pkg/tide/gerrit_test.go
+++ b/pkg/tide/gerrit_test.go
@@ -117,12 +117,12 @@ func TestGerritQueryParam(t *testing.T) {
 		{
 			name:  "default",
 			optIn: false,
-			want:  "status:open+-is:wip+is:submittable+-label:Prow-Auto-Submit=-1+label:Prow-Auto-Submit",
+			want:  "status:open -is:wip is:submittable -label:Prow-Auto-Submit=-1 label:Prow-Auto-Submit",
 		},
 		{
 			name:  "opt-in",
 			optIn: true,
-			want:  "status:open+-is:wip+is:submittable+-label:Prow-Auto-Submit=-1",
+			want:  "status:open -is:wip is:submittable -label:Prow-Auto-Submit=-1",
 		},
 	}
 


### PR DESCRIPTION
Bumps github.com/andygrunwald/go-gerrit from 0.0.0-20210709065208-9d38b0be0268 to 1.1.1.

It's been quite awhile since an official release of go-gerrit has been done, but the project has been active during that time and there have been a few breaking changes.

This replaces dependabot PR #827 to also include the updates to adjust for those changes.

---
LLM assistance was used in the creation of this PR.