### PR TITLE
controllers: trim informer-cached ProwJobs to reduce memory consumption

### DIFF
--- a/cmd/deck/main.go
+++ b/cmd/deck/main.go
@@ -362,6 +362,10 @@ func main() {
 				DefaultNamespaces: map[string]cache.Config{
 					cfg().ProwJobNamespace: {},
 				},
+				// Deck serves cached ProwJobs close to verbatim, so it cannot
+				// use pjutil.TrimCachedProwJob. Managed fields it does strip
+				// from every response already.
+				DefaultTransform: cache.TransformStripManagedFields(),
 			},
 			Metrics: metricsserver.Options{
 				BindAddress: "0",

--- a/cmd/exporter/main.go
+++ b/cmd/exporter/main.go
@@ -96,7 +96,12 @@ func main() {
 	if err != nil {
 		logrus.WithError(err).Fatal("Failed to create prowjob client set")
 	}
-	informerFactory := prowjobinformer.NewSharedInformerFactoryWithOptions(pjClientset, 0, prowjobinformer.WithNamespace(cfg().ProwJobNamespace))
+	informerFactory := prowjobinformer.NewSharedInformerFactoryWithOptions(
+		pjClientset,
+		0,
+		prowjobinformer.WithNamespace(cfg().ProwJobNamespace),
+		prowjobinformer.WithTransform(pjutil.TrimCachedProwJob),
+	)
 	pjLister := informerFactory.Prow().V1().ProwJobs().Lister()
 
 	go informerFactory.Start(interrupts.Context().Done())

--- a/cmd/horologium/main.go
+++ b/cmd/horologium/main.go
@@ -109,6 +109,7 @@ func main() {
 		o.Cache.DefaultNamespaces = map[string]cache.Config{
 			configAgent.Config().ProwJobNamespace: {},
 		}
+		o.Cache.DefaultTransform = trimCachedProwJob
 	})
 	if err != nil {
 		logrus.WithError(err).Fatal("Failed to construct prowjob client")
@@ -148,6 +149,32 @@ func main() {
 		}
 		logrus.WithField("duration", time.Since(start)).Info("Synced periodic jobs")
 	}, tickInterval)
+}
+
+// trimCachedProwJob drops what horologium never reads off a ProwJob before it
+// enters the cache: it only needs the job name and type, the rerun label and a
+// few Status timestamps. Must stay idempotent, DeltaFIFO can hand back objects
+// that already went through it.
+func trimCachedProwJob(obj any) (any, error) {
+	pj, ok := obj.(*prowapi.ProwJob)
+	if !ok {
+		return obj, nil
+	}
+
+	pj.ManagedFields = nil
+	pj.OwnerReferences = nil
+
+	pj.Spec.PodSpec = nil
+	pj.Spec.DecorationConfig = nil
+	pj.Spec.PipelineRunSpec = nil
+	pj.Spec.TektonPipelineRunSpec = nil
+	pj.Spec.ExtraRefs = nil
+	pj.Spec.RerunAuthConfig = nil
+	pj.Spec.RerunCommand = ""
+
+	pj.Status.PrevReportStates = nil
+
+	return pj, nil
 }
 
 type cronClient interface {

--- a/cmd/horologium/main.go
+++ b/cmd/horologium/main.go
@@ -109,7 +109,7 @@ func main() {
 		o.Cache.DefaultNamespaces = map[string]cache.Config{
 			configAgent.Config().ProwJobNamespace: {},
 		}
-		o.Cache.DefaultTransform = trimCachedProwJob
+		o.Cache.DefaultTransform = pjutil.TrimCachedProwJob
 	})
 	if err != nil {
 		logrus.WithError(err).Fatal("Failed to construct prowjob client")
@@ -149,32 +149,6 @@ func main() {
 		}
 		logrus.WithField("duration", time.Since(start)).Info("Synced periodic jobs")
 	}, tickInterval)
