### PR TITLE
test/integration: deflake TestDeck against parallel deck restarts

### DIFF
--- a/test/integration/config/prow/cluster/deck_deployment.yaml
+++ b/test/integration/config/prow/cluster/deck_deployment.yaml
@@ -93,7 +93,7 @@ spec:
             port: 8081
           initialDelaySeconds: 10
           periodSeconds: 3
-          timeoutSeconds: 600
+          timeoutSeconds: 3
       volumes:
       - name: oauth-config
         secret:

--- a/test/integration/config/prow/cluster/deck_tenant_deployment.yaml
+++ b/test/integration/config/prow/cluster/deck_tenant_deployment.yaml
@@ -95,7 +95,7 @@ spec:
             port: 8081
           initialDelaySeconds: 10
           periodSeconds: 3
-          timeoutSeconds: 600
+          timeoutSeconds: 3
       volumes:
       - name: oauth-config
         secret:

--- a/test/integration/test/deck_test.go
+++ b/test/integration/test/deck_test.go
@@ -227,17 +227,31 @@ func getSpecs(pjs *prowjobv1.ProwJobList) []prowjobv1.ProwJobSpec {
 func TestDeck(t *testing.T) {
 	t.Parallel()
 
-	resp, err := http.Get("http://localhost/deck")
-	if err != nil {
-		t.Fatalf("Failed getting deck front end %v", err)
+	// Deck can be transiently unavailable while this test runs: it has a
+	// single replica, and tests running in parallel (TestRerun) restart it
+	// to pick up job-config changes, during which the ingress answers with
+	// a 5xx. Retry until deck serves the front page.
+	var body []byte
+	scraper := func(ctx context.Context) (bool, error) {
+		resp, err := http.Get("http://localhost/deck")
+		if err != nil {
+			t.Logf("Failed getting deck front end: %v", err)
+			return false, nil
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Logf("Expected response status code %d, got %d", http.StatusOK, resp.StatusCode)
+			return false, nil
+		}
+		body, err = io.ReadAll(resp.Body)
+		if err != nil {
+			t.Logf("Failed getting deck body response content: %v", err)
+			return false, nil
+		}
+		return true, nil
 	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		t.Fatalf("Expected response status code %d, got %d, ", http.StatusOK, resp.StatusCode)
-	}
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		t.Fatalf("Failed getting deck body response content %v", err)
+	if waitErr := wait.PollUntilContextTimeout(context.Background(), 1*time.Second, 180*time.Second, true, scraper); waitErr != nil {
+		t.Fatalf("Timed out waiting for deck front end: %v", waitErr)
 	}
 	if got, want := string(body), "<title>Prow Status</title>"; !strings.Contains(got, want) {
 		firstLines := strings.Join(strings.SplitN(strings.TrimSpace(got), "\n", 30), "\n")

--- a/test/integration/test/deck_test.go
+++ b/test/integration/test/deck_test.go
@@ -472,11 +472,15 @@ func TestRerun(t *testing.T) {
 			lastErr = nil
 			res, err := http.DefaultClient.Do(req)
 			if err != nil {
+				// res is nil on a transport-level error (e.g. a pooled
+				// connection to the ingress closed under us; Go does not
+				// auto-retry POSTs), so there is no body to close. Retry
+				// like any other transient failure.
 				lastErr = fmt.Errorf("could not make post request %v", err)
-				res.Body.Close()
-				break
+				waitDur *= 2
+				time.Sleep(waitDur)
+				continue
 			}
-			// The only retry condition is status not ok
 			if res.StatusCode != http.StatusOK {
 				lastErr = fmt.Errorf("status not expected: %d", res.StatusCode)
 				res.Body.Close()

--- a/test/integration/test/setup.go
+++ b/test/integration/test/setup.go
@@ -26,11 +26,14 @@ import (
 	"io"
 	"sync"
 	"testing"
+	"time"
 
 	pipelinev1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	coreapi "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
@@ -130,17 +133,46 @@ func refreshProwPods(client ctrlruntimeclient.Client, ctx context.Context, name 
 	prowComponentsMux.Lock()
 	defer prowComponentsMux.Unlock()
 
-	var pods coreapi.PodList
-	labels, _ := labels.Parse("app = " + name)
-	if err := client.List(ctx, &pods, &ctrlruntimeclient.ListOptions{LabelSelector: labels}); err != nil {
+	selector, err := labels.Parse("app = " + name)
+	if err != nil {
 		return err
 	}
+	var pods coreapi.PodList
+	if err := client.List(ctx, &pods, &ctrlruntimeclient.ListOptions{LabelSelector: selector}); err != nil {
+		return err
+	}
+	oldPodUIDs := map[types.UID]bool{}
 	for _, pod := range pods.Items {
+		oldPodUIDs[pod.UID] = true
 		if err := client.Delete(ctx, &pod); err != nil {
 			return err
 		}
 	}
-	return nil
+	// Wait for the replacement pods to become ready before returning, so that
+	// callers (and any test racing with them through the ingress) resume
+	// against a live component instead of the downtime window left behind by
+	// the deletion above.
+	return wait.PollUntilContextTimeout(ctx, 2*time.Second, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
+		var current coreapi.PodList
+		if err := client.List(ctx, &current, &ctrlruntimeclient.ListOptions{LabelSelector: selector}); err != nil {
+			return false, nil
+		}
+		newPodReady := false
+		for _, pod := range current.Items {
+			if oldPodUIDs[pod.UID] {
+				return false, nil
+			}
+			if pod.DeletionTimestamp != nil {
+				continue
+			}
+			for _, cond := range pod.Status.Conditions {
+				if cond.Type == coreapi.PodReady && cond.Status == coreapi.ConditionTrue {
+					newPodReady = true
+				}
+			}
+		}
+		return newPodReady, nil
+	})
 }
 
 // RandomString generates random string of 32 characters in length, and fail if it failed


### PR DESCRIPTION
## Summary

`pull-prow-integration` intermittently fails `TestDeck` with a 504 from the ingress. Root cause: `TestRerun` restarts the single-replica deck deployment while running in parallel (to force kubelet to re-sync the updated `job-config` configmap volume), and until the replacement pod is ready, ingress-nginx answers 5xx for deck. `TestDeck` performed a single, unretried `http.Get` and lost that race.

One commit per change so any CI regression is attributable:

- **test/integration: retry TestDeck front page fetch** — `TestDeck` now polls for up to 180s, the same pattern its sibling `TestDeckTenantIDs` already uses for exactly this reason. The `<title>Prow Status</title>` assertion stays outside the poll: a served-but-wrong front page is a genuine failure, not a transient.
- **test/integration: fix nil deref in TestRerun rerun helper** — on a transport-level error, `res` is nil and `res.Body.Close()` panicked, killing the whole test binary. Transport errors are now retried like non-200 responses.
- **test/integration: wait for replacement pods in refreshProwPods** — `refreshProwPods` returned immediately after deleting pods, leaving callers to race the downtime window. It now records the deleted pods' UIDs and polls (up to 2 min) until no old pod remains and a new pod reports Ready. Also handles the previously ignored `labels.Parse` error. This lengthens how long `prowComponentsMux` is held (~10-15s for deck); both callers are long-running parallel tests with minute-scale polls, so this is absorbed.
- **test/integration: fix deck readiness probe timeout** — both deck deployments had readinessProbe `timeoutSeconds: 600` with `periodSeconds: 3`; kubelet runs probes serially per container, so one hung probe could freeze the Ready condition for 10 minutes. Now `3`; deck's `/healthz/ready` is trivial, so flapping risk is negligible.

## Out of scope / known limitations

- `prowComponentsMux` only serializes pod-deleters against each other; it cannot protect parallel readers from restarts. The TestDeck retry loop is what addresses that.
- The integration test binary runs with Go's default 10-minute `-timeout`, which is close to the suite's real runtime (`TestRerun` alone can exceed 3 minutes).

## Test plan

- [x] `go build ./test/integration/...` and `go vet ./test/integration/test/` pass; gofmt clean
- [ ] Rerun `pull-prow-integration` several times (the flake is intermittent, so individual passes are weak evidence). In runs where deck is mid-restart, `TestDeck`'s new retry `t.Logf` lines are positive evidence the retry engaged and absorbed the window.

## AI usage disclosure

This PR was created with the assistance of AI tooling (Claude Code). The author has reviewed and is responsible for all changes.