### PR TITLE
fix(githuboauth): fall back to fresh session on undecodable cookie

### DIFF
--- a/pkg/githuboauth/githuboauth.go
+++ b/pkg/githuboauth/githuboauth.go
@@ -156,8 +156,8 @@ func (ga *Agent) HandleLogin(client OAuthClient, secure bool) http.HandlerFunc {
 		oauthSession.Options.Secure = secure
 		oauthSession.Options.HttpOnly = true
 		if err != nil {
-			ga.serverErrorAndPrint(w, "Creating new OAuth session", err)
-			return
+			// New always returns a session; a decode error only means the existing cookie is invalid (e.g. stale signing key). Continue with this empty session so we can overwrite it.
+			ga.logger.WithError(err).Warning("Failed to decode existing OAuth session cookie, using new session.")
 		}
 		oauthSession.Options.MaxAge = 10 * 60
 		oauthSession.Values[stateKey] = state
@@ -179,6 +179,7 @@ func (ga *Agent) HandleLogin(client OAuthClient, secure bool) http.HandlerFunc {
 func (ga *Agent) GetLogin(r *http.Request, identifier AuthenticatedUserIdentifier) (string, error) {
 	session, err := ga.gc.CookieStore.Get(r, tokenSession)
 	if err != nil {
+		ga.logger.WithError(err).Warning("Failed to decode existing token session cookie.")
 		return "", err
 	}
 	token, ok := session.Values[tokenKey].(*oauth2.Token)
@@ -198,8 +199,8 @@ func (ga *Agent) HandleLogout(client OAuthClient) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		accessTokenSession, err := ga.gc.CookieStore.Get(r, tokenSession)
 		if err != nil {
-			ga.serverErrorAndPrint(w, "get cookie", err)
-			return
+			// Get always returns a session; a decode error only means the existing cookie is invalid (e.g. stale signing key). Continue with this empty session so logout can expire it.
+			ga.logger.WithError(err).Warning("Failed to decode existing token session cookie during logout.")
 		}
 		// Clear session
 		accessTokenSession.Options.MaxAge = -1
@@ -286,8 +287,8 @@ func (ga *Agent) HandleRedirect(client OAuthClient, identifier AuthenticatedUser
 		session.Options.Secure = secure
 		session.Options.HttpOnly = true
 		if err != nil {
-			ga.serverErrorAndPrint(w, "Create new session", err)
-			return
+			// New always returns a session; a decode error only means the existing cookie is invalid (e.g. stale signing key). Continue with this empty session so we can overwrite it.
+			ga.logger.WithError(err).Warning("Failed to decode existing token session cookie, using new session.")
 		}
 
 		session.Values[tokenKey] = token

--- a/pkg/githuboauth/githuboauth_test.go
+++ b/pkg/githuboauth/githuboauth_test.go
@@ -369,3 +369,179 @@ func TestHandleRedirectWithValidState(t *testing.T) {
 		t.Errorf("Incorrect final redirect URL. Actual path: %s, Expected path: /%s", path, dest+"?rerun="+rerunStatus)
 	}
 }
+
+func TestHandleRedirectWithStaleCookie(t *testing.T) {
+	gob.Register(&oauth2.Token{})
+
+	oldKey := []byte("old-secret-key-for-signing-cookies")
+	newKey := []byte("new-secret-key-after-rotation!!!!")
+
+	oldStore := sessions.NewCookieStore(oldKey)
+	newStore := sessions.NewCookieStore(newKey)
+
+	mockConfig := getMockConfig(newStore)
+	mockLogger := logrus.WithField("uni-test", "githuboauth")
+	mockAgent := NewAgent(mockConfig, mockLogger)
+	mockLogin := "foo_name"
+	mockOAuthClient := mockOAuthClient{}
+	mockStateToken := createMockStateToken(mockConfig)
+
+	// Simulate a stale token cookie signed with the old key: create a session
+	// using the old store, save it to a recorder, then extract the Set-Cookie
+	// header to inject into the new request.
+	staleReq := httptest.NewRequest(http.MethodGet, "/", nil)
+	staleResp := httptest.NewRecorder()
+	staleSession, _ := oldStore.New(staleReq, tokenSession)
+	staleSession.Values[tokenKey] = &oauth2.Token{AccessToken: "expired-token"}
+	if err := staleSession.Save(staleReq, staleResp); err != nil {
+		t.Fatalf("Failed to save stale session: %v", err)
+	}
+	var staleCookie *http.Cookie
+	for _, c := range staleResp.Result().Cookies() {
+		if c.Name == tokenSession {
+			staleCookie = c
+			break
+		}
+	}
+	if staleCookie == nil {
+		t.Fatal("Failed to create stale cookie")
+	}
+
+	dest := "somewhere"
+	mockRequest := httptest.NewRequest(http.MethodGet, "/mock-login?dest="+dest, nil)
+	// Attach the stale cookie -- this is what causes "the value is not valid"
+	mockRequest.AddCookie(staleCookie)
+	mockResponse := httptest.NewRecorder()
+	query := mockRequest.URL.Query()
+	query.Add("state", mockStateToken)
+	mockRequest.URL.RawQuery = query.Encode()
+
+	// Set up a valid OAuth state session using the new store
+	mockSession, err := sessions.GetRegistry(mockRequest).Get(newStore, oauthSessionCookie)
+	if err != nil {
+		t.Fatalf("Error with getting mock session: %v", err)
+	}
+	mockSession.Values[stateKey] = mockStateToken
+
+	handleRedirectFn := mockAgent.HandleRedirect(mockOAuthClient, &fakeAuthenticatedUserIdentifier{mockLogin}, false)
+	handleRedirectFn.ServeHTTP(mockResponse, mockRequest)
+	result := mockResponse.Result()
+
+	if result.StatusCode != http.StatusFound {
+		t.Errorf("Expected redirect (302) despite stale cookie, got %v", result.StatusCode)
+	}
+
+	// Verify a new valid token cookie was issued
+	var newTokenCookie *http.Cookie
+	for _, c := range result.Cookies() {
+		if c.Name == tokenSession {
+			newTokenCookie = c
+			break
+		}
+	}
+	if newTokenCookie == nil {
+		t.Fatal("Expected a new token session cookie to be issued")
+	}
+	decodedCookie := make(map[interface{}]interface{})
+	if err := securecookie.DecodeMulti(newTokenCookie.Name, newTokenCookie.Value, &decodedCookie, newStore.Codecs...); err != nil {
+		t.Fatalf("Cannot decode new cookie with current key: %v", err)
+	}
+	accessToken, ok := decodedCookie[tokenKey].(*oauth2.Token)
+	if !ok {
+		t.Fatalf("Error with getting access token from new cookie: %v", decodedCookie)
+	}
+	if accessToken.AccessToken != mockAccessToken {
+		t.Errorf("Invalid access token. Got %v, expected %v", accessToken.AccessToken, mockAccessToken)
+	}
+}
+
+func TestHandleLoginWithStaleCookie(t *testing.T) {
+	oldKey := []byte("old-secret-key-for-signing-cookies")
+	newKey := []byte("new-secret-key-after-rotation!!!!")
+
+	oldStore := sessions.NewCookieStore(oldKey)
+	newStore := sessions.NewCookieStore(newKey)
+
+	mockConfig := getMockConfig(newStore)
+	mockLogger := logrus.WithField("uni-test", "githuboauth")
+	mockAgent := NewAgent(mockConfig, mockLogger)
+	mockOAuthClient := mockOAuthClient{}
+
+	// Create a stale oauth-session cookie signed with the old key
+	staleReq := httptest.NewRequest(http.MethodGet, "/", nil)
+	staleResp := httptest.NewRecorder()
+	staleSession, _ := oldStore.New(staleReq, oauthSessionCookie)
+	staleSession.Values[stateKey] = "old-state"
+	if err := staleSession.Save(staleReq, staleResp); err != nil {
+		t.Fatalf("Failed to save stale session: %v", err)
+	}
+	var staleCookie *http.Cookie
+	for _, c := range staleResp.Result().Cookies() {
+		if c.Name == oauthSessionCookie {
+			staleCookie = c
+			break
+		}
+	}
+	if staleCookie == nil {
+		t.Fatal("Failed to create stale cookie")
+	}
+
+	mockRequest := httptest.NewRequest(http.MethodGet, "/mock-login?dest=somewhere", nil)
+	mockRequest.AddCookie(staleCookie)
+	mockResponse := httptest.NewRecorder()
+
+	handleLoginFn := mockAgent.HandleLogin(mockOAuthClient, false)
+	handleLoginFn.ServeHTTP(mockResponse, mockRequest)
+	result := mockResponse.Result()
+
+	if result.StatusCode != http.StatusFound {
+		t.Errorf("Expected redirect (302) despite stale cookie, got %v", result.StatusCode)
+	}
+}
+
+func TestHandleRedirectWithStaleOAuthSessionCookie(t *testing.T) {
+	oldKey := []byte("old-secret-key-for-signing-cookies")
+	newKey := []byte("new-secret-key-after-rotation!!!!")
+
+	oldStore := sessions.NewCookieStore(oldKey)
+	newStore := sessions.NewCookieStore(newKey)
+
+	mockConfig := getMockConfig(newStore)
+	mockLogger := logrus.WithField("uni-test", "githuboauth")
+	mockAgent := NewAgent(mockConfig, mockLogger)
+	mockOAuthClient := mockOAuthClient{}
+	mockStateToken := createMockStateToken(mockConfig)
+
+	staleReq := httptest.NewRequest(http.MethodGet, "/", nil)
+	staleResp := httptest.NewRecorder()
+	staleSession, _ := oldStore.New(staleReq, oauthSessionCookie)
+	staleSession.Values[stateKey] = mockStateToken
+	if err := staleSession.Save(staleReq, staleResp); err != nil {
+		t.Fatalf("Failed to save stale session: %v", err)
+	}
+	var staleCookie *http.Cookie
+	for _, c := range staleResp.Result().Cookies() {
+		if c.Name == oauthSessionCookie {
+			staleCookie = c
+			break
+		}
+	}
+	if staleCookie == nil {
+		t.Fatal("Failed to create stale cookie")
+	}
+
+	mockRequest := httptest.NewRequest(http.MethodGet, "/mock-login", nil)
+	mockRequest.AddCookie(staleCookie)
+	query := mockRequest.URL.Query()
+	query.Add("state", mockStateToken)
+	mockRequest.URL.RawQuery = query.Encode()
+	mockResponse := httptest.NewRecorder()
+
+	handleRedirectFn := mockAgent.HandleRedirect(mockOAuthClient, &fakeAuthenticatedUserIdentifier{""}, false)
+	handleRedirectFn.ServeHTTP(mockResponse, mockRequest)
+	result := mockResponse.Result()
+
+	if result.StatusCode != http.StatusInternalServerError {
+		t.Errorf("Expected 500 when OAuth state cookie cannot be decoded, got %v", result.StatusCode)
+	}
+}


### PR DESCRIPTION
Deck treated an undecodable gorilla session cookie as a 500. CookieStore.New()/Get() still return an empty session in that case (stale cookie after cookie-secret rotation, leftover from another deck, etc.), so OAuth could not finish and private-deck job reruns failed with
```
500 Internal server error Create new session: securecookie: the value is not valid
```

Login, the new token session, logout, and GetLogin now log and continue with a fresh session so a new cookie can be written. The OAuth state cookie on redirect still fails closed (CSRF).

(Also an issue was opened for this in DPTP jira: https://redhat.atlassian.net/browse/DPTP-4383)