-}
-
-// trimCachedProwJob drops what horologium never reads off a ProwJob before it
-// enters the cache: it only needs the job name and type, the rerun label and a
-// few Status timestamps. Must stay idempotent, DeltaFIFO can hand back objects
-// that already went through it.
-func trimCachedProwJob(obj any) (any, error) {
-	pj, ok := obj.(*prowapi.ProwJob)
-	if !ok {
-		return obj, nil
-	}
-
-	pj.ManagedFields = nil
-	pj.OwnerReferences = nil
-
-	pj.Spec.PodSpec = nil
-	pj.Spec.DecorationConfig = nil
-	pj.Spec.PipelineRunSpec = nil
-	pj.Spec.TektonPipelineRunSpec = nil
-	pj.Spec.ExtraRefs = nil
-	pj.Spec.RerunAuthConfig = nil
-	pj.Spec.RerunCommand = ""
-
-	pj.Status.PrevReportStates = nil
-
-	return pj, nil
 }
 
 type cronClient interface {

--- a/cmd/horologium/main_test.go
+++ b/cmd/horologium/main_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -617,5 +618,97 @@ func newCreateTrackingClient(objs []client.Object) *createTrackingClient {
 	return &createTrackingClient{
 		Client:  fakectrlruntimeclient.NewClientBuilder().WithObjects(objs...).Build(),
 		created: make([]ctrlruntimeclient.Object, 0),
+	}
+}
+
+func TestTrimCachedProwJob(t *testing.T) {
+	now := metav1.NewTime(time.Now().Truncate(time.Second))
+	full := func() *prowapi.ProwJob {
+		return &prowapi.ProwJob{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            "some-job",
+				Labels:          map[string]string{kube.ReRunLabel: "2"},
+				ManagedFields:   []metav1.ManagedFieldsEntry{{Manager: "prow"}},
+				OwnerReferences: []metav1.OwnerReference{{Name: "owner"}},
+			},
+			Spec: prowapi.ProwJobSpec{
+				Type:    prowapi.PeriodicJob,
+				Job:     "some-periodic",
+				PodSpec: &corev1.PodSpec{Containers: []corev1.Container{{Image: "img"}}},
+				DecorationConfig: &prowapi.DecorationConfig{
+					GCSConfiguration: &prowapi.GCSConfiguration{Bucket: "bucket"},
+				},
+				TektonPipelineRunSpec: &prowapi.TektonPipelineRunSpec{},
+				ExtraRefs:             []prowapi.Refs{{Org: "org"}},
+				RerunAuthConfig:       &prowapi.RerunAuthConfig{AllowAnyone: true},
+				RerunCommand:          "/test all",
+			},
+			Status: prowapi.ProwJobStatus{
+				State:            prowapi.SuccessState,
+				StartTime:        now,
+				CompletionTime:   &now,
+				PrevReportStates: map[string]prowapi.ProwJobState{"gcsk8sreporter": prowapi.SuccessState},
+			},
+		}
+	}
+
+	trimmed, err := trimCachedProwJob(full())
+	if err != nil {
+		t.Fatalf("trimCachedProwJob failed: %v", err)
+	}
+	pj, ok := trimmed.(*prowapi.ProwJob)
+	if !ok {
+		t.Fatalf("expected a *prowapi.ProwJob, got %T", trimmed)
+	}
+
+	// Kept: everything sync() and shouldTriggerFailedRun() read.
+	original := full()
+	if pj.Name != original.Name {
+		t.Errorf("name was dropped: %q", pj.Name)
+	}
+	if !reflect.DeepEqual(pj.Labels, original.Labels) {
+		t.Errorf("labels were changed: %v", pj.Labels)
+	}
+	if pj.Spec.Type != original.Spec.Type || pj.Spec.Job != original.Spec.Job {
+		t.Errorf("spec.type/spec.job were changed: %v/%v", pj.Spec.Type, pj.Spec.Job)
+	}
+	if !pj.Status.StartTime.Equal(&original.Status.StartTime) || pj.Status.CompletionTime == nil {
+		t.Error("status timestamps were dropped")
+	}
+	if pj.Status.State != original.Status.State {
+		t.Errorf("status.state was changed: %v", pj.Status.State)
+	}
+
+	// Dropped:
+	if pj.ManagedFields != nil || pj.OwnerReferences != nil {
+		t.Error("metadata was not trimmed")
+	}
+	if pj.Spec.PodSpec != nil || pj.Spec.DecorationConfig != nil || pj.Spec.TektonPipelineRunSpec != nil {
+		t.Error("spec was not trimmed")
+	}
+	if pj.Spec.ExtraRefs != nil || pj.Spec.RerunAuthConfig != nil || pj.Spec.RerunCommand != "" {
+		t.Error("spec was not trimmed")
+	}
+	if pj.Status.PrevReportStates != nil {
+		t.Error("status.prev_report_states was not trimmed")
+	}
+
+	// Must be idempotent.
+	retrimmed, err := trimCachedProwJob(pj)
+	if err != nil {
+		t.Fatalf("trimCachedProwJob failed on an already trimmed job: %v", err)
+	}
+	if !reflect.DeepEqual(retrimmed, pj) {
+		t.Error("trimCachedProwJob is not idempotent")
+	}
+
+	// Non-ProwJobs pass through.
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "some-pod"}}
+	out, err := trimCachedProwJob(pod)
+	if err != nil {
+		t.Fatalf("trimCachedProwJob failed on a pod: %v", err)
+	}
+	if !reflect.DeepEqual(out, pod) {
+		t.Error("a non-ProwJob was modified")
 	}
 }

