### PR TITLE
`override`: abort in-flight jobs so they cannot clobber `/override` or `/override-sticky`

### DIFF
--- a/pkg/plugins/override/override.go
+++ b/pkg/plugins/override/override.go
@@ -22,23 +22,30 @@ import (
 	"fmt"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/sirupsen/logrus"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	klabels "k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	prowapi "sigs.k8s.io/prow/pkg/apis/prowjobs/v1"
 	"sigs.k8s.io/prow/pkg/config"
 	"sigs.k8s.io/prow/pkg/git/v2"
 	"sigs.k8s.io/prow/pkg/github"
+	"sigs.k8s.io/prow/pkg/kube"
 	"sigs.k8s.io/prow/pkg/pjutil"
 	"sigs.k8s.io/prow/pkg/pluginhelp"
 	"sigs.k8s.io/prow/pkg/plugins"
 	"sigs.k8s.io/prow/pkg/repoowners"
 )
 
-const pluginName = "override"
+const (
+	pluginName                   = "override"
+	abortedByOverrideDescription = "Aborted by /override."
+)
 
 var (
 	overrideStickyRe = regexp.MustCompile(`(?mi)^/override-sticky( ([^\r\n]+))?[\r\n]?$`)
@@ -69,6 +76,8 @@ type githubClient interface {
 
 type prowJobClient interface {
 	Create(context.Context, *prowapi.ProwJob, metav1.CreateOptions) (*prowapi.ProwJob, error)
+	List(context.Context, metav1.ListOptions) (*prowapi.ProwJobList, error)
+	Update(context.Context, *prowapi.ProwJob, metav1.UpdateOptions) (*prowapi.ProwJob, error)
 }
 
 type ownersClient interface {
@@ -135,6 +144,14 @@ func (c client) Create(ctx context.Context, pj *prowapi.ProwJob, o metav1.Create
 	return c.prowJobClient.Create(ctx, pj, o)
 }
 
+func (c client) List(ctx context.Context, opts metav1.ListOptions) (*prowapi.ProwJobList, error) {
+	return c.prowJobClient.List(ctx, opts)
+}
+
+func (c client) Update(ctx context.Context, pj *prowapi.ProwJob, o metav1.UpdateOptions) (*prowapi.ProwJob, error) {
+	return c.prowJobClient.Update(ctx, pj, o)
+}
+
 func (c client) presubmits(org, repo string, baseSHAGetter config.RefGetter, headSHA string) ([]config.Presubmit, error) {
 	headSHAGetter := func() (string, error) {
 		return headSHA, nil
@@ -153,6 +170,50 @@ func presubmitForContext(presubmits []config.Presubmit, context string) *config.
 		}
 	}
 	return nil
+}
+
+func prowJobSelectorForPR(org, repo string, number int) (klabels.Selector, error) {
+	set := klabels.Set{
+		kube.OrgLabel:         org,
+		kube.RepoLabel:        repo,
+		kube.PullLabel:        strconv.Itoa(number),
+		kube.ProwJobTypeLabel: string(prowapi.PresubmitJob),
+	}
+	selector := klabels.SelectorFromSet(set)
+	if selector.Empty() {
+		return nil, fmt.Errorf("got back empty selector")
+	}
+	return selector, nil
+}
+
+// abortActiveJob silences reporting on ProwJobs named jobName and aborts any that are
+// still running so Plank can tear down the workload without crier clobbering
+// the override status. It sets AbortedState but does not SetComplete: Plank (or
+// Jenkins) reacts to the aborted state by deleting the pod/build and then
+// completing the ProwJob. Completing here would skip that handover and leak the
+// running workload.
+func abortActiveJob(oc overrideClient, log *logrus.Entry, org, repo string, number int, jobName string) {
+	selector, err := prowJobSelectorForPR(org, repo, number)
+	if err != nil {
+		log.WithError(err).Warn("Cannot construct prowjob selector to abort jobs for override")
+		return
+	}
+	jobs, err := oc.List(context.Background(), metav1.ListOptions{LabelSelector: selector.String()})
+	if err != nil {
+		log.WithError(err).Warn("Cannot list prowjobs to abort for override")
+		return
+	}
+	for _, job := range jobs.Items {
+		if job.Spec.Job != jobName || job.Complete() {
+			continue
+		}
+		job.Spec.Report = false
+		job.Status.State = prowapi.AbortedState
+		job.Status.Description = abortedByOverrideDescription
+		if _, err := oc.Update(context.Background(), &job, metav1.UpdateOptions{}); err != nil && !apierrors.IsConflict(err) {
+			log.WithError(err).WithFields(pjutil.ProwJobFields(&job)).Warn("Failed to abort prowjob for override")
+		}
+	}
 }
 
 func (c client) LoadRepoOwners(org, repo, base string) (repoowners.RepoOwner, error) {
@@ -559,6 +620,7 @@ If you are trying to override a checkrun that has a space in it, you must put a 
 				return oc.CreateComment(org, repo, number, plugins.FormatResponseRaw(e.Body, e.HTMLURL, user, resp))
 			}
 			contextsWithCreatedJobs.Insert(status.Context)
+			abortActiveJob(oc, log, org, repo, number, pre.Name)
 		}
 		status.State = github.StatusSuccess
 		status.Description = config.ContextDescriptionWithBaseSha(descFn(user), baseSHA)

--- a/pkg/plugins/override/override_test.go
+++ b/pkg/plugins/override/override_test.go
@@ -21,17 +21,20 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"strconv"
 	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	klabels "k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	prowapi "sigs.k8s.io/prow/pkg/apis/prowjobs/v1"
 	"sigs.k8s.io/prow/pkg/config"
 	"sigs.k8s.io/prow/pkg/github"
+	"sigs.k8s.io/prow/pkg/kube"
 	"sigs.k8s.io/prow/pkg/layeredsets"
 	"sigs.k8s.io/prow/pkg/plugins"
 	"sigs.k8s.io/prow/pkg/plugins/ownersconfig"
@@ -142,6 +145,7 @@ type fakeClient struct {
 	branchProtection *github.BranchProtection
 	ps               []config.Presubmit
 	jobs             sets.Set[string]
+	prowJobs         []prowapi.ProwJob
 	owners           ownersClient
 	checkruns        *github.CheckRunList
 	usesAppsAuth     bool
@@ -320,6 +324,34 @@ func (c *fakeClient) Create(_ context.Context, pj *prowapi.ProwJob, _ metav1.Cre
 	}
 	c.jobs.Insert(pj.Spec.Context)
 	return pj, nil
+}
+
+func (c *fakeClient) List(_ context.Context, opts metav1.ListOptions) (*prowapi.ProwJobList, error) {
+	selector := klabels.Everything()
+	if opts.LabelSelector != "" {
+		var err error
+		selector, err = klabels.Parse(opts.LabelSelector)
+		if err != nil {
+			return nil, err
+		}
+	}
+	var items []prowapi.ProwJob
+	for _, pj := range c.prowJobs {
+		if selector.Matches(klabels.Set(pj.Labels)) {
+			items = append(items, *pj.DeepCopy())
+		}
+	}
+	return &prowapi.ProwJobList{Items: items}, nil
+}
+
+func (c *fakeClient) Update(_ context.Context, pj *prowapi.ProwJob, _ metav1.UpdateOptions) (*prowapi.ProwJob, error) {
+	for i, existing := range c.prowJobs {
+		if existing.Name == pj.Name {
+			c.prowJobs[i] = *pj.DeepCopy()
+			return pj, nil
+		}
+	}
+	return nil, fmt.Errorf("prowjob %s not found", pj.Name)
 }
 
 func (c *fakeClient) LoadRepoOwners(org, repo, base string) (repoowners.RepoOwner, error) {
@@ -1622,5 +1654,149 @@ func TestStickyDescriptionFitsGitHubLimit(t *testing.T) {
 	}
 	if !strings.Contains(full, config.SkipRetestSentinel) {
 		t.Errorf("sticky description lost sentinel after ContextDescriptionWithBaseSha: %q", full)
+	}
+}
+
+func testPresubmitJob(name, context, sha string, state prowapi.ProwJobState, complete, report bool, pull int) prowapi.ProwJob {
+	pj := prowapi.ProwJob{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name + "-pj",
+			Labels: map[string]string{
+				kube.OrgLabel:         fakeOrg,
+				kube.RepoLabel:        fakeRepo,
+				kube.PullLabel:        strconv.Itoa(pull),
+				kube.ProwJobTypeLabel: string(prowapi.PresubmitJob),
+			},
+		},
+		Spec: prowapi.ProwJobSpec{
+			Type:    prowapi.PresubmitJob,
+			Job:     name,
+			Context: context,
+			Report:  report,
+			Refs: &prowapi.Refs{
+				Org:  fakeOrg,
+				Repo: fakeRepo,
+				Pulls: []prowapi.Pull{{
+					Number: pull,
+					SHA:    sha,
+				}},
+			},
+		},
+		Status: prowapi.ProwJobStatus{
+			State: state,
+		},
+	}
+	if complete {
+		now := metav1.Now()
+		pj.Status.CompletionTime = &now
+	}
+	return pj
+}
+
+func aborted(pj prowapi.ProwJob) prowapi.ProwJob {
+	pj.Spec.Report = false
+	pj.Status.State = prowapi.AbortedState
+	pj.Status.Description = abortedByOverrideDescription
+	return pj
+}
+
+func TestAbortJobsOnOverride(t *testing.T) {
+	log := logrus.WithField("plugin", pluginName)
+	jobPresubmit := config.Presubmit{
+		JobBase: config.JobBase{
+			Name: "job-a",
+		},
+		Reporter: config.Reporter{
+			Context: "job-a",
+		},
+	}
+
+	jobA := testPresubmitJob("job-a", "job-a", fakeSHA, prowapi.PendingState, false, true, fakePR)
+	jobB := testPresubmitJob("job-b", "job-b", fakeSHA, prowapi.PendingState, false, true, fakePR)
+	completeA := testPresubmitJob("job-a", "job-a", fakeSHA, prowapi.FailureState, true, true, fakePR)
+
+	cases := []struct {
+		name         string
+		body         string
+		prowJobs     []prowapi.ProwJob
+		wantProwJobs []prowapi.ProwJob
+	}{
+		{
+			name:         "aborts running job on /override",
+			body:         "/override job-a",
+			prowJobs:     []prowapi.ProwJob{jobA},
+			wantProwJobs: []prowapi.ProwJob{aborted(jobA)},
+		},
+		{
+			name:         "aborts running job on /override-sticky",
+			body:         "/override-sticky job-a",
+			prowJobs:     []prowapi.ProwJob{jobA},
+			wantProwJobs: []prowapi.ProwJob{aborted(jobA)},
+		},
+		{
+			name:         "leaves running job for a different context alone",
+			body:         "/override job-a",
+			prowJobs:     []prowapi.ProwJob{jobA, jobB},
+			wantProwJobs: []prowapi.ProwJob{aborted(jobA), jobB},
+		},
+		{
+			name:         "leaves already-complete matching job alone",
+			body:         "/override job-a",
+			prowJobs:     []prowapi.ProwJob{completeA},
+			wantProwJobs: []prowapi.ProwJob{completeA},
+		},
+		{
+			name: "no matching prowjob still overrides",
+			body: "/override job-a",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var prowJobs []prowapi.ProwJob
+			for _, pj := range tc.prowJobs {
+				prowJobs = append(prowJobs, *pj.DeepCopy())
+			}
+			fc := &fakeClient{
+				statuses: []github.Status{
+					{Context: "job-a", State: github.StatusFailure, Description: "Build failed"},
+				},
+				ps:       []config.Presubmit{jobPresubmit},
+				jobs:     sets.New[string](),
+				prowJobs: prowJobs,
+			}
+			event := github.GenericCommentEvent{
+				IsPR:       true,
+				IssueState: "open",
+				Action:     github.GenericCommentActionCreated,
+				Body:       tc.body,
+				Number:     fakePR,
+				User:       github.User{Login: adminUser},
+				Repo:       github.Repo{Owner: github.User{Login: fakeOrg}, Name: fakeRepo},
+			}
+
+			sticky := strings.Contains(tc.body, "/override-sticky")
+			if err := handle(fc, log, &event, plugins.Override{}, sticky); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			wantDesc := statusDescription(adminUser)
+			if sticky {
+				wantDesc = stickyStatusDescription(adminUser)
+			}
+			if diff := cmp.Diff([]github.Status{{
+				Context:     "job-a",
+				State:       github.StatusSuccess,
+				Description: wantDesc,
+			}}, fc.statuses); diff != "" {
+				t.Errorf("statuses mismatch (-want +got):\n%s", diff)
+			}
+			if diff := cmp.Diff(sets.New("job-a"), fc.jobs); diff != "" {
+				t.Errorf("created jobs mismatch (-want +got):\n%s", diff)
+			}
+			if diff := cmp.Diff(tc.wantProwJobs, fc.prowJobs); diff != "" {
+				t.Errorf("prowjobs mismatch (-want +got):\n%s", diff)
+			}
+		})
 	}
 }


### PR DESCRIPTION
When `/override` or `/override-sticky` is applied to a running presubmit, mark the ProwJob unreported and aborted without completing it so Plank can tear down the workload without crier overwriting the override status.