### PR TITLE
pkg/config/secret: fix TestAddWithParser flake

### DIFF
--- a/pkg/config/secret/agent_test.go
+++ b/pkg/config/secret/agent_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package secret
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -261,62 +260,107 @@ func TestAddWithParser(t *testing.T) {
 func testAddWithParser(t *testing.T) {
 	t.Parallel()
 
-	tmpDir := t.TempDir()
+	secretPath := filepath.Join(t.TempDir(), "secret")
+	writeSecret(t, secretPath, "1", 1)
 
-	secretPath := filepath.Join(tmpDir, "secret")
-	if err := os.WriteFile(secretPath, []byte("1"), 0644); err != nil {
-		t.Fatalf("failed to write initial content of secret: %v", err)
-	}
-
-	vals := make(chan int, 3)
-	errs := make(chan error, 3)
-	generator, err := AddWithParser(
-		secretPath,
-		func(raw []byte) (int, error) {
+	errs := make(chan error, 8)
+	loader := &parsingSecretReloader[int]{
+		path: secretPath,
+		parsingFN: func(raw []byte) (int, error) {
 			val, err := strconv.Atoi(string(raw))
 			if err != nil {
 				errs <- err
-				return val, err
 			}
-			vals <- val
 			return val, err
 		},
-	)
+	}
+
+	// reloadCensor is invoked after the parsed value is stored (reloader.go:44 and :82), so
+	// receiving from this channel guarantees loader.get() observes the published value. The
+	// parsingFN itself must NOT be used as the signal: it runs at reloader.go:72, before the
+	// store, which is what made this test flaky under -race.
+	published := make(chan int, 8)
+	if err := loader.start(func() { published <- loader.get() }); err != nil {
+		t.Fatalf("start failed: %v", err)
+	}
+
+	last := 0
+	awaitPublish := func(want int) {
+		t.Helper()
+		for {
+			select {
+			case got := <-published:
+				// The reload loop starts with a zero lastModTime, so its first tick always
+				// re-reads and republishes the current value. Repeats are meaningless; any
+				// other unexpected value is a real regression.
+				if got == last && got != want {
+					continue
+				}
+				if got != want {
+					t.Fatalf("expected published value %d, got %d", want, got)
+				}
+				last = got
+				if actual := loader.get(); actual != want {
+					t.Fatalf("expected value %d from getter after publish, got %d", want, actual)
+				}
+				return
+			case <-time.After(30 * time.Second):
+				t.Fatalf("timed out waiting for value %d to be published", want)
+			}
+		}
+	}
+
+	awaitPublish(1) // initial load, performed synchronously by start()
+
+	writeSecret(t, secretPath, "2", 2)
+	awaitPublish(2)
+
+	// A failed parse must leave the stored value untouched.
+	writeSecret(t, secretPath, "not-a-number", 3)
+	select {
+	case err := <-errs:
+		if want := `strconv.Atoi: parsing "not-a-number": invalid syntax`; err.Error() != want {
+			t.Fatalf("expected error %q, got %q", want, err.Error())
+		}
+	case <-time.After(30 * time.Second):
+		t.Fatalf("timed out waiting for the parse error")
+	}
+
+	// Bracket the negative assertion with a positive one: the reload loop is serialized, so a
+	// publish for the failed parse would necessarily be signalled before this one. Observing 3
+	// as the next published value proves nothing was published for "not-a-number".
+	writeSecret(t, secretPath, "3", 4)
+	awaitPublish(3)
+}
+
+// writeSecret writes content to path and advances its mtime by generation seconds.
+func writeSecret(t *testing.T, path, content string, generation int) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("failed to write secret: %v", err)
+	}
+	// Guarantee the mtime strictly advances regardless of filesystem timestamp granularity, so
+	// the reloader always detects the change.
+	mtime := time.Now().Add(time.Duration(generation) * time.Second)
+	if err := os.Chtimes(path, mtime, mtime); err != nil {
+		t.Fatalf("failed to set secret mtime: %v", err)
+	}
+}
+
+func TestAddWithParserRegistersSecret(t *testing.T) {
+	secretPath := filepath.Join(t.TempDir(), "secret")
+	writeSecret(t, secretPath, "1", 1)
+
+	generator, err := AddWithParser(secretPath, func(raw []byte) (int, error) {
+		return strconv.Atoi(string(raw))
+	})
 	if err != nil {
 		t.Fatalf("AddWithParser failed: %v", err)
 	}
-
-	checkValueAndErr := func(expected int, e error) {
-		t.Helper()
-		select {
-		case v := <-vals:
-			if v != expected {
-				t.Errorf("expected value to get updated to %d but got updated to %d", expected, v)
-			}
-			break
-		case err := <-errs:
-			if e == nil || e.Error() != err.Error() {
-				t.Fatalf("expected error %v, got %v", e, err)
-			}
-		// the agent reloads every second, so ten seconds should be plenty
-		case <-time.After(10 * time.Second):
-			t.Fatalf("timed out waiting for value %d and error %d", expected, e)
-		}
-		if actual := generator(); actual != expected {
-			t.Errorf("expected value %d from generator, got %d", expected, actual)
-		}
+	if got := generator(); got != 1 {
+		t.Errorf("expected 1 from generator, got %d", got)
 	}
-	checkValueAndErr(1, nil)
-
-	if err := os.WriteFile(secretPath, []byte("2"), 0644); err != nil {
-		t.Fatalf("failed to update secret on disk: %v", err)
+	if got := string(GetSecret(secretPath)); got != "1" {
+		t.Errorf("expected raw secret %q to be registered with the agent, got %q", "1", got)
 	}
-	// expect secret to get updated
-	checkValueAndErr(2, nil)
-
-	if err := os.WriteFile(secretPath, []byte("not-a-number"), 0644); err != nil {
-		t.Fatalf("failed to update secret on disk: %v", err)
-	}
-	// expect secret to remain unchanged and an error in the parsing func
-	checkValueAndErr(2, errors.New(`strconv.Atoi: parsing "not-a-number": invalid syntax`))
 }


### PR DESCRIPTION
## What this PR does / why we need it

`pkg/config/secret TestAddWithParser` flakes with `expected value 2 from generator, got 1`. It has been hitting unrelated PRs since at least January, and is currently the sole failure on `pull-prow-unit-test-race-detector-nonblocking` for #859.

This is a real defect in the test, not infrastructure noise: **the test synchronizes on an event that happens before the thing it asserts.**

### Root cause

`parsingSecretReloader.reloadSecret` publishes a new value in two distinct steps:

```go
raw, parsed, err := loadSingleSecretWithParser(p.path, p.parsingFN)  // :72  calls the user's parser
if err != nil { ...; continue }                                      // :73-76  no publish on parse failure
p.lock.Lock()
p.rawValue = raw
p.parsed = parsed                                                    // :80  value becomes visible to get()
p.lock.Unlock()
reloadCensor()                                                       // :82  runs after the store
```

The test's parsing function pushed the parsed value into a channel, and `checkValueAndErr` treated receiving from that channel as "the reload finished", then immediately called the generator. But the parser runs at `:72` and the store lands at `:80`, with no happens-before edge between them. Reading the old value is therefore legal — not a bug in the reloader. `-race` slows goroutine scheduling enough to widen the window, which is why only the race-detector job fails while `pull-prow-unit-test` passes.

### The fix

Synchronize on `reloadCensor` instead of on the parser. It is invoked at `reloader.go:44` and `:82`, in both cases *after* `p.lock.Unlock()`, so a channel send from inside it establishes a genuine happens-before edge with the store. Once the test receives that signal, the Go memory model guarantees `get()` observes the new value — deterministic, not merely likely.

`AddWithParser` hardwires `a.refreshCensorer` as that callback, so the test now constructs `parsingSecretReloader` directly and calls `start()` with its own callback. The public-API coverage that gives up is recovered by a new `TestAddWithParserRegistersSecret`, which has no timing dependence at all — everything it asserts is established synchronously before `AddWithParser` returns.

For the bad-parse case, the test now asserts on the **sequence of published values** rather than sampling the getter at a moment in time. The reload loop is a single serialized goroutine, so every publish emits exactly one signal, in order. Writing a subsequent good value (`3`) and requiring the next published value to be `3` proves nothing was published for the failed parse — any such publish would have been signalled strictly earlier. That converts an unprovable safety property ("never publishes a bad parse") into a liveness property that can be waited on, with **no observation window or sleep anywhere in the test**.

The new `writeSecret` helper bumps the file's mtime explicitly, so two writes can never share a timestamp on a coarse-granularity filesystem — which would otherwise hide the change until the 600-tick forced reload ten minutes later.

The `TestAddWithParser` wrapper that runs the subtest twice in parallel is kept exactly as-is; that is what makes `-race` exercise concurrent `get()` against the reload goroutine.

**No production code changes.**

### What each assertion still catches

| Regression | Caught by |
|---|---|
| Reloader stops noticing file changes | `awaitPublish(2)` / `awaitPublish(3)` time out |
| Wrong value stored (parse result dropped, stale value published) | `awaitPublish` value mismatch, and the `loader.get()` check after each publish |
| A failed parse clobbers the previously good value | `awaitPublish(3)` sees the bad publish first and fails with the actual value |
| `reloadCensor` moved before the store (censorer refreshed with a stale secret) | `loader.get()` check inside `awaitPublish` |
| Data races on `parsed` / `rawValue` | unchanged — two parallel subtests under `-race` |

### Verification

All green locally:

```
go test -race -count=20 ./pkg/config/secret/...                 # ok, 61s
go test -race -count=20 -cpu=1,2,4 ./pkg/config/secret/...      # ok, 182s
go test ./pkg/config/secret/...                                 # ok, 3.6s
```

I also confirmed the test still fails on a real regression rather than merely passing: temporarily deleting the `continue` at `reloader.go:75`, so a failed parse publishes the zero value, makes it fail with exactly `expected published value 3, got 0`. Reverted afterwards.

Runtime is ~3s per subtest (each publish waits up to one 1s reload tick), versus ~2s before.

### Known warts, deliberately not bundled into a flake fix

- `reloadSecret` uses `time.Tick` (`reloader.go:55`) and never stops; the goroutine leaks for process lifetime. Harmless for a daemon, noise in tests.
- `lastModTime` starts at the zero value, so the loop's first tick always re-reads and republishes the current value. The test tolerates this rather than changing behavior.
- Making the reload interval injectable would speed the test up, but adds production surface purely for tests and leans harder on filesystem mtime resolution.

## Which issue(s) this PR fixes

Fixes #603

(Reopened — it was closed as rotten by the lifecycle bot without a fix, and the identical error is still flaking.)

## Special notes for your reviewer

Kept separate from #859 (Pub/Sub v2 migration) so that PR stays scoped. Once this merges, `/test pull-prow-unit-test-race-detector-nonblocking` on #859 should go green.

```release-note
NONE
```
