### PR TITLE
tide: do not mutate ProwJobs in the cache

### DIFF
--- a/pkg/tide/blockers/blockers.go
+++ b/pkg/tide/blockers/blockers.go
@@ -17,10 +17,11 @@ limitations under the License.
 package blockers
 
 import (
+	"cmp"
 	"context"
 	"fmt"
 	"regexp"
-	"sort"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -87,8 +88,8 @@ func (b Blockers) GetApplicable(org, repo, branch string) []Blocker {
 	res = append(res, b.Repo[OrgRepo{Org: org, Repo: repo}]...)
 	res = append(res, b.Branch[OrgRepoBranch{Org: org, Repo: repo, Branch: branch}]...)
 
-	sort.Slice(res, func(i, j int) bool {
-		return res[i].Number < res[j].Number
+	slices.SortFunc(res, func(a, b Blocker) int {
+		return cmp.Compare(a.Number, b.Number)
 	})
 	return res
 }

--- a/pkg/tide/history/history.go
+++ b/pkg/tide/history/history.go
@@ -19,12 +19,13 @@ limitations under the License.
 package history
 
 import (
+	"cmp"
 	"context"
 	"encoding/json"
 	"fmt"
 	stdio "io"
 	"net/http"
-	"sort"
+	"slices"
 	"sync"
 	"time"
 
@@ -148,7 +149,7 @@ func New(maxRecordsPerKey int, opener io.Opener, path string) (*History, error) 
 // Record appends an entry to the recordlog specified by the poolKey.
 func (h *History) Record(poolKey, action, baseSHA, err string, targets []prowapi.Pull, tenantIDs []string) {
 	t := now()
-	sort.Sort(ByNum(targets))
+	slices.SortFunc(targets, func(a, b prowapi.Pull) int { return cmp.Compare(a.Number, b.Number) })
 	h.addRecord(
 		poolKey,
 		&Record{
@@ -259,10 +260,3 @@ func (rl *recordLog) toSlice() []*Record {
 	rl.cachedSlice = res
 	return res
 }
-
-// ByNum implements sort.Interface for []PRMeta to sort by ascending PR number.
-type ByNum []prowapi.Pull
-
-func (prs ByNum) Len() int           { return len(prs) }
-func (prs ByNum) Swap(i, j int)      { prs[i], prs[j] = prs[j], prs[i] }
-func (prs ByNum) Less(i, j int) bool { return prs[i].Number < prs[j].Number }

--- a/pkg/tide/status.go
+++ b/pkg/tide/status.go
@@ -23,7 +23,6 @@ import (
 	stdio "io"
 	"net/url"
 	"slices"
-	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -197,7 +196,7 @@ func requirementDiff(pr *PullRequest, q *config.TideQuery, cc contextChecker, me
 	}
 	diff += len(missingLabels)
 	if desc == "" && len(missingLabels) > 0 {
-		sort.Strings(missingLabels)
+		slices.Sort(missingLabels)
 		trunced := truncate(missingLabels)
 		if len(trunced) == 1 {
 			desc = fmt.Sprintf(" Needs %s label.", trunced[0])
@@ -217,7 +216,7 @@ func requirementDiff(pr *PullRequest, q *config.TideQuery, cc contextChecker, me
 	}
 	diff += len(presentLabels)
 	if desc == "" && len(presentLabels) > 0 {
-		sort.Strings(presentLabels)
+		slices.Sort(presentLabels)
 		trunced := truncate(presentLabels)
 		if len(trunced) == 1 {
 			desc = fmt.Sprintf(" Should not have %s label.", trunced[0])
@@ -244,7 +243,7 @@ func requirementDiff(pr *PullRequest, q *config.TideQuery, cc contextChecker, me
 	}
 	diff += len(contexts)
 	if desc == "" && len(contexts) > 0 {
-		sort.Strings(contexts)
+		slices.Sort(contexts)
 		contexts = slices.Compact(contexts)
 		trunced := truncate(contexts)
 		if len(trunced) == 1 {
@@ -385,7 +384,7 @@ func poolStatus(pr *PullRequest, mergeBlocksPolicy config.GitHubMergeBlocksPolic
 }
 
 func retestingStatus(retested []string) string {
-	sort.Strings(retested)
+	slices.Sort(retested)
 	all := fmt.Sprintf(statusNotInPool, fmt.Sprintf(" Retesting: %s", strings.Join(retested, " ")))
 	if len(all) > maxStatusDescriptionLength {
 		s := ""
@@ -652,7 +651,7 @@ func (sc *statusController) search() []CodeReviewCommon {
 		for org := range queries {
 			orgs = append(orgs, org)
 		}
-		sort.Strings(orgs)
+		slices.Sort(orgs)
 		var query strings.Builder
 		for _, org := range orgs {
 			query.WriteString(" " + queries[org])

--- a/pkg/tide/tide.go
+++ b/pkg/tide/tide.go
@@ -20,13 +20,14 @@ limitations under the License.
 package tide
 
 import (
+	"cmp"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"maps"
 	"net/http"
-	"sort"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -523,7 +524,7 @@ func contextsToStrings(contexts []Context) []string {
 		names = append(names, string(c.Context))
 	}
 	// Sorting names improves readability of logs and simplifies unit tests.
-	sort.Strings(names)
+	slices.Sort(names)
 	return names
 }
 
@@ -1207,7 +1208,7 @@ func (c *syncController) pickBatch(sp subpool, cc map[int]contextChecker, newBat
 	}
 
 	// we must choose the oldest PRs for the batch
-	sort.Slice(sp.prs, func(i, j int) bool { return sp.prs[i].Number < sp.prs[j].Number })
+	slices.SortFunc(sp.prs, func(a, b CodeReviewCommon) int { return cmp.Compare(a.Number, b.Number) })
 
 	var candidates []CodeReviewCommon
 	for _, pr := range sp.prs {
@@ -1878,18 +1879,16 @@ func prMeta(prs ...CodeReviewCommon) []prowapi.Pull {
 }
 
 func sortPools(pools []Pool) {
-	sort.Slice(pools, func(i, j int) bool {
-		if string(pools[i].Org) != string(pools[j].Org) {
-			return string(pools[i].Org) < string(pools[j].Org)
-		}
-		if string(pools[i].Repo) != string(pools[j].Repo) {
-			return string(pools[i].Repo) < string(pools[j].Repo)
-		}
-		return string(pools[i].Branch) < string(pools[j].Branch)
+	slices.SortFunc(pools, func(a, b Pool) int {
+		return cmp.Or(
+			cmp.Compare(a.Org, b.Org),
+			cmp.Compare(a.Repo, b.Repo),
+			cmp.Compare(a.Branch, b.Branch),
+		)
 	})
 
 	sortPRs := func(prs []CodeReviewCommon) {
-		sort.Slice(prs, func(i, j int) bool { return int(prs[i].Number) < int(prs[j].Number) })
+		slices.SortFunc(prs, func(a, b CodeReviewCommon) int { return cmp.Compare(a.Number, b.Number) })
 	}
 	for i := range pools {
 		sortPRs(pools[i].SuccessPRs)
@@ -2182,11 +2181,8 @@ const nonFailedBatchByNameBaseAndPullsIndexName = "tide-non-failed-jobs-by-name-
 func nonFailedBatchByNameBaseAndPullsIndexKey(jobName string, refs *prowapi.Refs) string {
 	// sort the pulls to make sure this is determinististic, but make a copy
 	// to avoid mutating the input, it can point to a cache-backed object
-	pulls := make([]prowapi.Pull, len(refs.Pulls))
-	copy(pulls, refs.Pulls)
-	sort.Slice(pulls, func(i, j int) bool {
-		return pulls[i].Number < pulls[j].Number
-	})
+	pulls := slices.Clone(refs.Pulls)
+	slices.SortFunc(pulls, func(a, b prowapi.Pull) int { return cmp.Compare(a.Number, b.Number) })
 
 	keys := []string{jobName, refs.Org, refs.Repo, refs.BaseRef, refs.BaseSHA}
 	for _, pull := range pulls {

--- a/pkg/tide/tide.go
+++ b/pkg/tide/tide.go
@@ -2180,13 +2180,16 @@ const nonFailedBatchByNameBaseAndPullsIndexName = "tide-non-failed-jobs-by-name-
 // the batch job, and returns a string contain all of them. This is used only by
 // nonFailedBatchByNameBaseAndPullsIndexFunc.
 func nonFailedBatchByNameBaseAndPullsIndexKey(jobName string, refs *prowapi.Refs) string {
-	// sort the pulls to make sure this is deterministic
-	sort.Slice(refs.Pulls, func(i, j int) bool {
-		return refs.Pulls[i].Number < refs.Pulls[j].Number
+	// sort the pulls to make sure this is determinististic, but make a copy
+	// to avoid mutating the input, it can point to a cache-backed object
+	pulls := make([]prowapi.Pull, len(refs.Pulls))
+	copy(pulls, refs.Pulls)
+	sort.Slice(pulls, func(i, j int) bool {
+		return pulls[i].Number < pulls[j].Number
 	})
 
 	keys := []string{jobName, refs.Org, refs.Repo, refs.BaseRef, refs.BaseSHA}
-	for _, pull := range refs.Pulls {
+	for _, pull := range pulls {
 		keys = append(keys, strconv.Itoa(pull.Number), pull.SHA)
 	}
 

--- a/pkg/tide/tide_test.go
+++ b/pkg/tide/tide_test.go
@@ -4569,6 +4569,42 @@ func TestNonFailedBatchByBaseAndPullsIndexFunc(t *testing.T) {
 	}
 }
 
+// TestNonFailedBatchByNameBaseAndPullsIndexKeyDoesNotMutateRefs verifies that
+// computing the index key leaves its input alone. The index func is handed the
+// ProwJob that lives in the cache, so sorting the pulls in place would mutate
+// shared state underneath every other reader of that cache.
+func TestNonFailedBatchByNameBaseAndPullsIndexKeyDoesNotMutateRefs(t *testing.T) {
+	unsorted := []prowapi.Pull{{Number: 3, SHA: "three"}, {Number: 1, SHA: "one"}, {Number: 2, SHA: "two"}}
+	refs := &prowapi.Refs{
+		Org:     "org",
+		Repo:    "repo",
+		BaseRef: "master",
+		BaseSHA: "base-sha",
+		Pulls:   slices.Clone(unsorted),
+	}
+
+	key := nonFailedBatchByNameBaseAndPullsIndexKey("some-job", refs)
+
+	// The key is still sorted by pull number, ...
+	if expected := "some-job|org|repo|master|base-sha|1|one|2|two|3|three"; key != expected {
+		t.Errorf("expected key %q, got %q", expected, key)
+	}
+	// ... but the refs we got handed are untouched.
+	if diff := cmp.Diff(unsorted, refs.Pulls); diff != "" {
+		t.Errorf("the pulls were reordered in place: %s", diff)
+	}
+
+	// The same must hold when it is reached through the index func.
+	pj := getProwJob(prowapi.BatchJob, "org", "repo", "master", "base-sha", prowapi.SuccessState, slices.Clone(unsorted))
+	pj.Spec.Job = "some-job"
+	if result := nonFailedBatchByNameBaseAndPullsIndexFunc(pj); !slices.Equal(result, []string{key}) {
+		t.Errorf("expected the index func to yield %v, got %v", []string{key}, result)
+	}
+	if diff := cmp.Diff(unsorted, pj.Spec.Refs.Pulls); diff != "" {
+		t.Errorf("the index func reordered the pulls of the indexed prowjob in place: %s", diff)
+	}
+}
+
 func TestCheckRunNodesToContexts(t *testing.T) {
 	t.Parallel()
 	testCases := []struct {


### PR DESCRIPTION
Avoid mutating the ProwJob object in the cache while computing an index key. It is probably benign here because the semantics should be the same, but the mutation is a suprising side effect and informer cache objects sould not be mutated by the reader.

Added a commit modernizing sorts in neighboring Tide codel

#904 side quest

Assisted by Claude Code