### PR TITLE
entrypoint: de-flake interrupt tests and fix SIGKILL-path data race

### DIFF
--- a/pkg/entrypoint/run.go
+++ b/pkg/entrypoint/run.go
@@ -60,6 +60,12 @@ const (
 	// DefaultGracePeriod is the default timeout for the test
 	// process after SIGINT is sent before SIGKILL is sent
 	DefaultGracePeriod = 15 * time.Second
+
+	// sigkillDrainTimeout bounds how long we wait for Wait to return
+	// after SIGKILL. Death and reap of the killed process are
+	// near-instant; if this expires, an orphaned descendant is holding
+	// the log pipe open and Wait may block arbitrarily long.
+	sigkillDrainTimeout = 1 * time.Second
 )
 
 var (
@@ -157,23 +163,26 @@ func (o Options) ExecuteProcess(signaledInterrupt chan os.Signal) (int, error) {
 	timeout := optionOrDefault(o.Timeout, DefaultTimeout)
 	gracePeriod := optionOrDefault(o.GracePeriod, DefaultGracePeriod)
 	var commandErr error
-	cancelled, aborted := false, false
-	done := make(chan error)
+	cancelled, aborted, exited := false, false, false
+	// buffered so the Wait goroutine can always complete its send and
+	// never leaks if we stop receiving after the grace period expires
+	done := make(chan error, 1)
 	go func() {
 		done <- command.Wait()
 	}()
 	select {
 	case err := <-done:
 		commandErr = err
+		exited = true
 	case <-time.After(timeout):
 		logrus.Errorf("Process did not finish before %s timeout", timeout)
 		cancelled = true
-		gracefullyTerminate(command, done, gracePeriod, nil)
+		exited = gracefullyTerminate(command, done, gracePeriod, nil)
 	case s := <-interrupt:
 		logrus.Errorf("Entrypoint received interrupt: %v", s)
 		cancelled = true
 		aborted = true
-		gracefullyTerminate(command, done, gracePeriod, &s)
+		exited = gracefullyTerminate(command, done, gracePeriod, &s)
 	}
 
 	var returnCode int
@@ -181,14 +190,14 @@ func (o Options) ExecuteProcess(signaledInterrupt chan os.Signal) (int, error) {
 		if aborted {
 			commandErr = errAborted
 			if o.PropagateErrorCode {
-				returnCode = command.ProcessState.ExitCode()
+				returnCode = propagatedExitCode(command, exited)
 			} else {
 				returnCode = AbortedErrorCode
 			}
 		} else {
 			commandErr = errTimedOut
 			if o.PropagateErrorCode {
-				returnCode = command.ProcessState.ExitCode()
+				returnCode = propagatedExitCode(command, exited)
 			} else {
 				returnCode = InternalErrorCode
 			}
@@ -250,7 +259,22 @@ func optionOrDefault(option, defaultValue time.Duration) time.Duration {
 	return option
 }
 
-func gracefullyTerminate(command *exec.Cmd, done <-chan error, gracePeriod time.Duration, signal *os.Signal) {
+// propagatedExitCode returns the exit code to propagate for a cancelled
+// process. Only a receive from done (exited) synchronizes with the Wait
+// goroutine's write to ProcessState; without it the read would be a data
+// race, so report -1 directly — the same value ExitCode() yields for a
+// signal-killed process.
+func propagatedExitCode(command *exec.Cmd, exited bool) int {
+	if !exited {
+		return -1
+	}
+	return command.ProcessState.ExitCode()
+}
+
+// gracefullyTerminate interrupts the process and waits for it to exit,
+// killing it once the grace period expires. It returns true iff it received
+// the Wait result, meaning command.ProcessState is safe to read.
+func gracefullyTerminate(command *exec.Cmd, done <-chan error, gracePeriod time.Duration, signal *os.Signal) bool {
 	if err := command.Process.Signal(os.Interrupt); err != nil {
 		logrus.WithError(err).Error("Could not interrupt process after timeout")
 	}
@@ -263,10 +287,21 @@ func gracefullyTerminate(command *exec.Cmd, done <-chan error, gracePeriod time.
 	case <-done:
 		logrus.Errorf("Process gracefully exited before %s grace period", gracePeriod)
 		// but we ignore the output error as we will want errTimedOut
+		return true
 	case <-time.After(gracePeriod):
 		logrus.Errorf("Process did not exit before %s grace period", gracePeriod)
 		if err := command.Process.Kill(); err != nil {
 			logrus.WithError(err).Error("Could not kill process after grace period")
+		}
+		// Wait also waits for the stdout/stderr copy goroutines, which
+		// only finish once every process holding the pipe has exited, so
+		// even after SIGKILL it may not return promptly.
+		select {
+		case <-done:
+			return true
+		case <-time.After(sigkillDrainTimeout):
+			logrus.Error("Process did not terminate after SIGKILL; a child process may be holding the log pipe open")
+			return false
 		}
 	}
 }

--- a/pkg/entrypoint/run_test.go
+++ b/pkg/entrypoint/run_test.go
@@ -137,18 +137,15 @@ func TestOptions_Run(t *testing.T) {
 			name:      "interrupt, propagate child error",
 			interrupt: true,
 			propagate: true,
-			args: []string{"bash", "-c", `function cleanup() {
-CHILDREN=$(jobs -p)
-if test -n "${CHILDREN}"
-then
-kill ${CHILDREN} && wait
-fi
-exit 3
-}
-trap cleanup SIGINT SIGTERM EXIT
+			// entrypoint sends SIGINT *and* the signal it received, so this
+			// trap can fire more than once. Keep the handler trivial and keep
+			// the process free of background children: a backgrounded job
+			// inherits the stdout/stderr pipe, and if it outlives the shell
+			// the pipe never reaches EOF, so exec.Cmd.Wait blocks for the
+			// whole grace period. Neither of those is what these cases test.
+			args: []string{"bash", "-c", `trap "exit 3" SIGINT SIGTERM
 echo process started
-sleep 9999 &
-wait`},
+while true; do sleep 0.1; done`},
 			expectedLog:    "process started\nlevel=error msg=\"Entrypoint received interrupt: terminated\"\nlevel=error msg=\"Process gracefully exited before 15s grace period\"\n",
 			expectedMarker: "3",
 			expectedCode:   3,
@@ -156,18 +153,15 @@ wait`},
 		{
 			name:      "interrupt, do not propagate child error",
 			interrupt: true,
-			args: []string{"bash", "-c", `function cleanup() {
-CHILDREN=$(jobs -p)
-if test -n "${CHILDREN}"
-then
-kill ${CHILDREN} && wait
-fi
-exit 3
-}
-trap cleanup SIGINT SIGTERM EXIT
+			// entrypoint sends SIGINT *and* the signal it received, so this
+			// trap can fire more than once. Keep the handler trivial and keep
+			// the process free of background children: a backgrounded job
+			// inherits the stdout/stderr pipe, and if it outlives the shell
+			// the pipe never reaches EOF, so exec.Cmd.Wait blocks for the
+			// whole grace period. Neither of those is what these cases test.
+			args: []string{"bash", "-c", `trap "exit 3" SIGINT SIGTERM
 echo process started
-sleep 9999 &
-wait`},
+while true; do sleep 0.1; done`},
 			expectedLog:    "process started\nlevel=error msg=\"Entrypoint received interrupt: terminated\"\nlevel=error msg=\"Process gracefully exited before 15s grace period\"\n",
 			expectedMarker: "130",
 			expectedCode:   130,
@@ -262,12 +256,77 @@ func waitForFileToBeWritten(ctx context.Context, file string) error {
 	for {
 		select {
 		case <-ticker.C:
-			fileInfo, _ := os.Stat(file)
-			if fileInfo.Size() != 0 {
+			fileInfo, err := os.Stat(file)
+			if err == nil && fileInfo.Size() != 0 {
 				return nil
 			}
 		case <-ctx.Done():
 			return fmt.Errorf("cancelled while waiting for file %s to exist", file)
 		}
+	}
+}
+
+// TestExecuteProcess_SignalForwarding pins the contract established in
+// "entrypoint: forward the signal we were sent": on the abort path the wrapped
+// process is sent an unconditional SIGINT *and* the signal entrypoint itself
+// received. Wrapped jobs still rely on the SIGINT for backwards compatibility.
+//
+// Each case ignores one of the two signals, so exiting cleanly proves the other
+// one was actually delivered; if it was not, the process keeps running until
+// the grace period expires and is SIGKILLed instead.
+func TestExecuteProcess_SignalForwarding(t *testing.T) {
+	var testCases = []struct {
+		name   string
+		script string
+	}{
+		{
+			name: "unconditional SIGINT is delivered",
+			script: `trap "" SIGTERM
+trap "exit 3" SIGINT
+echo process started
+while true; do sleep 0.1; done`,
+		},
+		{
+			name: "received SIGTERM is forwarded",
+			script: `trap "" SIGINT
+trap "exit 3" SIGTERM
+echo process started
+while true; do sleep 0.1; done`,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			options := Options{
+				// propagate so that a SIGKILLed process is distinguishable
+				// from one that handled the signal and exited 3
+				PropagateErrorCode: true,
+				// keep this short so a regression fails fast instead of
+				// waiting out DefaultGracePeriod
+				GracePeriod: 2 * time.Second,
+				Options: &wrapper.Options{
+					Args:       []string{"bash", "-c", testCase.script},
+					ProcessLog: path.Join(tmpDir, "process-log.txt"),
+					MarkerFile: path.Join(tmpDir, "marker-file.txt"),
+				},
+			}
+
+			interrupt := make(chan os.Signal, 1)
+			go func() {
+				ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+				defer cancel()
+				// sync with ExecuteProcess func to ensure that process has already started
+				if err := waitForFileToBeWritten(ctx, options.ProcessLog); err != nil {
+					t.Errorf("failed to wait for file: %v", err)
+				}
+				time.Sleep(200 * time.Millisecond)
+				interrupt <- syscall.SIGTERM
+			}()
+
+			if code := options.internalRun(interrupt); code != 3 {
+				t.Errorf("%s: expected the wrapped process to handle the signal and exit 3, got %d", testCase.name, code)
+			}
+		})
 	}
 }

--- a/pkg/entrypoint/run_test.go
+++ b/pkg/entrypoint/run_test.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"path"
 	"strconv"
+	"strings"
 	"syscall"
 	"testing"
 	"time"
@@ -87,7 +88,7 @@ func TestOptions_Run(t *testing.T) {
 			args:           []string{"bash", "-c", "trap 'sleep 10' EXIT; sleep 10"},
 			timeout:        1 * time.Second,
 			gracePeriod:    1 * time.Second,
-			expectedLog:    "level=error msg=\"Process did not finish before 1s timeout\"\nlevel=error msg=\"Process did not exit before 1s grace period\"\n",
+			expectedLog:    "level=error msg=\"Process did not finish before 1s timeout\"\nlevel=error msg=\"Process did not exit before 1s grace period\"\nlevel=error msg=\"Process did not terminate after SIGKILL; a child process may be holding the log pipe open\"\n",
 			expectedMarker: strconv.Itoa(InternalErrorCode),
 			expectedCode:   InternalErrorCode,
 		},
@@ -326,6 +327,80 @@ while true; do sleep 0.1; done`,
 
 			if code := options.internalRun(interrupt); code != 3 {
 				t.Errorf("%s: expected the wrapped process to handle the signal and exit 3, got %d", testCase.name, code)
+			}
+		})
+	}
+}
+
+// TestExecuteProcess_KillPath covers the abort path where the wrapped process
+// ignores every signal, survives the grace period, and is SIGKILLed. With
+// PropagateErrorCode set, the propagated code must deterministically be -1 —
+// what ExitCode() reports for a signal-killed process — whether or not the
+// post-kill Wait completed before the marker was written.
+func TestExecuteProcess_KillPath(t *testing.T) {
+	var testCases = []struct {
+		name        string
+		script      string
+		expectedLog string
+	}{
+		{
+			// The only pipe holder besides the shell is a <=0.1s sleep, so
+			// Wait returns promptly after the kill and the drain succeeds.
+			name: "kill path propagates a deterministic code",
+			script: `trap "" SIGINT SIGTERM
+echo process started
+while true; do sleep 0.1; done`,
+		},
+		{
+			// The backgrounded sleep inherits the log pipe and outlives the
+			// SIGKILL, so Wait cannot return before the drain gives up.
+			name: "kill path when a child holds the log pipe",
+			script: `trap "" SIGINT SIGTERM
+sleep 3 &
+echo process started
+while true; do sleep 0.1; done`,
+			expectedLog: "Process did not terminate after SIGKILL",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			options := Options{
+				PropagateErrorCode: true,
+				GracePeriod:        1 * time.Second,
+				Options: &wrapper.Options{
+					Args:       []string{"bash", "-c", testCase.script},
+					ProcessLog: path.Join(tmpDir, "process-log.txt"),
+					MarkerFile: path.Join(tmpDir, "marker-file.txt"),
+				},
+			}
+
+			interrupt := make(chan os.Signal, 1)
+			go func() {
+				ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+				defer cancel()
+				// sync with ExecuteProcess func to ensure that process has already started
+				if err := waitForFileToBeWritten(ctx, options.ProcessLog); err != nil {
+					t.Errorf("failed to wait for file: %v", err)
+				}
+				time.Sleep(200 * time.Millisecond)
+				interrupt <- syscall.SIGTERM
+			}()
+
+			if code := options.internalRun(interrupt); code != -1 {
+				t.Errorf("%s: expected the SIGKILLed process to propagate -1, got %d", testCase.name, code)
+			}
+			compareFileContents(testCase.name, options.MarkerFile, "-1", t)
+
+			if testCase.expectedLog != "" {
+				data, err := os.ReadFile(options.ProcessLog)
+				if err != nil {
+					t.Fatalf("%s: could not read process log: %v", testCase.name, err)
+				}
+				if !strings.Contains(string(data), testCase.expectedLog) {
+					t.Errorf("%s: expected process log to contain %q, got %q", testCase.name, testCase.expectedLog, data)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind flake

#### What this PR does / why we need it:

`TestOptions_Run/interrupt,{propagate,do_not_propagate}_child_error` fail intermittently — roughly 3% with `-count=100` on `main`. Chasing that flake turned up a real data race on the SIGKILL path, so this PR fixes both, one per commit.

**1. `entrypoint: de-flake the interrupt tests`**

The most visible symptom is a stray `kill: (<pid>) - No such process` line in the process log, which the tests match byte-for-byte. On the abort path `gracefullyTerminate` sends the wrapped process an unconditional `SIGINT` and then the signal entrypoint itself received. The fixtures trapped `SIGINT`, `SIGTERM` and `EXIT` with the same cleanup function, so it ran more than once per abort, and the two signals arrive close enough together that a later pass can kill a job `jobs(1)` still lists but that has already been reaped.

The same fixtures fail a second, rarer way: the backgrounded `sleep` inherits the stdout/stderr pipe, and if it outlives the shell that pipe never reaches EOF, so `exec.Cmd.Wait` blocks for the whole grace period.

Neither the background job nor the cleanup bookkeeping is what these cases exercise, so both are dropped in favour of a fixture that just traps the signal and exits. Expected logs, markers and exit codes are unchanged.

Also adds `TestExecuteProcess_SignalForwarding`, pinning the "forward the signal we were sent" contract that makes a trap handler run twice in the first place and was otherwise untested, and stops `waitForFileToBeWritten` from discarding the `os.Stat` error it then dereferences.

**2. `entrypoint: fix ProcessState data race on the SIGKILL path`**

A goroutine runs `done <- command.Wait()`, and `Wait` writes `command.ProcessState`. On the graceful path `gracefullyTerminate` receives from `done` before returning, which synchronizes the later `ProcessState` reads. On the grace-period-expired path it calls `Process.Kill()` and returns immediately, so with `propagate_error_code` set `ExecuteProcess` reads `command.ProcessState.ExitCode()` concurrently with `Wait` writing it — a data race the detector flags reliably once a test drives a process into the kill path. The propagated marker value was nondeterministic: usually `-1` (from a nil `ProcessState`), sometimes the real code, and formally undefined. Two adjacent latent defects share the path: `done` is unbuffered, so after a kill the `Wait` goroutine leaks blocked on its send, and nothing bounds how stale the read is.

An unconditional post-kill `<-done` would not do as a fix: `Wait` also waits for the stdout/stderr copy goroutines, which only finish once every process holding the pipe has exited, so an orphaned descendant of the wrapped process could block entrypoint arbitrarily long. Instead:

* buffer `done` so the `Wait` goroutine can always complete its send,
* have `gracefullyTerminate` report whether it received the `Wait` result, draining for up to a bounded `sigkillDrainTimeout` (1s) after the kill and logging when a child still holds the log pipe open,
* gate the `ProcessState` reads on that: without the receive, report `-1` directly — the value `ExitCode()` yields for a signal-killed process and what the racy read already produced in the common case, so the de-facto marker behavior is unchanged, just deterministic.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

* This PR was written in part with the assistance of generative AI. I have reviewed and verified every change and can explain each one.
* The new `TestExecuteProcess_KillPath` covers both drain outcomes and reproduces the race under `-race` before the fix.
* The kill path gains at most 1s of latency, and only when the process already survived the full grace period.
* The marker/exit code on the kill path is unchanged in practice (`-1` was the common outcome of the racy read) — it is now guaranteed rather than incidental.
* Suggested verification: `go test -race -count=100 ./pkg/entrypoint/...`
