### PR TITLE
checkconfig: don't require tide to forbid needs-rebase

### DIFF
--- a/cmd/checkconfig/main.go
+++ b/cmd/checkconfig/main.go
@@ -675,12 +675,22 @@ func validateTideRequirements(cfg *config.Config, pcfg *plugins.Configuration, i
 		// using the matcher
 		config *orgRepoConfig
 	}
-	// configs list relationships between tide config
-	// and plugin enablement that we want to validate
+	// configs list relationships between tide config and plugin enablement
+	// that we want to validate in both directions: the plugin must be
+	// enabled wherever tide honors the label, and tide must honor the label
+	// wherever the plugin is enabled.
 	configs := []plugin{
 		{name: lgtm.PluginName, label: labels.LGTM, matcher: requires},
 		{name: approve.PluginName, label: labels.Approved, matcher: requires},
 	}
+	// needsRebaseConfig is validated in one direction only: a query that
+	// forbids the needs-rebase label must have the plugin enabled. The
+	// reverse is not checked, since enabling the plugin without forbidding
+	// the label in tide is not a misconfiguration -- tide already refuses
+	// to merge any PR with a merge conflict regardless of the query (see
+	// mergeChecker.isAllowedToMerge in pkg/tide/github.go), so requiring
+	// the query to also forbid the label would be redundant.
+	needsRebaseConfig := plugin{name: needsrebase.PluginName, label: labels.NeedsRebase, external: true, matcher: forbids}
 	if includeForbidden {
 		configs = append(configs,
 			plugin{name: hold.PluginName, label: labels.Hold, matcher: forbids},
@@ -690,20 +700,25 @@ func validateTideRequirements(cfg *config.Config, pcfg *plugins.Configuration, i
 			plugin{name: releasenote.PluginName, label: labels.ReleaseNoteLabelNeeded, matcher: forbids},
 			plugin{name: cherrypickunapproved.PluginName, label: labels.CpUnapproved, matcher: forbids},
 			plugin{name: blockade.PluginName, label: labels.BlockedPaths, matcher: forbids},
-			plugin{name: needsrebase.PluginName, label: labels.NeedsRebase, external: true, matcher: forbids},
 		)
 	}
 
-	for i := range configs {
+	populateConfig := func(p *plugin) {
 		// For each plugin determine the subset of tide queries that match and then
 		// the orgs and repos that the subset matches.
 		var matchingQueries config.TideQueries
 		for _, query := range cfg.Tide.Queries {
-			if configs[i].matcher.matches(configs[i].label, query) {
+			if p.matcher.matches(p.label, query) {
 				matchingQueries = append(matchingQueries, query)
 			}
 		}
-		configs[i].config = newOrgRepoConfig(matchingQueries.OrgExceptionsAndRepos())
+		p.config = newOrgRepoConfig(matchingQueries.OrgExceptionsAndRepos())
+	}
+	for i := range configs {
+		populateConfig(&configs[i])
+	}
+	if includeForbidden {
+		populateConfig(&needsRebaseConfig)
 	}
 
 	overallTideConfig := newOrgRepoConfig(cfg.Tide.Queries.OrgExceptionsAndRepos())
@@ -720,6 +735,15 @@ func validateTideRequirements(cfg *config.Config, pcfg *plugins.Configuration, i
 			enabledOrgReposForPlugin(pcfg, pluginConfig.name, pluginConfig.external),
 		)
 		validationErrs = append(validationErrs, err)
+	}
+	if includeForbidden {
+		validationErrs = append(validationErrs, ensureLabelPluginEnabled(
+			needsRebaseConfig.name,
+			needsRebaseConfig.label,
+			needsRebaseConfig.matcher.verb,
+			needsRebaseConfig.config,
+			enabledOrgReposForPlugin(pcfg, needsRebaseConfig.name, needsRebaseConfig.external),
+		))
 	}
 
 	return utilerrors.NewAggregate(validationErrs)
@@ -902,18 +926,28 @@ func enabledOrgReposForPlugin(c *plugins.Configuration, plugin string, external 
 //     plugins as are configured. If the repository has LGTM and approve enabled, the tide query
 //     must require both labels
 func ensureValidConfiguration(plugin, label, verb string, tideSubSet, tideSuperSet, pluginsSubSet *orgRepoConfig) error {
-	notEnabled := tideSubSet.difference(pluginsSubSet).items()
-	notRequired := pluginsSubSet.intersection(tideSuperSet).difference(tideSubSet).items()
-
 	var configErrors []error
-	if len(notEnabled) > 0 {
-		configErrors = append(configErrors, fmt.Errorf("the following orgs or repos %s the %s label for merging but do not enable the %s plugin: %v", verb, label, plugin, notEnabled))
+	if err := ensureLabelPluginEnabled(plugin, label, verb, tideSubSet, pluginsSubSet); err != nil {
+		configErrors = append(configErrors, err)
 	}
+
+	notRequired := pluginsSubSet.intersection(tideSuperSet).difference(tideSubSet).items()
 	if len(notRequired) > 0 {
 		configErrors = append(configErrors, fmt.Errorf("the following orgs or repos enable the %s plugin but do not %s the %s label for merging: %v", plugin, verb, label, notRequired))
 	}
 
 	return utilerrors.NewAggregate(configErrors)
+}
+
+// ensureLabelPluginEnabled checks that every org or repo for which tide
+// honors the label (per tideSubSet) also has the corresponding plugin
+// enabled.
+func ensureLabelPluginEnabled(plugin, label, verb string, tideSubSet, pluginsSubSet *orgRepoConfig) error {
+	notEnabled := tideSubSet.difference(pluginsSubSet).items()
+	if len(notEnabled) > 0 {
+		return fmt.Errorf("the following orgs or repos %s the %s label for merging but do not enable the %s plugin: %v", verb, label, plugin, notEnabled)
+	}
+	return nil
 }
 
 func validateDecoratedJobs(cfg *config.Config) error {

--- a/cmd/checkconfig/main_test.go
+++ b/cmd/checkconfig/main_test.go
@@ -179,6 +179,45 @@ func TestEnsureValidConfiguration(t *testing.T) {
 	}
 }
 
+func TestEnsureLabelPluginEnabled(t *testing.T) {
+	var testCases = []struct {
+		name                      string
+		tideSubSet, pluginsSubSet *orgRepoConfig
+		expectedErr               bool
+	}{
+		{
+			name:          "query forbids label, plugin enabled: no error",
+			tideSubSet:    newOrgRepoConfig(nil, sets.New[string]("org/repo")),
+			pluginsSubSet: newOrgRepoConfig(nil, sets.New[string]("org/repo")),
+			expectedErr:   false,
+		},
+		{
+			name:          "query forbids label, plugin not enabled: error",
+			tideSubSet:    newOrgRepoConfig(nil, sets.New[string]("org/repo")),
+			pluginsSubSet: newOrgRepoConfig(nil, nil),
+			expectedErr:   true,
+		},
+		{
+			name:          "plugin enabled without query forbidding label: no error (unlike the two-directional check)",
+			tideSubSet:    newOrgRepoConfig(nil, nil),
+			pluginsSubSet: newOrgRepoConfig(nil, sets.New[string]("org/repo")),
+			expectedErr:   false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			err := ensureLabelPluginEnabled("plugin", "label", "verb", testCase.tideSubSet, testCase.pluginsSubSet)
+			if testCase.expectedErr && err == nil {
+				t.Errorf("%s: expected an error but got none", testCase.name)
+			}
+			if !testCase.expectedErr && err != nil {
+				t.Errorf("%s: expected no error but got one: %v", testCase.name, err)
+			}
+		})
+	}
+}
+
 func TestOrgRepoDifference(t *testing.T) {
 	testCases := []struct {
 		name           string


### PR DESCRIPTION
Tide already refuses to merge any PR with a merge conflict (MergeableStateConflicting), independent of the tide query, in mergeChecker.isAllowedToMerge (pkg/tide/github.go). Requiring the needs-rebase label to also be forbidden in missingLabels is therefore always redundant, and a repo should be free to enable the needs-rebase
plugin purely for its labeling/UX value without checkconfig demanding the query also forbid it.

This removes only the "notRequired" direction of the check for needs-rebase; the "notEnabled" direction (query forbids needs-rebase but the plugin isn't enabled) is still a real misconfiguration and is kept, as are both directions for every other plugin/label pair.

Assisted by Claude Code
