### PR TITLE
statusreconciler: decouple reconciliation from config change messages

### DIFF
--- a/pkg/config/agent.go
+++ b/pkg/config/agent.go
@@ -415,6 +415,9 @@ func (ca *Agent) Set(c *Config) {
 			select {
 			case sub <- delta:
 			case <-end.C:
+				logrus.WithField("old_config_revision", delta.Before.ConfigVersionSHA).
+					WithField("config_revision", delta.After.ConfigVersionSHA).
+					Warn("Timed out delivering config delta to a subscriber; the delta was dropped")
 			}
 			if !end.Stop() { // prevent new events
 				<-end.C // drain the pending event

--- a/pkg/statusreconciler/controller.go
+++ b/pkg/statusreconciler/controller.go
@@ -165,14 +165,65 @@ func (c *Controller) Run(ctx context.Context) {
 		return
 	}
 
+	// We reconcile from the last config we successfully reconciled to the most
+	// recent one we know about, rather than trusting an incoming delta's Before
+	// value. A dedicated goroutine drains the delta channel immediately and keeps
+	// only the latest After, so the config agent's sender never blocks (its
+	// delivery times out and drops the delta after a minute) and no config change
+	// is missed while we are busy reconciling. See kubernetes-sigs/prow#848.
+	latest := make(chan config.Config, 1)
+	push := func(after config.Config) {
+		// Single producer: drop any stale pending value and keep only the latest.
+		select {
+		case <-latest:
+		default:
+		}
+		latest <- after
+	}
+
+	// Seed from the first delta's Before: the config loaded from stored state, or
+	// the empty config on a fresh start.
+	var lastReconciled *config.Config
+	select {
+	case delta := <-changes:
+		before := delta.Before
+		lastReconciled = &before
+		push(delta.After)
+	case <-ctx.Done():
+		logrus.Info("status-reconciler is shutting down...")
+		return
+	}
+
+	go func() {
+		for {
+			select {
+			case delta := <-changes:
+				push(delta.After)
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
 	for {
 		select {
-		case change := <-changes:
-			start := time.Now()
-			log := logrus.WithField("old_config_revision", change.Before.ConfigVersionSHA).WithField("config_revision", change.After.ConfigVersionSHA)
-			if err := c.reconcile(change, log); err != nil {
-				log.WithError(err).Error("Error reconciling statuses.")
+		case after := <-latest:
+			// Skip unchanged wakeups; ConfigVersionSHA is empty in some setups
+			// (e.g. tests), so only trust it when populated.
+			if lastReconciled.ConfigVersionSHA != "" && after.ConfigVersionSHA == lastReconciled.ConfigVersionSHA {
+				continue
 			}
+			start := time.Now()
+			delta := config.Delta{Before: *lastReconciled, After: after}
+			log := logrus.WithField("old_config_revision", delta.Before.ConfigVersionSHA).WithField("config_revision", delta.After.ConfigVersionSHA)
+			if err := c.reconcile(delta, log); err != nil {
+				// Leave lastReconciled untouched so the skipped transition is
+				// retried against the next config we are told about.
+				log.WithError(err).Error("Error reconciling statuses.")
+				continue
+			}
+			reconciled := after
+			lastReconciled = &reconciled
 			log.WithField("duration", fmt.Sprintf("%v", time.Since(start))).Info("Statuses reconciled")
 			c.statusClient.Save()
 		case <-ctx.Done():

--- a/pkg/statusreconciler/controller.go
+++ b/pkg/statusreconciler/controller.go
@@ -37,6 +37,14 @@ import (
 	"sigs.k8s.io/prow/pkg/statusreconciler/migrator"
 )
 
+const (
+	// defaultMaxReconcileAttempts bounds retries of a single transition so a
+	// persistently-failing ("poison") config cannot block later changes.
+	defaultMaxReconcileAttempts = 5
+	// defaultReconcileRetryDelay is how long we wait between reconcile attempts.
+	defaultReconcileRetryDelay = 30 * time.Second
+)
+
 // NewController constructs a new controller to reconcile stauses on config change
 func NewController(continueOnError bool, addedPresubmitDenylist, addedPresubmitDenylistAll sets.Set[string], opener io.Opener, configOpts configflagutil.ConfigOptions, statusURI string, prowJobClient prowv1.ProwJobInterface, githubClient github.Client, pluginAgent *plugins.ConfigAgent) *Controller {
 	sc := &statusController{
@@ -50,6 +58,8 @@ func NewController(continueOnError bool, addedPresubmitDenylist, addedPresubmitD
 		continueOnError:           continueOnError,
 		addedPresubmitDenylist:    addedPresubmitDenylist,
 		addedPresubmitDenylistAll: addedPresubmitDenylistAll,
+		maxReconcileAttempts:      defaultMaxReconcileAttempts,
+		reconcileRetryDelay:       defaultReconcileRetryDelay,
 		prowJobTriggerer: &kubeProwJobTriggerer{
 			prowJobClient: prowJobClient,
 			githubClient:  githubClient,
@@ -149,6 +159,8 @@ type Controller struct {
 	continueOnError           bool
 	addedPresubmitDenylist    sets.Set[string]
 	addedPresubmitDenylistAll sets.Set[string]
+	maxReconcileAttempts      int
+	reconcileRetryDelay       time.Duration
 	prowJobTriggerer          prowJobTriggerer
 	githubClient              githubClient
 	statusMigrator            statusMigrator
@@ -216,11 +228,14 @@ func (c *Controller) Run(ctx context.Context) {
 			start := time.Now()
 			delta := config.Delta{Before: *lastReconciled, After: after}
 			log := logrus.WithField("old_config_revision", delta.Before.ConfigVersionSHA).WithField("config_revision", delta.After.ConfigVersionSHA)
-			if err := c.reconcile(delta, log); err != nil {
-				// Leave lastReconciled untouched so the skipped transition is
-				// retried against the next config we are told about.
-				log.WithError(err).Error("Error reconciling statuses.")
-				continue
+			if err := c.reconcileWithRetry(ctx, delta, log); err != nil {
+				if ctx.Err() != nil {
+					// Shutting down mid-retry; let the next iteration observe ctx.Done().
+					continue
+				}
+				// Retries exhausted: advance past this transition (losing it) and
+				// alert, so a persistently-failing config cannot block later changes.
+				log.WithError(err).Error("Giving up reconciling statuses after retries; skipping this transition to avoid blocking later config changes")
 			}
 			reconciled := after
 			lastReconciled = &reconciled
@@ -229,6 +244,37 @@ func (c *Controller) Run(ctx context.Context) {
 		case <-ctx.Done():
 			logrus.Info("status-reconciler is shutting down...")
 			return
+		}
+	}
+}
+
+// reconcileWithRetry reconciles a single config transition, retrying a bounded
+// number of times so a persistently-failing transition cannot wedge the
+// controller. Returns nil on success, or the last error once the attempt budget
+// is exhausted or ctx is cancelled.
+func (c *Controller) reconcileWithRetry(ctx context.Context, delta config.Delta, log *logrus.Entry) error {
+	attempts := c.maxReconcileAttempts
+	if attempts <= 0 {
+		attempts = defaultMaxReconcileAttempts
+	}
+	delay := c.reconcileRetryDelay
+	if delay <= 0 {
+		delay = defaultReconcileRetryDelay
+	}
+
+	var err error
+	for attempt := 1; ; attempt++ {
+		if err = c.reconcile(delta, log); err == nil {
+			return nil
+		}
+		if attempt >= attempts {
+			return err
+		}
+		log.WithError(err).WithField("attempt", attempt).Warn("Error reconciling statuses; will retry.")
+		select {
+		case <-time.After(delay):
+		case <-ctx.Done():
+			return err
 		}
 	}
 }
@@ -307,7 +353,11 @@ func (c *Controller) triggerNewPresubmits(addedPresubmits map[string][]config.Pr
 			logger := log.WithFields(logrus.Fields{"org": org, "repo": repo, "number": number, "branch": branch})
 			toTrigger, err := pjutil.FilterPresubmits(filter, changes, branch, presubmits, logger)
 			if err != nil {
-				return err
+				triggerErrors = append(triggerErrors, fmt.Errorf("failed to filter presubmits for %s#%d: %w", orgrepo, pr.Number, err))
+				if !c.continueOnError {
+					return utilerrors.NewAggregate(triggerErrors)
+				}
+				continue
 			}
 			if err := c.triggerIfTrusted(org, repo, pr, toTrigger); err != nil {
 				triggerErrors = append(triggerErrors, fmt.Errorf("failed to trigger jobs for %s#%d: %w", orgrepo, pr.Number, err))

--- a/pkg/statusreconciler/controller_test.go
+++ b/pkg/statusreconciler/controller_test.go
@@ -1436,6 +1436,87 @@ func TestControllerRunRecoversDroppedDelta(t *testing.T) {
 	checkTriggerer(t, fpjt, expected)
 }
 
+// TestControllerRunDoesNotWedgeOnFailure verifies that a persistently-failing
+// ("poison") config transition is retried a bounded number of times and then
+// skipped, so that later config changes are not blocked behind it forever.
+func TestControllerRunDoesNotWedgeOnFailure(t *testing.T) {
+	baseConfigData := `presubmits:
+  "org/repo":
+  - name: existing-job
+    context: existing-job
+    always_run: true`
+	withNewJobData := `presubmits:
+  "org/repo":
+  - name: existing-job
+    context: existing-job
+    always_run: true
+  - name: new-required-job
+    context: new-required-context
+    always_run: true`
+
+	mustConfig := func(data string) config.Config {
+		var c config.Config
+		if err := yaml.Unmarshal([]byte(data), &c); err != nil {
+			t.Fatalf("could not unmarshal config: %v", err)
+		}
+		for _, presubmits := range c.PresubmitsStatic {
+			if err := config.SetPresubmitRegexes(presubmits); err != nil {
+				t.Fatalf("could not set presubmit regexes: %v", err)
+			}
+		}
+		return c
+	}
+	base := mustConfig(baseConfigData)
+	withNewJob := mustConfig(withNewJobData)
+
+	org, repo := "org", "repo"
+	orgRepoKey := orgRepo{org: org, repo: repo}
+
+	fpjt := newfakeProwJobTriggerer()
+	fghc := newFakeGitHubClient(orgRepoKey)
+	// GetPullRequests always fails for this repo, so triggering the added
+	// blocking presubmit can never succeed - a poison transition.
+	fghc.prErrors = orgRepoSet{orgRepoKey: nil}
+	fsm := newFakeMigrator(orgRepoKey)
+	ftc := newFakeTrustedChecker(orgRepoKey)
+
+	changes := make(chan config.Delta)
+	saves := make(chan struct{}, 8)
+	controller := Controller{
+		continueOnError:        true,
+		addedPresubmitDenylist: sets.New[string](),
+		maxReconcileAttempts:   2,
+		reconcileRetryDelay:    time.Millisecond,
+		prowJobTriggerer:       &fpjt,
+		githubClient:           &fghc,
+		statusMigrator:         &fsm,
+		trustedChecker:         &ftc,
+		statusClient:           &fakeStatusClient{changes: changes, saves: saves},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go controller.Run(ctx)
+
+	waitForSave := func(what string) {
+		select {
+		case <-saves:
+		case <-time.After(10 * time.Second):
+			t.Fatalf("timed out waiting for %s reconcile to complete", what)
+		}
+	}
+
+	// The poison transition (adds a blocking presubmit whose triggering always
+	// fails) must still complete - retried, then skipped - and advance.
+	changes <- config.Delta{Before: base, After: withNewJob}
+	waitForSave("poison")
+
+	// A subsequent transition must still be processed rather than being wedged
+	// behind the failed one. This no-op diff touches no GitHub API.
+	changes <- config.Delta{Before: withNewJob, After: withNewJob}
+	waitForSave("subsequent")
+}
+
 func logrusEntry() *logrus.Entry {
 	return logrus.NewEntry(logrus.StandardLogger())
 }

--- a/pkg/statusreconciler/controller_test.go
+++ b/pkg/statusreconciler/controller_test.go
@@ -17,8 +17,10 @@ limitations under the License.
 package statusreconciler
 
 import (
+	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -1316,6 +1318,122 @@ func TestControllerReconcile(t *testing.T) {
 			check(t)
 		})
 	}
+}
+
+type fakeStatusClient struct {
+	changes chan config.Delta
+	saves   chan struct{}
+}
+
+func (f *fakeStatusClient) Load() (chan config.Delta, error) { return f.changes, nil }
+
+func (f *fakeStatusClient) Save() error {
+	if f.saves != nil {
+		f.saves <- struct{}{}
+	}
+	return nil
+}
+
+// TestControllerRunRecoversDroppedDelta reproduces kubernetes-sigs/prow#848: a
+// config delta that adds a blocking presubmit is dropped while the controller is
+// busy, and the controller must still trigger the new presubmit when the next
+// delta arrives, by reconciling from the last config it actually processed
+// rather than trusting the dropped-through Before value.
+func TestControllerRunRecoversDroppedDelta(t *testing.T) {
+	baseConfigData := `presubmits:
+  "org/repo":
+  - name: existing-job
+    context: existing-job
+    always_run: true`
+	withNewJobData := `presubmits:
+  "org/repo":
+  - name: existing-job
+    context: existing-job
+    always_run: true
+  - name: new-required-job
+    context: new-required-context
+    always_run: true`
+
+	mustConfig := func(data string) config.Config {
+		var c config.Config
+		if err := yaml.Unmarshal([]byte(data), &c); err != nil {
+			t.Fatalf("could not unmarshal config: %v", err)
+		}
+		for _, presubmits := range c.PresubmitsStatic {
+			if err := config.SetPresubmitRegexes(presubmits); err != nil {
+				t.Fatalf("could not set presubmit regexes: %v", err)
+			}
+		}
+		return c
+	}
+	// v1 == v2 (no blocking change); new-required-job is introduced in the
+	// v2->v3 transition (whose delta is dropped) and remains in v4.
+	v1 := mustConfig(baseConfigData)
+	v2 := mustConfig(baseConfigData)
+	v3 := mustConfig(withNewJobData)
+	v4 := mustConfig(withNewJobData)
+
+	org, repo := "org", "repo"
+	orgRepoKey := orgRepo{org: org, repo: repo}
+	author := "user"
+	prNumber := 1
+	pr := github.PullRequest{
+		User:   github.User{Login: author},
+		Number: prNumber,
+		Base: github.PullRequestBranch{
+			Repo: github.Repo{Owner: github.User{Login: org}, Name: repo},
+			Ref:  "base",
+		},
+		Head: github.PullRequestBranch{SHA: "prsha"},
+	}
+
+	fpjt := newfakeProwJobTriggerer()
+	fghc := newFakeGitHubClient(orgRepoKey)
+	fghc.prs[orgRepoKey] = []github.PullRequest{pr}
+	fghc.refs[orgRepoKey]["heads/"+pr.Base.Ref] = "abc"
+	fsm := newFakeMigrator(orgRepoKey)
+	ftc := newFakeTrustedChecker(orgRepoKey)
+	ftc.trusted[orgRepoKey][prAuthor{author: author, pr: prNumber}] = true
+
+	changes := make(chan config.Delta)
+	saves := make(chan struct{}, 8)
+	controller := Controller{
+		continueOnError:        true,
+		addedPresubmitDenylist: sets.New[string](),
+		prowJobTriggerer:       &fpjt,
+		githubClient:           &fghc,
+		statusMigrator:         &fsm,
+		trustedChecker:         &ftc,
+		statusClient:           &fakeStatusClient{changes: changes, saves: saves},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go controller.Run(ctx)
+
+	waitForSave := func(what string) {
+		select {
+		case <-saves:
+		case <-time.After(10 * time.Second):
+			t.Fatalf("timed out waiting for %s reconcile to complete", what)
+		}
+	}
+
+	// First delta v1->v2 establishes lastReconciled == v2 (no new presubmit).
+	changes <- config.Delta{Before: v1, After: v2}
+	waitForSave("first")
+
+	// v2->v3 is dropped (never delivered). Deliver v3->v4; its Before (v3)
+	// already contains new-required-job, so trusting it would skip the trigger.
+	changes <- config.Delta{Before: v3, After: v4}
+	waitForSave("second")
+
+	cancel()
+
+	expected := map[prKey]sets.Set[string]{
+		{org: org, repo: repo, num: prNumber}: sets.New[string]("new-required-job"),
+	}
+	checkTriggerer(t, fpjt, expected)
 }
 
 func logrusEntry() *logrus.Entry {


### PR DESCRIPTION
config.Agent.Set delivers deltas on a best-effort basis, abandoning delivery if the subscriber cannot receive within a minute. While status-reconciler is busy reconciling one change, later deltas can be dropped. Because the agent's internal config has already advanced, a subsequent delta's Before value no longer reflects the last config status-reconciler actually reconciled, so trusting it permanently hides the skipped transition - e.g. a newly-added blocking presubmit is never triggered on open PRs.

Stop trusting the incoming delta's Before value. Track the last config we successfully reconciled and always reconcile from there to the most recent config we have been told about. A dedicated goroutine drains the delta channel immediately so the agent's sender never blocks (and so never times out and drops a delta), recording only the latest After it has seen. lastReconciled advances only after a successful reconcile.

Also log a warning from config.Agent.Set when a delta delivery times out, so dropped deltas are visible to operators.

Ensure that we eventually advance from a potential problematic delta (a config transition that fails deterministically like a renamed/inaccessible repo, a persistent GitHub error) by bounding retries:

- Retry a failing transition a bounded number of times with a delay between attempts, recovering transient/overload failures automatically instead of waiting for the next config change.
- Once the attempt budget is exhausted, advance past the transition and emit a loud error, so a poison config cannot wedge the controller - while making the skipped transition visible to operators.
- Retry parameters are configurable (with sane defaults) so tests can exercise the path quickly.

Also honor continueOnError when pjutil.FilterPresubmits fails: previously a single PR whose changed files could not be fetched aborted triggering for the entire repo regardless of the continueOnError setting.

Fixes kubernetes-sigs/prow#848
Alternative to #849 / #870

Assisted by Claude Code (Opus 4.8)