### PR TITLE
blunderbuss, rifle: count existing eligible reviewers toward the reviewer count

### DIFF
--- a/pkg/plugins/blunderbuss/blunderbuss.go
+++ b/pkg/plugins/blunderbuss/blunderbuss.go
@@ -62,7 +62,7 @@ func helpProvider(config *plugins.Configuration, _ []config.OrgRepo) (*pluginhel
 		logrus.WithError(err).Warnf("cannot generate comments for %s plugin", PluginName)
 	}
 	pluginHelp := &pluginhelp.PluginHelp{
-		Description: "The blunderbuss plugin automatically requests reviews from reviewers when a new PR is created. The reviewers are selected randomly from the OWNERS files that apply to the files modified by the PR.",
+		Description: "The blunderbuss plugin automatically requests reviews from reviewers when a new PR is created. The reviewers are selected randomly from the OWNERS files that apply to the files modified by the PR. Reviewers that are already requested on the PR and present in those OWNERS files count toward the configured reviewer count.",
 		Config: map[string]string{
 			"": reviewer.ConfigString(PluginName, reviewCount),
 		},
@@ -256,6 +256,8 @@ func handle(ghc reviewer.GitHubClient, roc reviewer.RepoOwnersClient, log *logru
 		return fmt.Errorf("error getting PR changes: %w", err)
 	}
 
+	existingEligible := reviewer.EligibleRequestedReviewers(oc, pr, changes, !excludeApprovers)
+
 	busyReviewers := sets.New[string]()
 	selector := func(candidates *layeredsets.String) string {
 		return reviewer.FindReviewer(ghc, log, useStatusAvailability, &busyReviewers, candidates)
@@ -264,34 +266,51 @@ func handle(ghc reviewer.GitHubClient, roc reviewer.RepoOwnersClient, log *logru
 	var reviewers []string
 	var requiredReviewers []string
 	if reviewerCount != nil {
-		reviewers, requiredReviewers, err = reviewer.GetReviewers(oc, selector, log, pr.User.Login, changes, *reviewerCount)
-		if err != nil {
-			return err
+		neededReviewers := max(*reviewerCount-existingEligible.Len(), 0)
+		if existingEligible.Len() > 0 {
+			log.Infof("Counting %d already requested reviewer(s) from the OWNERS files toward the reviewer count. %d additional reviewer(s) needed.", existingEligible.Len(), neededReviewers)
 		}
-		if missing := *reviewerCount - len(reviewers); missing > 0 {
-			if !excludeApprovers {
-				frc := reviewer.FallbackReviewersClient{OwnersClient: oc}
-				approvers, _, err := reviewer.GetReviewers(frc, selector, log, pr.User.Login, changes, *reviewerCount)
-				if err != nil {
-					return err
-				}
-				var added int
-				combinedReviewers := sets.New[string](reviewers...)
-				for _, approver := range approvers {
-					if !combinedReviewers.Has(approver) {
-						reviewers = append(reviewers, approver)
-						combinedReviewers.Insert(approver)
-						added++
-					}
-				}
-				log.Infof("Added %d approvers as reviewers. %d/%d reviewers found.", added, combinedReviewers.Len(), *reviewerCount)
+		if neededReviewers > 0 {
+			reviewers, requiredReviewers, err = reviewer.GetReviewers(oc, selector, log, pr.User.Login, changes, neededReviewers, existingEligible)
+			if err != nil {
+				return err
 			}
+			if missing := neededReviewers - len(reviewers); missing > 0 {
+				if !excludeApprovers {
+					frc := reviewer.FallbackReviewersClient{OwnersClient: oc}
+					approvers, _, err := reviewer.GetReviewers(frc, selector, log, pr.User.Login, changes, neededReviewers, existingEligible)
+					if err != nil {
+						return err
+					}
+					var added int
+					combinedReviewers := sets.New[string](reviewers...)
+					for _, approver := range approvers {
+						if !combinedReviewers.Has(approver) {
+							reviewers = append(reviewers, approver)
+							combinedReviewers.Insert(approver)
+							added++
+						}
+					}
+					log.Infof("Added %d approvers as reviewers. %d/%d reviewers found.", added, combinedReviewers.Len(), neededReviewers)
+				}
+			}
+		} else if *reviewerCount > 0 {
+			// The reviewer quota is already met by existing requested reviewers, but
+			// required reviewers must still be requested.
+			required := sets.New[string]()
+			for _, change := range changes {
+				required = required.Union(oc.RequiredReviewers(change.Filename))
+			}
+			requiredReviewers = sets.List(required)
 		}
 	}
 
-	if maxReviewers > 0 && len(reviewers) > maxReviewers {
-		log.Infof("Limiting request of %d reviewers to %d maxReviewers.", len(reviewers), maxReviewers)
-		reviewers = reviewers[:maxReviewers]
+	if maxReviewers > 0 {
+		maxNewReviewers := max(maxReviewers-existingEligible.Len(), 0)
+		if len(reviewers) > maxNewReviewers {
+			log.Infof("Limiting request to %d new reviewer(s) (maxReviewers=%d, counting %d already requested reviewer(s)).", maxNewReviewers, maxReviewers, existingEligible.Len())
+			reviewers = reviewers[:maxNewReviewers]
+		}
 	}
 
 	reviewers = append(reviewers, requiredReviewers...)

--- a/pkg/plugins/blunderbuss/blunderbuss_test.go
+++ b/pkg/plugins/blunderbuss/blunderbuss_test.go
@@ -592,11 +592,172 @@ func TestHandleWithoutExcludeApproversMixed(t *testing.T) {
 	}
 }
 
+func TestHandleWithExistingRequestedReviewers(t *testing.T) {
+	froc := &fakeRepoownersClient{
+		foc: &fakeOwnersClient{
+			owners: map[string]string{
+				"a.go": "1",
+				"r.go": "2",
+			},
+			reviewers: map[string]layeredsets.String{
+				"a.go": layeredsets.NewString("bob", "christoph", "david"),
+				"r.go": layeredsets.NewString("bob", "christoph", "david"),
+			},
+			leafReviewers: map[string]sets.Set[string]{
+				"a.go": sets.New[string]("bob", "christoph", "david"),
+				"r.go": sets.New[string]("bob", "christoph", "david"),
+			},
+			approvers: map[string]layeredsets.String{
+				"a.go": layeredsets.NewString("adam"),
+				"r.go": layeredsets.NewString("adam"),
+			},
+			leafApprovers: map[string]sets.Set[string]{
+				"a.go": sets.New[string]("adam"),
+				"r.go": sets.New[string]("adam"),
+			},
+			requiredReviewers: map[string]sets.Set[string]{
+				"r.go": sets.New[string]("rachel"),
+			},
+		},
+	}
+
+	testcases := []struct {
+		name               string
+		filesChanged       []string
+		requestedReviewers []string
+		reviewerCount      int
+		maxReviewerCount   int
+		excludeApprovers   bool
+		expectedCount      int
+		allowedRequested   []string
+		mustRequest        []string
+		mustNotRequest     []string
+	}{
+		{
+			name:               "eligible existing reviewer counts toward the quota",
+			filesChanged:       []string{"a.go"},
+			requestedReviewers: []string{"christoph"},
+			reviewerCount:      2,
+			excludeApprovers:   true,
+			expectedCount:      1,
+			allowedRequested:   []string{"bob", "david"},
+			mustNotRequest:     []string{"christoph"},
+		},
+		{
+			name:               "quota fully satisfied by existing eligible reviewers",
+			filesChanged:       []string{"a.go"},
+			requestedReviewers: []string{"christoph", "bob"},
+			reviewerCount:      2,
+			excludeApprovers:   true,
+			expectedCount:      0,
+		},
+		{
+			name:               "quota satisfied but required reviewers still requested",
+			filesChanged:       []string{"r.go"},
+			requestedReviewers: []string{"christoph", "bob"},
+			reviewerCount:      2,
+			excludeApprovers:   true,
+			expectedCount:      1,
+			allowedRequested:   []string{"rachel"},
+			mustRequest:        []string{"rachel"},
+		},
+		{
+			name:               "ineligible existing reviewer does not count",
+			filesChanged:       []string{"a.go"},
+			requestedReviewers: []string{"stranger"},
+			reviewerCount:      2,
+			excludeApprovers:   true,
+			expectedCount:      2,
+			allowedRequested:   []string{"bob", "christoph", "david"},
+		},
+		{
+			name:               "requested login case differs from OWNERS entry",
+			filesChanged:       []string{"a.go"},
+			requestedReviewers: []string{"Christoph"},
+			reviewerCount:      2,
+			excludeApprovers:   true,
+			expectedCount:      1,
+			allowedRequested:   []string{"bob", "david"},
+			mustNotRequest:     []string{"christoph", "Christoph"},
+		},
+		{
+			name:               "approver-only existing reviewer counts when approvers are not excluded",
+			filesChanged:       []string{"a.go"},
+			requestedReviewers: []string{"adam"},
+			reviewerCount:      1,
+			excludeApprovers:   false,
+			expectedCount:      0,
+		},
+		{
+			name:               "approver-only existing reviewer does not count when approvers are excluded",
+			filesChanged:       []string{"a.go"},
+			requestedReviewers: []string{"adam"},
+			reviewerCount:      1,
+			excludeApprovers:   true,
+			expectedCount:      1,
+			allowedRequested:   []string{"bob", "christoph", "david"},
+		},
+		{
+			name:               "maxReviewerCount accounts for existing eligible reviewers",
+			filesChanged:       []string{"a.go"},
+			requestedReviewers: []string{"christoph"},
+			reviewerCount:      3,
+			maxReviewerCount:   2,
+			excludeApprovers:   true,
+			expectedCount:      1,
+			allowedRequested:   []string{"bob", "david"},
+			mustNotRequest:     []string{"christoph"},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			pr := github.PullRequest{Number: 5, User: github.User{Login: "alice"}}
+			for _, login := range tc.requestedReviewers {
+				pr.RequestedReviewers = append(pr.RequestedReviewers, github.User{Login: login})
+			}
+			repo := github.Repo{Owner: github.User{Login: "org"}, Name: "repo"}
+			fghc := newFakeGitHubClient(&pr, tc.filesChanged)
+
+			if err := handle(
+				fghc, froc, logrus.WithField("plugin", PluginName),
+				&tc.reviewerCount, tc.maxReviewerCount, tc.excludeApprovers, false, &repo, &pr,
+			); err != nil {
+				t.Fatalf("unexpected error from handle: %v", err)
+			}
+
+			if len(fghc.requested) != tc.expectedCount {
+				t.Fatalf("expected %d newly requested reviewers, got %d: %v", tc.expectedCount, len(fghc.requested), fghc.requested)
+			}
+			allowed := sets.New[string](tc.allowedRequested...)
+			for _, login := range fghc.requested {
+				if !allowed.Has(login) {
+					t.Errorf("requested reviewer %q is not in the allowed set %v", login, sets.List(allowed))
+				}
+			}
+			requested := sets.New[string](fghc.requested...)
+			for _, login := range tc.mustRequest {
+				if !requested.Has(login) {
+					t.Errorf("expected reviewer %q to be requested, got %v", login, fghc.requested)
+				}
+			}
+			for _, login := range tc.mustNotRequest {
+				if requested.Has(login) {
+					t.Errorf("reviewer %q must not be requested again, got %v", login, fghc.requested)
+				}
+			}
+		})
+	}
+}
+
 func TestHandlePullRequest(t *testing.T) {
 	froc := &fakeRepoownersClient{
 		foc: &fakeOwnersClient{
 			owners: map[string]string{
 				"a.go": "1",
+			},
+			reviewers: map[string]layeredsets.String{
+				"a.go": layeredsets.NewString("al"),
 			},
 			leafReviewers: map[string]sets.Set[string]{
 				"a.go": sets.New[string]("al"),
@@ -605,16 +766,17 @@ func TestHandlePullRequest(t *testing.T) {
 	}
 
 	var testcases = []struct {
-		name              string
-		action            github.PullRequestEventAction
-		body              string
-		filesChanged      []string
-		reviewerCount     int
-		expectedRequested []string
-		draft             bool
-		ignoreDrafts      bool
-		ignoreAuthors     []string
-		waitForStatus     *plugins.ContextMatch
+		name               string
+		action             github.PullRequestEventAction
+		body               string
+		filesChanged       []string
+		reviewerCount      int
+		requestedReviewers []string
+		expectedRequested  []string
+		draft              bool
+		ignoreDrafts       bool
+		ignoreAuthors      []string
+		waitForStatus      *plugins.ContextMatch
 	}{
 		{
 			name:              "PR opened",
@@ -670,6 +832,13 @@ func TestHandlePullRequest(t *testing.T) {
 			expectedRequested: []string{"al"},
 		},
 		{
+			name:               "draft is ready for review with eligible reviewer already requested, request no more",
+			action:             github.PullRequestActionReadyForReview,
+			filesChanged:       []string{"a.go"},
+			reviewerCount:      1,
+			requestedReviewers: []string{"al"},
+		},
+		{
 			name:          "PR opened by ignored author, do not assign review to PR",
 			action:        github.PullRequestActionOpened,
 			filesChanged:  []string{"a.go"},
@@ -679,6 +848,9 @@ func TestHandlePullRequest(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			pr := github.PullRequest{Number: 5, User: github.User{Login: "author"}, Body: tc.body, Draft: tc.draft}
+			for _, login := range tc.requestedReviewers {
+				pr.RequestedReviewers = append(pr.RequestedReviewers, github.User{Login: login})
+			}
 			repo := github.Repo{Owner: github.User{Login: "org"}, Name: "repo"}
 			fghc := newFakeGitHubClient(&pr, tc.filesChanged)
 			c := plugins.Blunderbuss{

--- a/pkg/plugins/rifle/rifle.go
+++ b/pkg/plugins/rifle/rifle.go
@@ -72,7 +72,7 @@ func helpProvider(config *plugins.Configuration, _ []config.OrgRepo) (*pluginhel
 		logrus.WithError(err).Warnf("cannot generate comments for %s plugin", PluginName)
 	}
 	pluginHelp := &pluginhelp.PluginHelp{
-		Description: "The rifle plugin automatically requests reviews from reviewers when a new PR is created. Unlike blunderbuss (which selects randomly), rifle uses git blame data to identify reviewers most familiar with the changed code.",
+		Description: "The rifle plugin automatically requests reviews from reviewers when a new PR is created. Unlike blunderbuss (which selects randomly), rifle uses git blame data to identify reviewers most familiar with the changed code. Reviewers that are already requested on the PR and present in the applicable OWNERS files count toward the configured reviewer count.",
 		Config: map[string]string{
 			"": reviewer.ConfigString(PluginName, reviewCount),
 		},
@@ -266,6 +266,8 @@ func handle(ghc rifleGitHubClient, roc reviewer.RepoOwnersClient, log *logrus.En
 		return fmt.Errorf("error getting PR changes: %w", err)
 	}
 
+	existingEligible := reviewer.EligibleRequestedReviewers(oc, pr, changes, !excludeApprovers)
+
 	allReviewerCandidates := sets.New[string]()
 	allApproverCandidates := sets.New[string]()
 	for _, file := range changes {
@@ -314,47 +316,65 @@ func handle(ghc rifleGitHubClient, roc reviewer.RepoOwnersClient, log *logrus.En
 	var reviewers []string
 	var requiredReviewers []string
 	if reviewerCount != nil {
-		reviewers, requiredReviewers, err = reviewer.GetReviewers(oc, selector, log, pr.User.Login, changes, *reviewerCount)
-		if err != nil {
-			return err
+		neededReviewers := max(*reviewerCount-existingEligible.Len(), 0)
+		if existingEligible.Len() > 0 {
+			log.Infof("Counting %d already requested reviewer(s) from the OWNERS files toward the reviewer count. %d additional reviewer(s) needed.", existingEligible.Len(), neededReviewers)
 		}
-		if missing := *reviewerCount - len(reviewers); missing > 0 {
-			if !excludeApprovers {
-				frc := reviewer.FallbackReviewersClient{OwnersClient: oc}
-				approvers, _, err := reviewer.GetReviewers(frc, selector, log, pr.User.Login, changes, *reviewerCount)
-				if err != nil {
-					return err
-				}
-				var added int
-				combinedReviewers := sets.New[string](reviewers...)
-				for _, approver := range approvers {
-					if !combinedReviewers.Has(approver) {
-						reviewers = append(reviewers, approver)
-						combinedReviewers.Insert(approver)
-						added++
+		if neededReviewers > 0 {
+			reviewers, requiredReviewers, err = reviewer.GetReviewers(oc, selector, log, pr.User.Login, changes, neededReviewers, existingEligible)
+			if err != nil {
+				return err
+			}
+			if missing := neededReviewers - len(reviewers); missing > 0 {
+				if !excludeApprovers {
+					frc := reviewer.FallbackReviewersClient{OwnersClient: oc}
+					approvers, _, err := reviewer.GetReviewers(frc, selector, log, pr.User.Login, changes, neededReviewers, existingEligible)
+					if err != nil {
+						return err
 					}
+					var added int
+					combinedReviewers := sets.New[string](reviewers...)
+					for _, approver := range approvers {
+						if !combinedReviewers.Has(approver) {
+							reviewers = append(reviewers, approver)
+							combinedReviewers.Insert(approver)
+							added++
+						}
+					}
+					log.Infof("Added %d approvers as reviewers. %d/%d reviewers found.", added, combinedReviewers.Len(), neededReviewers)
 				}
-				log.Infof("Added %d approvers as reviewers. %d/%d reviewers found.", added, combinedReviewers.Len(), *reviewerCount)
 			}
-		}
-		if missing := *reviewerCount - len(reviewers); missing > 0 {
-			log.Debugf("Not enough reviewers found in OWNERS files for files touched by this PR. %d/%d reviewers found.", len(reviewers), *reviewerCount)
+			if missing := neededReviewers - len(reviewers); missing > 0 {
+				log.Debugf("Not enough reviewers found in OWNERS files for files touched by this PR. %d/%d reviewers found.", len(reviewers), neededReviewers)
 
-			excludeFromFallback := sets.New[string](reviewers...)
-			excludeFromFallback.Insert(github.NormLogin(pr.User.Login))
-			fallbackReviewers := findFallbackReviewers(
-				blameScores, oc, excludeFromFallback, missing,
-			)
-			if len(fallbackReviewers) > 0 {
-				reviewers = append(reviewers, fallbackReviewers...)
-				log.Infof("Fallback added %d reviewer(s) from broader OWNERS scope: %v", len(fallbackReviewers), fallbackReviewers)
+				excludeFromFallback := sets.New[string](reviewers...)
+				excludeFromFallback.Insert(github.NormLogin(pr.User.Login))
+				excludeFromFallback = excludeFromFallback.Union(existingEligible)
+				fallbackReviewers := findFallbackReviewers(
+					blameScores, oc, excludeFromFallback, missing,
+				)
+				if len(fallbackReviewers) > 0 {
+					reviewers = append(reviewers, fallbackReviewers...)
+					log.Infof("Fallback added %d reviewer(s) from broader OWNERS scope: %v", len(fallbackReviewers), fallbackReviewers)
+				}
 			}
+		} else if *reviewerCount > 0 {
+			// The reviewer quota is already met by existing requested reviewers, but
+			// required reviewers must still be requested.
+			required := sets.New[string]()
+			for _, change := range changes {
+				required = required.Union(oc.RequiredReviewers(change.Filename))
+			}
+			requiredReviewers = sets.List(required)
 		}
 	}
 
-	if maxReviewers > 0 && len(reviewers) > maxReviewers {
-		log.Infof("Limiting request of %d reviewers to %d maxReviewers.", len(reviewers), maxReviewers)
-		reviewers = reviewers[:maxReviewers]
+	if maxReviewers > 0 {
+		maxNewReviewers := max(maxReviewers-existingEligible.Len(), 0)
+		if len(reviewers) > maxNewReviewers {
+			log.Infof("Limiting request to %d new reviewer(s) (maxReviewers=%d, counting %d already requested reviewer(s)).", maxNewReviewers, maxReviewers, existingEligible.Len())
+			reviewers = reviewers[:maxNewReviewers]
+		}
 	}
 
 	reviewers = append(reviewers, requiredReviewers...)

--- a/pkg/plugins/rifle/rifle_test.go
+++ b/pkg/plugins/rifle/rifle_test.go
@@ -132,16 +132,17 @@ func (froc fakeRepoownersClient) LoadRepoOwners(org, repo, base string) (repoown
 }
 
 type fakeOwnersClient struct {
-	owners        map[string]string
-	approvers     map[string]layeredsets.String
-	leafApprovers map[string]sets.Set[string]
-	reviewers     map[string]layeredsets.String
-	leafReviewers map[string]sets.Set[string]
-	allOwners     sets.Set[string]
+	owners            map[string]string
+	approvers         map[string]layeredsets.String
+	leafApprovers     map[string]sets.Set[string]
+	reviewers         map[string]layeredsets.String
+	requiredReviewers map[string]sets.Set[string]
+	leafReviewers     map[string]sets.Set[string]
+	allOwners         sets.Set[string]
 }
 
-func (foc *fakeOwnersClient) AllApprovers() sets.Set[string]    { return sets.Set[string]{} }
-func (foc *fakeOwnersClient) AllReviewers() sets.Set[string]    { return sets.Set[string]{} }
+func (foc *fakeOwnersClient) AllApprovers() sets.Set[string]      { return sets.Set[string]{} }
+func (foc *fakeOwnersClient) AllReviewers() sets.Set[string]      { return sets.Set[string]{} }
 func (foc *fakeOwnersClient) TopLevelApprovers() sets.Set[string] { return sets.Set[string]{} }
 
 func (foc *fakeOwnersClient) AllOwners() sets.Set[string] {
@@ -168,7 +169,7 @@ func (foc *fakeOwnersClient) Reviewers(path string) layeredsets.String {
 }
 
 func (foc *fakeOwnersClient) RequiredReviewers(path string) sets.Set[string] {
-	return sets.Set[string]{}
+	return foc.requiredReviewers[path]
 }
 
 func (foc *fakeOwnersClient) LeafReviewers(path string) sets.Set[string] {
@@ -183,7 +184,7 @@ func (foc *fakeOwnersClient) FindLabelsForFile(path string) sets.Set[string] {
 	return sets.Set[string]{}
 }
 
-func (foc *fakeOwnersClient) IsNoParentOwners(path string) bool              { return false }
+func (foc *fakeOwnersClient) IsNoParentOwners(path string) bool               { return false }
 func (foc *fakeOwnersClient) IsAutoApproveUnownedSubfolders(path string) bool { return false }
 
 func (foc *fakeOwnersClient) ParseSimpleConfig(path string) (repoowners.SimpleConfig, error) {
@@ -505,6 +506,249 @@ func TestHandleRifleWithBlameScoring(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestHandleRifleWithExistingRequestedReviewers(t *testing.T) {
+	froc := &fakeRepoownersClient{
+		foc: &fakeOwnersClient{
+			owners: map[string]string{
+				"a.go": "1",
+				"r.go": "2",
+			},
+			approvers: map[string]layeredsets.String{
+				"a.go": layeredsets.NewString("adam"),
+				"r.go": layeredsets.NewString("adam"),
+			},
+			leafApprovers: map[string]sets.Set[string]{
+				"a.go": sets.New[string]("adam"),
+				"r.go": sets.New[string]("adam"),
+			},
+			reviewers: map[string]layeredsets.String{
+				"a.go": layeredsets.NewString("bob", "christoph", "david"),
+				"r.go": layeredsets.NewString("bob", "christoph", "david"),
+			},
+			leafReviewers: map[string]sets.Set[string]{
+				"a.go": sets.New[string]("bob", "christoph", "david"),
+				"r.go": sets.New[string]("bob", "christoph", "david"),
+			},
+			requiredReviewers: map[string]sets.Set[string]{
+				"r.go": sets.New[string]("rachel"),
+			},
+		},
+	}
+
+	testcases := []struct {
+		name               string
+		filesChanged       []string
+		requestedReviewers []string
+		reviewerCount      int
+		maxReviewerCount   int
+		excludeApprovers   bool
+		expectedCount      int
+		allowedRequested   []string
+		mustRequest        []string
+		mustNotRequest     []string
+	}{
+		{
+			name:               "eligible existing reviewer counts toward the quota",
+			filesChanged:       []string{"a.go"},
+			requestedReviewers: []string{"christoph"},
+			reviewerCount:      2,
+			excludeApprovers:   true,
+			expectedCount:      1,
+			allowedRequested:   []string{"bob", "david"},
+			mustNotRequest:     []string{"christoph"},
+		},
+		{
+			name:               "quota fully satisfied by existing eligible reviewers",
+			filesChanged:       []string{"a.go"},
+			requestedReviewers: []string{"christoph", "bob"},
+			reviewerCount:      2,
+			excludeApprovers:   true,
+			expectedCount:      0,
+		},
+		{
+			name:               "ineligible existing reviewer does not count",
+			filesChanged:       []string{"a.go"},
+			requestedReviewers: []string{"stranger"},
+			reviewerCount:      2,
+			excludeApprovers:   true,
+			expectedCount:      2,
+			allowedRequested:   []string{"bob", "christoph", "david"},
+		},
+		{
+			name:               "requested login case differs from OWNERS entry",
+			filesChanged:       []string{"a.go"},
+			requestedReviewers: []string{"Christoph"},
+			reviewerCount:      2,
+			excludeApprovers:   true,
+			expectedCount:      1,
+			allowedRequested:   []string{"bob", "david"},
+			mustNotRequest:     []string{"christoph", "Christoph"},
+		},
+		{
+			name:               "quota satisfied but required reviewers still requested",
+			filesChanged:       []string{"r.go"},
+			requestedReviewers: []string{"christoph", "bob"},
+			reviewerCount:      2,
+			excludeApprovers:   true,
+			expectedCount:      1,
+			allowedRequested:   []string{"rachel"},
+			mustRequest:        []string{"rachel"},
+		},
+		{
+			name:               "maxReviewerCount accounts for existing eligible reviewers",
+			filesChanged:       []string{"a.go"},
+			requestedReviewers: []string{"christoph"},
+			reviewerCount:      3,
+			maxReviewerCount:   2,
+			excludeApprovers:   true,
+			expectedCount:      1,
+			allowedRequested:   []string{"bob", "david"},
+			mustNotRequest:     []string{"christoph"},
+		},
+		{
+			name:               "approver-only existing reviewer counts when approvers are not excluded",
+			filesChanged:       []string{"a.go"},
+			requestedReviewers: []string{"adam"},
+			reviewerCount:      1,
+			excludeApprovers:   false,
+			expectedCount:      0,
+		},
+		{
+			name:               "approver-only existing reviewer does not count when approvers are excluded",
+			filesChanged:       []string{"a.go"},
+			requestedReviewers: []string{"adam"},
+			reviewerCount:      1,
+			excludeApprovers:   true,
+			expectedCount:      1,
+			allowedRequested:   []string{"bob", "christoph", "david"},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			pr := github.PullRequest{
+				Number: 5,
+				User:   github.User{Login: "alice"},
+				Base:   github.PullRequestBranch{Ref: "main"},
+			}
+			for _, login := range tc.requestedReviewers {
+				pr.RequestedReviewers = append(pr.RequestedReviewers, github.User{Login: login})
+			}
+			repo := github.Repo{Owner: github.User{Login: "org"}, Name: "repo"}
+			fghc := &fakeRifleClient{
+				fakeGitHubClient: newFakeGitHubClient(&pr, tc.filesChanged),
+			}
+
+			if err := handle(
+				fghc, froc, logrusEntry(),
+				&tc.reviewerCount, tc.maxReviewerCount, tc.excludeApprovers, false, &repo, &pr,
+			); err != nil {
+				t.Fatalf("unexpected error from handle: %v", err)
+			}
+
+			if len(fghc.requested) != tc.expectedCount {
+				t.Fatalf("expected %d newly requested reviewers, got %d: %v", tc.expectedCount, len(fghc.requested), fghc.requested)
+			}
+			allowed := sets.New[string](tc.allowedRequested...)
+			requested := sets.New[string](fghc.requested...)
+			for _, login := range fghc.requested {
+				if !allowed.Has(login) {
+					t.Errorf("requested reviewer %q is not in the allowed set %v", login, sets.List(allowed))
+				}
+			}
+			for _, login := range tc.mustRequest {
+				if !requested.Has(login) {
+					t.Errorf("expected reviewer %q to be requested, got %v", login, fghc.requested)
+				}
+			}
+			for _, login := range tc.mustNotRequest {
+				if requested.Has(login) {
+					t.Errorf("reviewer %q must not be requested again, got %v", login, fghc.requested)
+				}
+			}
+		})
+	}
+}
+
+// TestHandleRifleFallbackExcludesExistingRequestedReviewers drives the git-blame
+// fallback branch (rifle-only) and asserts that an already-requested eligible
+// reviewer is not re-requested through it.
+func TestHandleRifleFallbackExcludesExistingRequestedReviewers(t *testing.T) {
+	froc := &fakeRepoownersClient{
+		foc: &fakeOwnersClient{
+			owners: map[string]string{
+				"pkg/foo/a.go": "1",
+			},
+			approvers: map[string]layeredsets.String{},
+			reviewers: map[string]layeredsets.String{
+				"pkg/foo/a.go": layeredsets.NewString("alice", "bob"),
+			},
+			leafReviewers: map[string]sets.Set[string]{
+				"pkg/foo/a.go": sets.New[string]("alice", "bob"),
+			},
+			// charlie owns code elsewhere in the repo, and so is only reachable
+			// through the broader fallback scope.
+			allOwners: sets.New[string]("alice", "bob", "charlie"),
+		},
+	}
+
+	now := time.Now()
+	pr := github.PullRequest{
+		Number:             5,
+		User:               github.User{Login: "author"},
+		Base:               github.PullRequestBranch{Ref: "main"},
+		Head:               github.PullRequestBranch{SHA: "abc123"},
+		RequestedReviewers: []github.User{{Login: "alice"}},
+	}
+	repo := github.Repo{Owner: github.User{Login: "org"}, Name: "repo"}
+
+	fghc := &fakeRifleClient{
+		fakeGitHubClient: &fakeGitHubClient{
+			pr: &pr,
+			changes: []github.PullRequestChange{
+				{
+					Filename: "pkg/foo/a.go",
+					Status:   "modified",
+					Patch:    "@@ -1,10 +1,12 @@ package foo",
+					SHA:      "abc123",
+				},
+			},
+		},
+		blames: map[string][]github.BlameRange{
+			"pkg/foo/a.go": {
+				{StartingLine: 1, EndingLine: 10, AuthorLogin: "alice", Date: now.Add(-24 * time.Hour)},
+				{StartingLine: 1, EndingLine: 8, AuthorLogin: "bob", Date: now.Add(-24 * time.Hour)},
+				{StartingLine: 1, EndingLine: 4, AuthorLogin: "charlie", Date: now.Add(-48 * time.Hour)},
+			},
+		},
+		mergeBase: "mergebaseSHA",
+	}
+
+	// alice is already requested and eligible, so only 3 more reviewers are
+	// needed. The OWNERS pool can supply just bob, leaving 2 missing and forcing
+	// the fallback over allOwners.
+	reviewerCount := 4
+	if err := handle(
+		fghc, froc, logrusEntry(),
+		&reviewerCount, 0, true, false, &repo, &pr,
+	); err != nil {
+		t.Fatalf("unexpected error from handle: %v", err)
+	}
+
+	got := append([]string(nil), fghc.requested...)
+	sort.Strings(got)
+	want := []string{"bob", "charlie"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("expected fallback to request %v, got %v", want, got)
+	}
+	// Without the existingEligible union in excludeFromFallback, alice would be
+	// re-requested here: the fallback needs 2 reviewers and only alice and
+	// charlie would remain eligible.
+	if sets.New[string](got...).Has("alice") {
+		t.Errorf("already requested reviewer %q must not be re-requested via the blame fallback, got %v", "alice", got)
 	}
 }
 

--- a/pkg/reviewer/reviewer.go
+++ b/pkg/reviewer/reviewer.go
@@ -89,8 +89,8 @@ func ConfigString(pluginName string, reviewCount int) string {
 	return fmt.Sprintf("%s is currently configured to request reviews from %d reviewer%s.", pluginName, reviewCount, pluralSuffix)
 }
 
-func GetReviewers(rc ReviewersClient, selector ReviewerSelector, log *logrus.Entry, author string, files []github.PullRequestChange, minReviewers int) ([]string, []string, error) {
-	authorSet := sets.New[string](github.NormLogin(author))
+func GetReviewers(rc ReviewersClient, selector ReviewerSelector, log *logrus.Entry, author string, files []github.PullRequestChange, minReviewers int, excluded sets.Set[string]) ([]string, []string, error) {
+	nonCandidates := sets.New[string](github.NormLogin(author)).Union(excluded)
 	reviewers := layeredsets.NewString()
 	requiredReviewers := sets.New[string]()
 	leafReviewers := layeredsets.NewString()
@@ -108,7 +108,7 @@ func GetReviewers(rc ReviewersClient, selector ReviewerSelector, log *logrus.Ent
 
 		requiredReviewers.Insert(rc.RequiredReviewers(file.Filename).UnsortedList()...)
 
-		fileUnusedLeaves := layeredsets.NewString(sets.List(rc.LeafReviewers(file.Filename))...).Difference(reviewers.Set()).Difference(authorSet)
+		fileUnusedLeaves := layeredsets.NewString(sets.List(rc.LeafReviewers(file.Filename))...).Difference(reviewers.Set()).Difference(nonCandidates)
 		if fileUnusedLeaves.Len() == 0 {
 			continue
 		}
@@ -129,7 +129,7 @@ func GetReviewers(rc ReviewersClient, selector ReviewerSelector, log *logrus.Ent
 		if reviewers.Len() >= minReviewers {
 			break
 		}
-		fileReviewers := rc.Reviewers(file.Filename).Difference(authorSet)
+		fileReviewers := rc.Reviewers(file.Filename).Difference(nonCandidates)
 		for reviewers.Len() < minReviewers && fileReviewers.Len() > 0 {
 			if r := selector(&fileReviewers); r != "" {
 				reviewers.Insert(2, r)
@@ -139,6 +139,27 @@ func GetReviewers(rc ReviewersClient, selector ReviewerSelector, log *logrus.Ent
 		}
 	}
 	return reviewers.List(), sets.List(requiredReviewers), nil
+}
+
+// EligibleRequestedReviewers returns the PR's currently requested reviewers that are
+// in the reviewer pool (and, when includeApprovers, the approver pool) of the OWNERS
+// files covering the changed files. Logins are normalized with github.NormLogin.
+func EligibleRequestedReviewers(oc OwnersClient, pr *github.PullRequest, files []github.PullRequestChange, includeApprovers bool) sets.Set[string] {
+	requested := sets.New[string]()
+	for _, user := range pr.RequestedReviewers {
+		requested.Insert(github.NormLogin(user.Login))
+	}
+	if requested.Len() == 0 {
+		return requested
+	}
+	pool := sets.New[string]()
+	for _, file := range files {
+		pool = pool.Union(oc.Reviewers(file.Filename).Set())
+		if includeApprovers {
+			pool = pool.Union(oc.Approvers(file.Filename).Set())
+		}
+	}
+	return requested.Intersection(pool)
 }
 
 func FindReviewer(ghc GitHubClient, log *logrus.Entry, useStatusAvailability bool, busyReviewers *sets.Set[string], targetSet *layeredsets.String) string {

--- a/pkg/reviewer/reviewer_test.go
+++ b/pkg/reviewer/reviewer_test.go
@@ -1,0 +1,213 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reviewer
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	"sigs.k8s.io/prow/pkg/github"
+	"sigs.k8s.io/prow/pkg/layeredsets"
+)
+
+type fakeOwners struct {
+	owners            map[string]string
+	reviewers         map[string]layeredsets.String
+	approvers         map[string]layeredsets.String
+	leafReviewers     map[string]sets.Set[string]
+	requiredReviewers map[string]sets.Set[string]
+}
+
+func (f *fakeOwners) FindReviewersOwnersForFile(path string) string { return f.owners[path] }
+func (f *fakeOwners) Reviewers(path string) layeredsets.String      { return f.reviewers[path] }
+func (f *fakeOwners) RequiredReviewers(path string) sets.Set[string] {
+	return f.requiredReviewers[path]
+}
+func (f *fakeOwners) LeafReviewers(path string) sets.Set[string]   { return f.leafReviewers[path] }
+func (f *fakeOwners) FindApproverOwnersForFile(path string) string { return f.owners[path] }
+func (f *fakeOwners) Approvers(path string) layeredsets.String     { return f.approvers[path] }
+func (f *fakeOwners) LeafApprovers(path string) sets.Set[string]   { return nil }
+func (f *fakeOwners) AllOwners() sets.Set[string]                  { return nil }
+
+func changedFiles(files ...string) []github.PullRequestChange {
+	changes := make([]github.PullRequestChange, 0, len(files))
+	for _, f := range files {
+		changes = append(changes, github.PullRequestChange{Filename: f})
+	}
+	return changes
+}
+
+func TestEligibleRequestedReviewers(t *testing.T) {
+	oc := &fakeOwners{
+		owners: map[string]string{
+			"a.go": "a",
+			"b.go": "b",
+		},
+		reviewers: map[string]layeredsets.String{
+			"a.go": layeredsets.NewString("rev1", "rev2"),
+			"b.go": layeredsets.NewString("rev3"),
+		},
+		approvers: map[string]layeredsets.String{
+			"a.go": layeredsets.NewString("app1"),
+		},
+	}
+
+	testcases := []struct {
+		name             string
+		requested        []string
+		files            []string
+		includeApprovers bool
+		expected         sets.Set[string]
+	}{
+		{
+			name:     "no requested reviewers",
+			files:    []string{"a.go"},
+			expected: sets.New[string](),
+		},
+		{
+			name:      "requested reviewer in pool counts",
+			requested: []string{"rev1"},
+			files:     []string{"a.go"},
+			expected:  sets.New[string]("rev1"),
+		},
+		{
+			name:      "requested reviewer outside pool is ignored",
+			requested: []string{"stranger"},
+			files:     []string{"a.go"},
+			expected:  sets.New[string](),
+		},
+		{
+			name:      "only reviewers of changed files count",
+			requested: []string{"rev3"},
+			files:     []string{"a.go"},
+			expected:  sets.New[string](),
+		},
+		{
+			name:      "pool is the union over all changed files",
+			requested: []string{"rev1", "rev3"},
+			files:     []string{"a.go", "b.go"},
+			expected:  sets.New[string]("rev1", "rev3"),
+		},
+		{
+			name:             "approver counts when approvers are included",
+			requested:        []string{"app1"},
+			files:            []string{"a.go"},
+			includeApprovers: true,
+			expected:         sets.New[string]("app1"),
+		},
+		{
+			name:      "approver does not count when approvers are excluded",
+			requested: []string{"app1"},
+			files:     []string{"a.go"},
+			expected:  sets.New[string](),
+		},
+		{
+			name:      "requested login case is normalized",
+			requested: []string{"Rev1"},
+			files:     []string{"a.go"},
+			expected:  sets.New[string]("rev1"),
+		},
+		{
+			name:      "file without OWNERS entries yields no pool",
+			requested: []string{"rev1"},
+			files:     []string{"unknown.go"},
+			expected:  sets.New[string](),
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			pr := &github.PullRequest{}
+			for _, login := range tc.requested {
+				pr.RequestedReviewers = append(pr.RequestedReviewers, github.User{Login: login})
+			}
+			actual := EligibleRequestedReviewers(oc, pr, changedFiles(tc.files...), tc.includeApprovers)
+			if !actual.Equal(tc.expected) {
+				t.Errorf("expected eligible reviewers %v, got %v", sets.List(tc.expected), sets.List(actual))
+			}
+		})
+	}
+}
+
+func TestGetReviewersExcluded(t *testing.T) {
+	oc := &fakeOwners{
+		owners: map[string]string{
+			"a.go": "a",
+		},
+		reviewers: map[string]layeredsets.String{
+			"a.go": layeredsets.NewString("alice", "bob", "carl", "dave"),
+		},
+		leafReviewers: map[string]sets.Set[string]{
+			"a.go": sets.New[string]("alice", "bob", "carl"),
+		},
+		requiredReviewers: map[string]sets.Set[string]{
+			"a.go": sets.New[string]("req1"),
+		},
+	}
+	selector := func(candidates *layeredsets.String) string { return candidates.PopRandom() }
+	log := logrus.WithField("plugin", "test")
+
+	testcases := []struct {
+		name             string
+		minReviewers     int
+		excluded         sets.Set[string]
+		expected         []string
+		expectedRequired []string
+	}{
+		{
+			name:             "excluded reviewers are never selected",
+			minReviewers:     2,
+			excluded:         sets.New[string]("bob"),
+			expected:         []string{"carl", "dave"},
+			expectedRequired: []string{"req1"},
+		},
+		{
+			name:             "nil excluded set only filters the author",
+			minReviewers:     3,
+			excluded:         nil,
+			expected:         []string{"bob", "carl", "dave"},
+			expectedRequired: []string{"req1"},
+		},
+		{
+			name:             "exclusion can exhaust the pool",
+			minReviewers:     3,
+			excluded:         sets.New[string]("bob", "carl", "dave"),
+			expected:         nil,
+			expectedRequired: []string{"req1"},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			reviewers, required, err := GetReviewers(oc, selector, log, "alice", changedFiles("a.go"), tc.minReviewers, tc.excluded)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			sort.Strings(reviewers)
+			if !reflect.DeepEqual(reviewers, tc.expected) {
+				t.Errorf("expected reviewers %v, got %v", tc.expected, reviewers)
+			}
+			if !reflect.DeepEqual(required, tc.expectedRequired) {
+				t.Errorf("expected required reviewers %v, got %v", tc.expectedRequired, required)
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When a PR moves from draft to ready-for-review (or `/auto-cc` is used), blunderbuss selects `reviewer_count` reviewers without looking at who is already requested on the PR. A reviewer who is eligible per OWNERS but was already added — e.g. `/cc`'d while the PR was a draft — does not count, so blunderbuss still picks a full quota of new reviewers and over-assigns the PR. Repeated draft→ready cycles keep adding reviewers until the pool is exhausted. Rifle's handler is a copy of blunderbuss's selection logic and had the identical bug.

This PR makes both plugins treat pending requested reviewers (`requested_reviewers`) that are in the OWNERS reviewer pool for the changed files as counting toward `reviewer_count` and `max_reviewer_count`, and excludes them from being picked again. When `exclude_approvers: false`, members of the approver pool also count, because approvers are legitimate picks via the existing fallback path. Concretely:

* `pkg/reviewer`: `GetReviewers` gains an `excluded` set that is never selected (in addition to the author), and a new shared `EligibleRequestedReviewers` helper computes the already-requested reviewers that are eligible per OWNERS (logins normalized with `NormLogin`).
* `blunderbuss`/`rifle` `handle()`: the number of new picks is reduced by the existing eligible reviewers, the max cap accounts for them too, and rifle's blame-based fallback excludes them as well.
* OWNERS `required_reviewers` are still requested even when the quota is already met by existing reviewers.
* A configured `reviewer_count: 0` keeps today's no-op semantics.

Users who already submitted a review are out of scope — only pending requested reviewers count.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

* This is a default behavior change (bug fix), not a new config option.
* This PR was written in part with the assistance of generative AI. I have reviewed and verified every change and can explain each one.
* Suggested verification: `go test ./pkg/reviewer/... ./pkg/plugins/blunderbuss/... ./pkg/plugins/rifle/...` — the new blunderbuss test cases include the reported scenario end-to-end (draft→ready with an eligible reviewer already `/cc`'d picks only the shortfall; a second run adds nobody).
