### PR TITLE
Added a case for tarball files on gcs

### DIFF
--- a/pkg/pod-utils/gcs/metadata.go
+++ b/pkg/pod-utils/gcs/metadata.go
@@ -39,12 +39,15 @@ func WriterOptionsFromFileName(filename string) (string, io.WriterOptions) {
 	segment := segments[index]
 
 	// https://www.iana.org/assignments/http-parameters/http-parameters.xhtml#content-coding
-	switch segment {
-	case "gz", "gzip":
-		attrs.ContentEncoding = new("gzip")
-	}
+	isGzip := segment == "gz" || segment == "gzip"
+	// A .tar.gz is a gzipped archive, not a gzip-encoded .tar: declaring
+	// Content-Encoding: gzip would store it as a bare .tar and have GCS
+	// decompress it on read, so leave both the name and the bytes alone.
+	isTarball := isGzip && index > 0 && segments[index-1] == "tar"
 
-	if attrs.ContentEncoding != nil {
+	if isGzip && !isTarball {
+		attrs.ContentEncoding = new("gzip")
+
 		if index == 0 {
 			segment = ""
 		} else {
@@ -54,14 +57,13 @@ func WriterOptionsFromFileName(filename string) (string, io.WriterOptions) {
 		}
 	}
 
-	if segment != "" {
-		mediaType := mime.TypeByExtension("." + segment)
-		if mediaType != "" {
+	if !isTarball && segment != "" {
+		if mediaType := mime.TypeByExtension("." + segment); mediaType != "" {
 			attrs.ContentType = new(mediaType)
 		}
 	}
 
-	if attrs.ContentType == nil && attrs.ContentEncoding != nil && *attrs.ContentEncoding == "gzip" {
+	if attrs.ContentType == nil && isGzip {
 		attrs.ContentType = new("application/gzip")
 		attrs.ContentEncoding = nil
 	}

--- a/pkg/pod-utils/gcs/metadata_test.go
+++ b/pkg/pod-utils/gcs/metadata_test.go
@@ -26,6 +26,7 @@ import (
 
 func TestWriterOptionsFromFileName(t *testing.T) {
 	mime.AddExtensionType(".log", "text/plain")
+	mime.AddExtensionType(".tar", "application/x-tar")
 
 	testCases := []struct {
 		name             string
@@ -106,6 +107,30 @@ func TestWriterOptionsFromFileName(t *testing.T) {
 			expectedFileName: "journal.log",
 			expectedAttrs: io.WriterOptions{
 				ContentType: new("text/plain; charset=utf-8"),
+			},
+		},
+		{
+			name:             "tar",
+			filename:         "build-logs.tar",
+			expectedFileName: "build-logs.tar",
+			expectedAttrs: io.WriterOptions{
+				ContentType: new("application/x-tar"),
+			},
+		},
+		{
+			name:             "tar.gzip",
+			filename:         "build-logs.tar.gzip",
+			expectedFileName: "build-logs.tar.gzip",
+			expectedAttrs: io.WriterOptions{
+				ContentType: new("application/gzip"),
+			},
+		},
+		{
+			name:             "tar.gz",
+			filename:         "build-logs.tar.gz",
+			expectedFileName: "build-logs.tar.gz",
+			expectedAttrs: io.WriterOptions{
+				ContentType: new("application/gzip"),
 			},
 		},
 		{


### PR DESCRIPTION
`WriterOptionsFromFileName` guesses upload attributes from a file's name. For a file ending in `.gz` it uploads the compressed bytes, strips the extension, and sets `Content-Encoding: gzip` - so `build-log.txt.gz` is stored as `build-log.txt` and GCS decompresses on read. That is the behavior we want for logs: Deck fetches `build-log.txt` and gets plain text, without anything in the chain needing to know it was gzipped.

Archives gain nothing from that trade, `must-gather.tar.gz` is stored as `must-gather.tar` holding gzip bytes; no viewer renders a tar inline, the user simply wants to download the artifact the job produced. What they get is an object whose name no longer matches what was uploaded, and whose bytes depend on whether the client sends `Accept-Encoding: gzip` - a client that does receives a gzip stream in a file named `.tar`.

This change adds an exception for tarballs: when the segment before `.gz/.gzip` is `tar`, the file keeps its full name and is stored with `Content-Type: application/gzip` and no `Content-Encoding`, so GCS serves the bytes untouched.

This will help KDE [Ark](https://apps.kde.org/ark/) to correctly handle these files.
About GCS [transcoding](https://docs.cloud.google.com/storage/docs/transcoding) process.

**Note** that artifacts previously landing at `foo.tar` will now land at `foo.tar.gz`.