--- a/cmd/horologium/main_test.go
+++ b/cmd/horologium/main_test.go
@@ -25,7 +25,6 @@ import (
 	"testing"
 	"time"
 
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -618,97 +617,5 @@ func newCreateTrackingClient(objs []client.Object) *createTrackingClient {
 	return &createTrackingClient{
 		Client:  fakectrlruntimeclient.NewClientBuilder().WithObjects(objs...).Build(),
 		created: make([]ctrlruntimeclient.Object, 0),
-	}
-}
-
-func TestTrimCachedProwJob(t *testing.T) {
-	now := metav1.NewTime(time.Now().Truncate(time.Second))
-	full := func() *prowapi.ProwJob {
-		return &prowapi.ProwJob{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:            "some-job",
-				Labels:          map[string]string{kube.ReRunLabel: "2"},
-				ManagedFields:   []metav1.ManagedFieldsEntry{{Manager: "prow"}},
-				OwnerReferences: []metav1.OwnerReference{{Name: "owner"}},
-			},
-			Spec: prowapi.ProwJobSpec{
-				Type:    prowapi.PeriodicJob,
-				Job:     "some-periodic",
-				PodSpec: &corev1.PodSpec{Containers: []corev1.Container{{Image: "img"}}},
-				DecorationConfig: &prowapi.DecorationConfig{
-					GCSConfiguration: &prowapi.GCSConfiguration{Bucket: "bucket"},
-				},
-				TektonPipelineRunSpec: &prowapi.TektonPipelineRunSpec{},
-				ExtraRefs:             []prowapi.Refs{{Org: "org"}},
-				RerunAuthConfig:       &prowapi.RerunAuthConfig{AllowAnyone: true},
-				RerunCommand:          "/test all",
-			},
-			Status: prowapi.ProwJobStatus{
-				State:            prowapi.SuccessState,
-				StartTime:        now,
-				CompletionTime:   &now,
-				PrevReportStates: map[string]prowapi.ProwJobState{"gcsk8sreporter": prowapi.SuccessState},
-			},
-		}
-	}
-
-	trimmed, err := trimCachedProwJob(full())
-	if err != nil {
-		t.Fatalf("trimCachedProwJob failed: %v", err)
-	}
-	pj, ok := trimmed.(*prowapi.ProwJob)
-	if !ok {
-		t.Fatalf("expected a *prowapi.ProwJob, got %T", trimmed)
-	}
-
-	// Kept: everything sync() and shouldTriggerFailedRun() read.
-	original := full()
-	if pj.Name != original.Name {
-		t.Errorf("name was dropped: %q", pj.Name)
-	}
-	if !reflect.DeepEqual(pj.Labels, original.Labels) {
-		t.Errorf("labels were changed: %v", pj.Labels)
-	}
-	if pj.Spec.Type != original.Spec.Type || pj.Spec.Job != original.Spec.Job {
-		t.Errorf("spec.type/spec.job were changed: %v/%v", pj.Spec.Type, pj.Spec.Job)
-	}
-	if !pj.Status.StartTime.Equal(&original.Status.StartTime) || pj.Status.CompletionTime == nil {
-		t.Error("status timestamps were dropped")
-	}
-	if pj.Status.State != original.Status.State {
-		t.Errorf("status.state was changed: %v", pj.Status.State)
-	}
-
-	// Dropped:
-	if pj.ManagedFields != nil || pj.OwnerReferences != nil {
-		t.Error("metadata was not trimmed")
-	}
-	if pj.Spec.PodSpec != nil || pj.Spec.DecorationConfig != nil || pj.Spec.TektonPipelineRunSpec != nil {
-		t.Error("spec was not trimmed")
-	}
-	if pj.Spec.ExtraRefs != nil || pj.Spec.RerunAuthConfig != nil || pj.Spec.RerunCommand != "" {
-		t.Error("spec was not trimmed")
-	}
-	if pj.Status.PrevReportStates != nil {
-		t.Error("status.prev_report_states was not trimmed")
-	}
-
-	// Must be idempotent.
-	retrimmed, err := trimCachedProwJob(pj)
-	if err != nil {
-		t.Fatalf("trimCachedProwJob failed on an already trimmed job: %v", err)
-	}
-	if !reflect.DeepEqual(retrimmed, pj) {
-		t.Error("trimCachedProwJob is not idempotent")
-	}
-
-	// Non-ProwJobs pass through.
-	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "some-pod"}}
-	out, err := trimCachedProwJob(pod)
-	if err != nil {
-		t.Fatalf("trimCachedProwJob failed on a pod: %v", err)
-	}
-	if !reflect.DeepEqual(out, pod) {
-		t.Error("a non-ProwJob was modified")
 	}
 }

