### PR TITLE
statusreconciler: never drop config deltas

### DIFF
--- a/pkg/config/agent.go
+++ b/pkg/config/agent.go
@@ -35,15 +35,18 @@ type Delta struct {
 	Before, After Config
 }
 
-// DeltaChan is a channel to receive config delta events when config changes.
-type DeltaChan = chan<- Delta
+// DeltaChan is a receive-only channel handed out by Subscribe to deliver config
+// delta events when config changes.
+type DeltaChan = <-chan Delta
 
 // Agent watches a path and automatically loads the config stored
 // therein.
 type Agent struct {
-	mut           sync.RWMutex // do not export Lock, etc methods
-	c             *Config
-	subscriptions []DeltaChan
+	mut sync.RWMutex // do not export Lock, etc methods
+	c   *Config
+	// subscriptions are single-slot buffered channels owned by the Agent; Set
+	// coalesces into them (see deliverDelta) and hands out a receive-only view.
+	subscriptions []chan Delta
 }
 
 // IsConfigMapMount determines whether the provided directory is a configmap mounted directory
@@ -378,14 +381,16 @@ func (ca *Agent) Start(prowConfig, jobConfig string, additionalProwConfigDirs []
 	return nil
 }
 
-// Subscribe registers the channel for messages on config reload.
-// The caller can expect a copy of the previous and current config
-// to be sent down the subscribed channel when a new configuration
-// is loaded.
-func (ca *Agent) Subscribe(subscription DeltaChan) {
+// Subscribe returns a channel that receives a copy of the previous and current
+// config whenever a new configuration is loaded. The Agent owns the channel: it
+// is single-slot buffered so Set can coalesce into it (see deliverDelta) rather
+// than block or drop when the subscriber is busy.
+func (ca *Agent) Subscribe() DeltaChan {
 	ca.mut.Lock()
 	defer ca.mut.Unlock()
+	subscription := make(chan Delta, 1)
 	ca.subscriptions = append(ca.subscriptions, subscription)
+	return subscription
 }
 
 // Getter returns the current Config in a thread-safe manner.
@@ -410,16 +415,34 @@ func (ca *Agent) Set(c *Config) {
 	delta := Delta{oldConfig, *c}
 	ca.c = c
 	for _, subscription := range ca.subscriptions {
-		go func(sub DeltaChan) { // wait a minute to send each event
-			end := time.NewTimer(time.Minute)
+		deliverDelta(subscription, delta)
+	}
+}
+
+// deliverDelta hands delta to a subscriber without blocking or dropping it.
+//
+// sub is a single-slot buffered channel. If the subscriber has not drained the
+// previous delta yet, we take it back and coalesce: the pending {Before, _} is
+// replaced with {Before, delta.After}, widening it to cover both transitions.
+// Deltas chain (each Before equals the previous After), so the merged delta is
+// exactly the transition the subscriber still owes -- letting a subscriber trust
+// Before even across changes it was too busy to observe individually.
+//
+// With a single producer (Set is serialized by ca.mut) and a single consumer
+// that only receives, this terminates in at most two iterations: once we take
+// the pending value back the slot is empty and nobody else can refill it.
+func deliverDelta(sub chan Delta, delta Delta) {
+	for {
+		select {
+		case sub <- delta:
+			return
+		default:
 			select {
-			case sub <- delta:
-			case <-end.C:
+			case pending := <-sub:
+				delta = Delta{Before: pending.Before, After: delta.After}
+			default:
 			}
-			if !end.Stop() { // prevent new events
-				<-end.C // drain the pending event
-			}
-		}(subscription)
+		}
 	}
 }
 

--- a/pkg/config/agent_test.go
+++ b/pkg/config/agent_test.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import "testing"
+
+func cfg(sha string) *Config {
+	return &Config{ProwConfig: ProwConfig{ConfigVersionSHA: sha}}
+}
+
+// TestSetCoalescesForBusySubscriber verifies that when a subscriber has not
+// drained the previous delta, further Set calls coalesce into its single slot
+// rather than blocking or dropping: the pending Before is preserved and the
+// After advances to the newest config, so the subscriber can still trust Before.
+func TestSetCoalescesForBusySubscriber(t *testing.T) {
+	agent := &Agent{}
+	sub := agent.Subscribe()
+
+	// v0(empty) -> v1 lands in the buffer; nobody is reading yet.
+	agent.Set(cfg("v1"))
+	// v1 -> v2 -> v3 while the subscriber is still busy: each must coalesce
+	// into the one slot instead of blocking Set or being dropped.
+	agent.Set(cfg("v2"))
+	agent.Set(cfg("v3"))
+
+	var got Delta
+	select {
+	case got = <-sub:
+	default:
+		t.Fatal("expected a coalesced delta in the buffer, found none")
+	}
+	if got.Before.ConfigVersionSHA != "" {
+		t.Errorf("Before = %q, want %q (the initial config, not skipped)", got.Before.ConfigVersionSHA, "")
+	}
+	if got.After.ConfigVersionSHA != "v3" {
+		t.Errorf("After = %q, want %q (the newest config)", got.After.ConfigVersionSHA, "v3")
+	}
+
+	// Everything coalesced into a single delta; nothing else is queued.
+	select {
+	case extra := <-sub:
+		t.Fatalf("unexpected second delta: before=%q after=%q", extra.Before.ConfigVersionSHA, extra.After.ConfigVersionSHA)
+	default:
+	}
+}
+
+// TestSetDeliversChainedDeltasWhenDrained verifies that a subscriber that keeps
+// up receives each transition as a properly chained delta (every Before equals
+// the previous After).
+func TestSetDeliversChainedDeltasWhenDrained(t *testing.T) {
+	agent := &Agent{}
+	sub := agent.Subscribe()
+
+	for _, want := range []struct{ before, after string }{
+		{"", "v1"},
+		{"v1", "v2"},
+		{"v2", "v3"},
+	} {
+		agent.Set(cfg(want.after))
+		got := <-sub // drain immediately, so no coalescing happens
+		if got.Before.ConfigVersionSHA != want.before || got.After.ConfigVersionSHA != want.after {
+			t.Errorf("delta = {%q -> %q}, want {%q -> %q}", got.Before.ConfigVersionSHA, got.After.ConfigVersionSHA, want.before, want.after)
+		}
+	}
+}

--- a/pkg/moonraker/moonraker.go
+++ b/pkg/moonraker/moonraker.go
@@ -104,8 +104,7 @@ func (mr *Moonraker) ServeGetInrepoconfig(w http.ResponseWriter, r *http.Request
 }
 
 func (mr *Moonraker) RunConfigWatcher(ctx context.Context) error {
-	configEvent := make(chan config.Delta, 2)
-	mr.ConfigAgent.Subscribe(configEvent)
+	configEvent := mr.ConfigAgent.Subscribe()
 
 	var err error
 	defer func() {

--- a/pkg/pubsub/subscriber/server.go
+++ b/pkg/pubsub/subscriber/server.go
@@ -155,8 +155,7 @@ func (s *PullServer) handlePulls(ctx context.Context, projectSubscriptions confi
 // Run will block listening to all subscriptions and return once the context is cancelled
 // or one of the subscription has a unrecoverable error.
 func (s *PullServer) Run(ctx context.Context) error {
-	configEvent := make(chan config.Delta, 2)
-	s.Subscriber.ConfigAgent.Subscribe(configEvent)
+	configEvent := s.Subscriber.ConfigAgent.Subscribe()
 
 	var err error
 	defer func() {

--- a/pkg/statusreconciler/status.go
+++ b/pkg/statusreconciler/status.go
@@ -34,7 +34,7 @@ type storedState struct {
 }
 
 type statusClient interface {
-	Load() (chan config.Delta, error)
+	Load() (config.DeltaChan, error)
 	Save() error
 }
 
@@ -54,14 +54,13 @@ type statusController struct {
 	config.Agent
 }
 
-func (s *statusController) Load() (chan config.Delta, error) {
+func (s *statusController) Load() (config.DeltaChan, error) {
 	s.Agent = config.Agent{}
 	state, err := s.loadState()
 	if err == nil {
 		s.Agent.Set(&state.Config)
 	}
-	changes := make(chan config.Delta)
-	s.Agent.Subscribe(changes)
+	changes := s.Agent.Subscribe()
 
 	if _, err := s.configOpts.ConfigAgent(&s.Agent); err != nil {
 		s.logger.WithError(err).Error("Error starting config agent.")


### PR DESCRIPTION
config.Agent.Set delivered each config delta to subscribers via a goroutine that waited up to a minute and then silently dropped the delta. A subscriber busy longer than that (the status-reconciler, while reconciling PR statuses) would miss the drop, and because it trusts the next delta's Before field, every config change hidden by the dropped delta was skipped permanently.

Make delivery lossless at the source. Subscribe now owns the channel: it hands back a single-slot buffered channel and returns a receive-only view. Set coalesces into that slot instead of blocking or dropping -- an undelivered {Before, _} is taken back and replaced with {Before, newAfter}. Deltas chain (each Before equals the previous After), so the merged delta is exactly the transition the subscriber still owes, and Before stays trustworthy no matter how long the subscriber was busy.

This removes the per-send goroutine and one-minute timer entirely and fixes the bug for every subscriber, not just the status-reconciler. moonraker and pubsub already track their own last config and are unaffected.

- config.Agent: Subscribe() returns an owned single-slot DeltaChan; Set uses deliverDelta to coalesce; DeltaChan is now receive-only (<-chan Delta)
- moonraker, pubsub, statusreconciler subscribers updated to the new Subscribe

Fixes kubernetes-sigs/prow#848
Alternative to #849 / #871

Assisted by Claude Code (Opus 4.8)