--- a/cmd/sinker/main.go
+++ b/cmd/sinker/main.go
@@ -37,6 +37,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/cluster"
 	ctrlruntimelog "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -144,6 +145,7 @@ func main() {
 			DefaultNamespaces: map[string]cache.Config{
 				cfg().ProwJobNamespace: {},
 			},
+			DefaultTransform: pjutil.TrimCachedProwJob,
 		},
 		Metrics: metricsserver.Options{
 			BindAddress: "0",
@@ -182,6 +184,9 @@ func main() {
 		// binary if a build cluster can be connected later .
 		callBack,
 		cfg().PodNamespace,
+		func(o *cluster.Options) {
+			o.Cache.DefaultTransform = pjutil.TrimCachedPod
+		},
 	)
 	if err != nil {
 		logrus.WithError(err).Error("Failed to construct build clusters. Is there a bad entry in the kubeconfig secret?")

--- a/cmd/sinker/main_test.go
+++ b/cmd/sinker/main_test.go
@@ -41,9 +41,11 @@ import (
 
 	prowv1 "sigs.k8s.io/prow/pkg/apis/prowjobs/v1"
 	"sigs.k8s.io/prow/pkg/config"
+	kubernetesreporterapi "sigs.k8s.io/prow/pkg/crier/reporters/gcs/kubernetes/api"
 	"sigs.k8s.io/prow/pkg/flagutil"
 	configflagutil "sigs.k8s.io/prow/pkg/flagutil/config"
 	"sigs.k8s.io/prow/pkg/kube"
+	"sigs.k8s.io/prow/pkg/pjutil"
 )
 
 const (
@@ -1124,5 +1126,68 @@ func TestGetConfigMapDirs(t *testing.T) {
 
 	if diff := cmp.Diff(dirs, expectedToplevelOnly); diff != "" {
 		t.Fatal(diff)
+	}
+}
+
+func fullCachedPod() *corev1api.Pod {
+	// Fixed times: the fake client round-trips through JSON, truncating to seconds.
+	created := metav1.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	started := metav1.Date(2024, 1, 1, 0, 1, 0, 0, time.UTC)
+	return &corev1api.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "some-pod",
+			Namespace:         "ns",
+			CreationTimestamp: created,
+			Labels: map[string]string{
+				kube.CreatedByProw:  "true",
+				kube.ProwJobIDLabel: "some-job",
+			},
+			Finalizers:      []string{kubernetesreporterapi.FinalizerName},
+			ManagedFields:   []metav1.ManagedFieldsEntry{{Manager: "plank"}},
+			OwnerReferences: []metav1.OwnerReference{{Name: "owner"}},
+		},
+		Spec: corev1api.PodSpec{
+			Containers: []corev1api.Container{{Name: "test", Image: "img"}},
+		},
+		Status: corev1api.PodStatus{
+			Phase:             corev1api.PodSucceeded,
+			StartTime:         &started,
+			ContainerStatuses: []corev1api.ContainerStatus{{Name: "test"}},
+		},
+	}
+}
+
+// TestCleanupKubernetesFinalizerOnTrimmedPod verifies that patching a pod from a
+// trimmed cache does not wipe the dropped fields: the MergeFrom patch is
+// computed between two trimmed copies.
+func TestCleanupKubernetesFinalizerOnTrimmedPod(t *testing.T) {
+	stored := fullCachedPod()
+	// The fake client rejects managed fields without an operation.
+	stored.ManagedFields = nil
+	client := fakectrlruntimeclient.NewClientBuilder().WithRuntimeObjects(stored).Build()
+
+	trimmed, err := pjutil.TrimCachedPod(fullCachedPod())
+	if err != nil {
+		t.Fatalf("pjutil.TrimCachedPod failed: %v", err)
+	}
+
+	c := &controller{ctx: context.Background()}
+	if err := c.cleanupKubernetesFinalizer(trimmed.(*corev1api.Pod), client); err != nil {
+		t.Fatalf("cleanupKubernetesFinalizer failed: %v", err)
+	}
+
+	var got corev1api.Pod
+	name := types.NamespacedName{Namespace: stored.Namespace, Name: stored.Name}
+	if err := client.Get(context.Background(), name, &got); err != nil {
+		t.Fatalf("failed to get pod: %v", err)
+	}
+	if len(got.Finalizers) != 0 {
+		t.Errorf("finalizer was not removed: %v", got.Finalizers)
+	}
+	if diff := cmp.Diff(stored.Spec, got.Spec); diff != "" {
+		t.Errorf("patch clobbered the pod spec: %s", diff)
+	}
+	if diff := cmp.Diff(stored.Status, got.Status); diff != "" {
+		t.Errorf("patch clobbered the pod status: %s", diff)
 	}
 }

--- a/cmd/tide/main.go
+++ b/cmd/tide/main.go
@@ -39,6 +39,7 @@ import (
 	"sigs.k8s.io/prow/pkg/interrupts"
 	"sigs.k8s.io/prow/pkg/logrusutil"
 	"sigs.k8s.io/prow/pkg/metrics"
+	"sigs.k8s.io/prow/pkg/pjutil"
 	"sigs.k8s.io/prow/pkg/tide"
 )
 
@@ -163,6 +164,7 @@ func main() {
 			DefaultNamespaces: map[string]cache.Config{
 				cfg().ProwJobNamespace: {},
 			},
+			DefaultTransform: pjutil.TrimCachedProwJob,
 		},
 		Metrics: metricsserver.Options{
 			BindAddress: "0",

--- a/pkg/pjutil/cachetransform.go
+++ b/pkg/pjutil/cachetransform.go
@@ -1,0 +1,69 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pjutil
+
+import (
+	corev1 "k8s.io/api/core/v1"
+
+	prowapi "sigs.k8s.io/prow/pkg/apis/prowjobs/v1"
+)
+
+// The transforms below are for informer caches of components that only observe
+// ProwJobs and their pods. They keep the union of what those components read,
+// so that adopting one does not need a bespoke field set, and they must stay
+// idempotent: DeltaFIFO can hand back objects that already went through them.
+// Do not use them where a cached object is read, modified and written back.
+
+// TrimCachedProwJob drops the parts of a ProwJob that describe what it runs:
+// the pod and pipeline run specs, the decoration config and the rerun
+// configuration. ExtraRefs is kept, the exporter builds metric labels out of
+// it. Objects that are not ProwJobs pass through untouched.
+func TrimCachedProwJob(obj any) (any, error) {
+	pj, ok := obj.(*prowapi.ProwJob)
+	if !ok {
+		return obj, nil
+	}
+
+	pj.ManagedFields = nil
+	pj.OwnerReferences = nil
+
+	pj.Spec.PodSpec = nil
+	pj.Spec.DecorationConfig = nil
+	pj.Spec.PipelineRunSpec = nil
+	pj.Spec.TektonPipelineRunSpec = nil
+	pj.Spec.RerunAuthConfig = nil
+	pj.Spec.RerunCommand = ""
+
+	return pj, nil
+}
+
+// TrimCachedPod drops everything but the metadata and Status.StartTime of a
+// prow-created pod. Labels are kept, such pods are listed out of caches with a
+// label selector. Objects that are not pods pass through untouched.
+func TrimCachedPod(obj any) (any, error) {
+	pod, ok := obj.(*corev1.Pod)
+	if !ok {
+		return obj, nil
+	}
+
+	pod.ManagedFields = nil
+	pod.OwnerReferences = nil
+	pod.Spec = corev1.PodSpec{}
+	pod.Status = corev1.PodStatus{StartTime: pod.Status.StartTime}
+
+	return pod, nil
+}

--- a/pkg/pjutil/cachetransform_test.go
+++ b/pkg/pjutil/cachetransform_test.go
@@ -1,0 +1,210 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pjutil
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	prowapi "sigs.k8s.io/prow/pkg/apis/prowjobs/v1"
+	"sigs.k8s.io/prow/pkg/kube"
+)
+
+func fullProwJob() *prowapi.ProwJob {
+	started := metav1.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	completed := metav1.Date(2024, 1, 1, 0, 10, 0, 0, time.UTC)
+	return &prowapi.ProwJob{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "some-job",
+			Namespace:       "ns",
+			Labels:          map[string]string{kube.ReRunLabel: "2"},
+			ManagedFields:   []metav1.ManagedFieldsEntry{{Manager: "prow"}},
+			OwnerReferences: []metav1.OwnerReference{{Name: "owner"}},
+		},
+		Spec: prowapi.ProwJobSpec{
+			Type:    prowapi.PeriodicJob,
+			Job:     "some-periodic",
+			Context: "some-context",
+			PodSpec: &corev1.PodSpec{Containers: []corev1.Container{{Image: "img"}}},
+			DecorationConfig: &prowapi.DecorationConfig{
+				GCSConfiguration: &prowapi.GCSConfiguration{Bucket: "bucket"},
+			},
+			TektonPipelineRunSpec: &prowapi.TektonPipelineRunSpec{},
+			ExtraRefs:             []prowapi.Refs{{Org: "org"}},
+			RerunAuthConfig:       &prowapi.RerunAuthConfig{AllowAnyone: true},
+			RerunCommand:          "/test all",
+		},
+		Status: prowapi.ProwJobStatus{
+			State:            prowapi.SuccessState,
+			StartTime:        started,
+			CompletionTime:   &completed,
+			BuildID:          "12345",
+			PrevReportStates: map[string]prowapi.ProwJobState{"gcsk8sreporter": prowapi.SuccessState},
+		},
+	}
+}
+
+func fullPod() *corev1.Pod {
+	// Fixed times: fake clients round-trip pods through JSON, truncating to seconds.
+	created := metav1.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	started := metav1.Date(2024, 1, 1, 0, 1, 0, 0, time.UTC)
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "some-pod",
+			Namespace:         "ns",
+			CreationTimestamp: created,
+			Labels: map[string]string{
+				kube.CreatedByProw:  "true",
+				kube.ProwJobIDLabel: "some-job",
+			},
+			Finalizers:      []string{"prow.x-k8s.io/gcsk8sreporter"},
+			ManagedFields:   []metav1.ManagedFieldsEntry{{Manager: "plank"}},
+			OwnerReferences: []metav1.OwnerReference{{Name: "owner"}},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{Name: "test", Image: "img"}},
+		},
+		Status: corev1.PodStatus{
+			Phase:             corev1.PodSucceeded,
+			StartTime:         &started,
+			ContainerStatuses: []corev1.ContainerStatus{{Name: "test"}},
+		},
+	}
+}
+
+func TestTrimCachedProwJob(t *testing.T) {
+	trimmed, err := TrimCachedProwJob(fullProwJob())
+	if err != nil {
+		t.Fatalf("TrimCachedProwJob failed: %v", err)
+	}
+	pj, ok := trimmed.(*prowapi.ProwJob)
+	if !ok {
+		t.Fatalf("expected a *prowapi.ProwJob, got %T", trimmed)
+	}
+
+	// Kept:
+	original := fullProwJob()
+	if pj.Name != original.Name || pj.Namespace != original.Namespace {
+		t.Errorf("identity was changed: %s/%s", pj.Namespace, pj.Name)
+	}
+	if diff := cmp.Diff(original.Labels, pj.Labels); diff != "" {
+		t.Errorf("labels were changed: %s", diff)
+	}
+	if diff := cmp.Diff(original.Status, pj.Status); diff != "" {
+		t.Errorf("status was changed: %s", diff)
+	}
+	if pj.Spec.Type != original.Spec.Type || pj.Spec.Job != original.Spec.Job || pj.Spec.Context != original.Spec.Context {
+		t.Errorf("the job identity in the spec was changed: %+v", pj.Spec)
+	}
+	// The exporter needs these for metric labels.
+	if diff := cmp.Diff(original.Spec.ExtraRefs, pj.Spec.ExtraRefs); diff != "" {
+		t.Errorf("extra refs were changed: %s", diff)
+	}
+
+	// Dropped:
+	if pj.ManagedFields != nil || pj.OwnerReferences != nil {
+		t.Error("metadata was not trimmed")
+	}
+	if pj.Spec.PodSpec != nil || pj.Spec.DecorationConfig != nil || pj.Spec.TektonPipelineRunSpec != nil {
+		t.Error("spec was not trimmed")
+	}
+	if pj.Spec.RerunAuthConfig != nil || pj.Spec.RerunCommand != "" {
+		t.Error("spec was not trimmed")
+	}
+
+	// Must be idempotent.
+	retrimmed, err := TrimCachedProwJob(pj)
+	if err != nil {
+		t.Fatalf("TrimCachedProwJob failed on an already trimmed job: %v", err)
+	}
+	if diff := cmp.Diff(pj, retrimmed); diff != "" {
+		t.Errorf("TrimCachedProwJob is not idempotent: %s", diff)
+	}
+
+	// Non-ProwJobs pass through.
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "some-pod"}}
+	out, err := TrimCachedProwJob(pod)
+	if err != nil {
+		t.Fatalf("TrimCachedProwJob failed on a pod: %v", err)
+	}
+	if diff := cmp.Diff(pod, out); diff != "" {
+		t.Errorf("a non-ProwJob was modified: %s", diff)
+	}
+}
+
+func TestTrimCachedPod(t *testing.T) {
+	trimmed, err := TrimCachedPod(fullPod())
+	if err != nil {
+		t.Fatalf("TrimCachedPod failed: %v", err)
+	}
+	pod, ok := trimmed.(*corev1.Pod)
+	if !ok {
+		t.Fatalf("expected a *corev1.Pod, got %T", trimmed)
+	}
+
+	// Kept:
+	original := fullPod()
+	if pod.Name != original.Name || pod.Namespace != original.Namespace {
+		t.Errorf("identity was changed: %s/%s", pod.Namespace, pod.Name)
+	}
+	if diff := cmp.Diff(original.Labels, pod.Labels); diff != "" {
+		t.Errorf("labels were changed: %s", diff)
+	}
+	if diff := cmp.Diff(original.Finalizers, pod.Finalizers); diff != "" {
+		t.Errorf("finalizers were changed: %s", diff)
+	}
+	if !pod.CreationTimestamp.Equal(&original.CreationTimestamp) {
+		t.Error("creation timestamp was dropped")
+	}
+	if pod.Status.StartTime == nil || !pod.Status.StartTime.Equal(original.Status.StartTime) {
+		t.Error("status.startTime was dropped")
+	}
+
+	// Dropped:
+	if pod.ManagedFields != nil || pod.OwnerReferences != nil {
+		t.Error("metadata was not trimmed")
+	}
+	if diff := cmp.Diff(corev1.PodSpec{}, pod.Spec); diff != "" {
+		t.Errorf("spec was not trimmed: %s", diff)
+	}
+	if pod.Status.Phase != "" || pod.Status.ContainerStatuses != nil {
+		t.Error("status was not trimmed")
+	}
+
+	// Must be idempotent.
+	retrimmed, err := TrimCachedPod(pod)
+	if err != nil {
+		t.Fatalf("TrimCachedPod failed on an already trimmed pod: %v", err)
+	}
+	if diff := cmp.Diff(pod, retrimmed); diff != "" {
+		t.Errorf("TrimCachedPod is not idempotent: %s", diff)
+	}
+
+	// Non-pods pass through.
+	pj := &prowapi.ProwJob{ObjectMeta: metav1.ObjectMeta{Name: "some-job"}}
+	out, err := TrimCachedPod(pj)
+	if err != nil {
+		t.Fatalf("TrimCachedPod failed on a prowjob: %v", err)
+	}
+	if diff := cmp.Diff(pj, out); diff != "" {
+		t.Errorf("a non-pod was modified: %s", diff)
+	}
+}

--- a/pkg/tide/cachetransform_test.go
+++ b/pkg/tide/cachetransform_test.go
@@ -1,0 +1,91 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tide
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	corev1 "k8s.io/api/core/v1"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	prowapi "sigs.k8s.io/prow/pkg/apis/prowjobs/v1"
+	"sigs.k8s.io/prow/pkg/pjutil"
+)
+
+// TestIndexFuncsToleratePrunedProwJobs verifies that the cache indexes tide
+// registers still work on ProwJobs that went through pjutil.TrimCachedProwJob,
+// which is set as the transform on tide's cache: the index funcs run on the
+// trimmed objects, not on what the API server returned.
+func TestIndexFuncsToleratePrunedProwJobs(t *testing.T) {
+	pulls := []prowapi.Pull{{Number: 1, SHA: "pull-sha"}}
+	full := func() *prowapi.ProwJob {
+		pj := getProwJob(prowapi.BatchJob, "org", "repo", "master", "base-sha", prowapi.SuccessState, pulls)
+		pj.Name = "some-job"
+		pj.Spec.Job = "some-batch-job"
+		pj.Spec.Context = "some-context"
+		pj.Spec.PodSpec = &corev1.PodSpec{Containers: []corev1.Container{{Image: "img"}}}
+		pj.Spec.DecorationConfig = &prowapi.DecorationConfig{
+			GCSConfiguration: &prowapi.GCSConfiguration{Bucket: "bucket"},
+		}
+		pj.Spec.ExtraRefs = []prowapi.Refs{{Org: "other-org"}}
+		pj.Spec.RerunCommand = "/test all"
+		return pj
+	}
+
+	trimmed, err := pjutil.TrimCachedProwJob(full())
+	if err != nil {
+		t.Fatalf("pjutil.TrimCachedProwJob failed: %v", err)
+	}
+	pj, ok := trimmed.(*prowapi.ProwJob)
+	if !ok {
+		t.Fatalf("expected a *prowapi.ProwJob, got %T", trimmed)
+	}
+
+	// Nothing the sync loop reads may be gone.
+	if pj.Spec.PodSpec != nil {
+		t.Error("expected the podspec to be trimmed away")
+	}
+	if diff := cmp.Diff(full().Spec.Refs, pj.Spec.Refs); diff != "" {
+		t.Errorf("refs were changed: %s", diff)
+	}
+	if pj.Spec.Job != full().Spec.Job || pj.Spec.Context != full().Spec.Context {
+		t.Errorf("the job identity was changed: %+v", pj.Spec)
+	}
+	if pj.Status.State != full().Status.State {
+		t.Errorf("state was changed: %v", pj.Status.State)
+	}
+
+	for _, tc := range []struct {
+		name      string
+		indexFunc func(ctrlruntimeclient.Object) []string
+	}{
+		{name: cacheIndexName, indexFunc: cacheIndexFunc},
+		{name: nonFailedBatchByNameBaseAndPullsIndexName, indexFunc: nonFailedBatchByNameBaseAndPullsIndexFunc},
+		{name: indexNamePassingJobs, indexFunc: indexFuncPassingJobs},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			expected := tc.indexFunc(full())
+			if len(expected) == 0 {
+				t.Fatal("the untrimmed prowjob yields no index keys, the fixture is not exercising this index")
+			}
+			if diff := cmp.Diff(expected, tc.indexFunc(pj)); diff != "" {
+				t.Errorf("trimming the prowjob changed the index keys: %s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
A cluster typically has many ProwJobs and they are large resources, a big part of which is the embedded payload PodSpec (but also other fields). Some controllers (horologium, sinker, tide, exporter and deck) set up an informer to be able to read various state from existing ProwJobs, but do not need the full resources to be present.

Informer caches accept a transform function that runs on every object on its way in, and what it returns is what the cache stores. Each controller above (notably NOT prow-cm (plank) and crier now sets one that nils out the fields it never reads — the PodSpec above all, but also the decoration config, the pipeline run specs and the rerun configuration — shared in pjutil. Deck is the exception: it serves cached ProwJobs almost verbatim, so only trim managed fields there.

Assisted by Claude Code