### PR TITLE
tide: exclude PR from subpool when its changed files cannot be fetched

### DIFF
--- a/pkg/tide/tide.go
+++ b/pkg/tide/tide.go
@@ -1681,7 +1681,8 @@ func refGetterFactory(ref string) config.RefGetter {
 }
 
 // presubmitsByPull creates a map pr -> requiredPresubmits and will filter out all PRs
-// where we failed to find out the required presubmits (can happen if inrepoconfig is enabled).
+// where we failed to find out the required presubmits (can happen if inrepoconfig is enabled
+// or if the changed files of the PR cannot be retrieved).
 func (c *syncController) presubmitsByPull(sp *subpool) (map[int][]config.Presubmit, error) {
 	presubmits := make(map[int][]config.Presubmit, len(sp.prs))
 
@@ -1696,9 +1697,9 @@ func (c *syncController) presubmitsByPull(sp *subpool) (map[int][]config.Presubm
 			log.WithError(err).Debug("Failed to get presubmits for PR, excluding from subpool")
 			continue
 		}
-		filteredPRs = append(filteredPRs, pr)
 		log.WithField("num_possible_presubmit", len(presubmitsForPull)).Debug("Found possible presubmits")
 
+		var changedFilesErr error
 		for _, ps := range presubmitsForPull {
 			if !c.provider.jobIsRequiredByTide(&ps, &pr) {
 				continue
@@ -1712,7 +1713,8 @@ func (c *syncController) presubmitsByPull(sp *subpool) (map[int][]config.Presubm
 			forceRun := (requireManuallyTriggeredJobs && ps.ContextRequired() && ps.NeedsExplicitTrigger()) || ps.RunBeforeMerge
 			shouldRun, err := ps.ShouldRun(sp.branch, c.changedFiles.prChanges(&pr), forceRun, false)
 			if err != nil {
-				return nil, err
+				changedFilesErr = err
+				break
 			}
 			if !shouldRun {
 				continue
@@ -1720,6 +1722,12 @@ func (c *syncController) presubmitsByPull(sp *subpool) (map[int][]config.Presubm
 
 			presubmits[pr.Number] = append(presubmits[pr.Number], ps)
 		}
+		if changedFilesErr != nil {
+			log.WithError(changedFilesErr).Warn("Failed to determine required presubmits for PR, excluding from subpool")
+			delete(presubmits, pr.Number)
+			continue
+		}
+		filteredPRs = append(filteredPRs, pr)
 		log.WithField("required-presubmit-count", len(presubmits[pr.Number])).Debug("Determined required presubmits for PR.")
 	}
 

--- a/pkg/tide/tide_test.go
+++ b/pkg/tide/tide_test.go
@@ -3306,9 +3306,11 @@ func TestPresubmitsByPull(t *testing.T) {
 		presubmits         []config.Presubmit
 		prs                []CodeReviewCommon
 		prowYAMLGetter     config.ProwYAMLGetter
+		ghc                githubClient
 
 		expectedPresubmits           map[int][]config.Presubmit
 		expectedChangeCache          map[changeCacheKey][]string
+		expectedPRs                  []int
 		requireManuallyTriggeredJobs bool
 		fromBranchProtection         bool
 	}{
@@ -3639,6 +3641,51 @@ func TestPresubmitsByPull(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "changed files error excludes only the affected PR from the subpool",
+			presubmits: []config.Presubmit{
+				{
+					Reporter:  config.Reporter{Context: "always"},
+					AlwaysRun: true,
+				},
+				{
+					Reporter: config.Reporter{Context: "presubmit"},
+					RegexpChangeMatcher: config.RegexpChangeMatcher{
+						RunIfChanged: "^CHANGE.$",
+					},
+				},
+			},
+			ghc: &ghcInterceptor{
+				c: &fgc{},
+				interceptors: githubClientFuncs{
+					GetPullRequestChanges: func(ghc githubClient, org, repo string, number int) ([]github.PullRequestChange, error) {
+						if number == 1 {
+							return nil, errors.New("return code not 2XX: 422 Unprocessable Entity")
+						}
+						return ghc.GetPullRequestChanges(org, repo, number)
+					},
+				},
+			},
+			prs: []CodeReviewCommon{
+				{Number: 1, HeadRefOID: "1"},
+			},
+			expectedPresubmits: map[int][]config.Presubmit{
+				100: {
+					{
+						Reporter:  config.Reporter{Context: "always"},
+						AlwaysRun: true,
+					},
+					{
+						Reporter: config.Reporter{Context: "presubmit"},
+						RegexpChangeMatcher: config.RegexpChangeMatcher{
+							RunIfChanged: "^CHANGE.$",
+						},
+					},
+				},
+			},
+			expectedChangeCache: map[changeCacheKey][]string{{number: 100, sha: "sha"}: {"CHANGED"}},
+			expectedPRs:         []int{100},
+		},
 	}
 
 	for _, tc := range testcases {
@@ -3685,7 +3732,11 @@ func TestPresubmitsByPull(t *testing.T) {
 				prs:    append(tc.prs, *CodeReviewCommonFromPullRequest(&samplePR)),
 			}
 			log := logrus.WithField("test", tc.name)
-			ghProvider := newGitHubProvider(log, &fgc{}, nil, cfgAgent.Config, newMergeChecker(cfgAgent.Config, &fgc{}), false)
+			var ghc githubClient = &fgc{}
+			if tc.ghc != nil {
+				ghc = tc.ghc
+			}
+			ghProvider := newGitHubProvider(log, ghc, nil, cfgAgent.Config, newMergeChecker(cfgAgent.Config, &fgc{}), false)
 			c := &syncController{
 				config:   cfgAgent.Config,
 				provider: ghProvider,
@@ -3710,6 +3761,15 @@ func TestPresubmitsByPull(t *testing.T) {
 			}
 			if got := c.changedFiles.changeCache; !reflect.DeepEqual(got, tc.expectedChangeCache) {
 				t.Errorf("got incorrect file change cache: %v", diff.Diff(tc.expectedChangeCache, got))
+			}
+			if tc.expectedPRs != nil {
+				var gotPRs []int
+				for _, pr := range sp.prs {
+					gotPRs = append(gotPRs, pr.Number)
+				}
+				if !reflect.DeepEqual(gotPRs, tc.expectedPRs) {
+					t.Errorf("got incorrect PRs in subpool: %v", diff.Diff(tc.expectedPRs, gotPRs))
+				}
 			}
 		})
 	}


### PR DESCRIPTION
## Problem

When the changed files of a single PR cannot be retrieved (GitHub answers `422 Unprocessable Entity` for `GET /repos/{owner}/{repo}/pulls/{n}/files` when the diff is too large to generate), tide drops the **entire** subpool for that org/repo/branch on every sync, not only the affected PR. Every other merge-eligible PR sharing that subpool is blocked from merging for as long as the unreadable PR stays eligible, and tide logs `Error initializing subpool.` each loop.

## Root cause

`pkg/tide/tide.go`, `presubmitsByPull` (function at line 1685 on base `104d452f`): the error from `ps.ShouldRun(sp.branch, c.changedFiles.prChanges(&pr), forceRun, false)` at line 1713 is returned as the error of the whole function (`return nil, err` at line 1715).

`initSubpoolData` (function at `pkg/tide/tide.go:694`) wraps it into `error determining required presubmit prowjobs` at line 698, and `filterSubpools` (function at `pkg/tide/tide.go:666`) logs `Error initializing subpool.` at line 675 and returns without adding the subpool to the filtered pool map.

The same function already tolerates a per-PR failure a few lines earlier: when `GetPresubmits` fails (broken inrepoconfig) the PR is logged and excluded from `sp.prs` and the loop continues. A changed-files failure is the same kind of per-PR problem but was treated as fatal for the subpool.

## Fix

Treat a changed-files failure the same way as a failure to load the presubmits of that PR:

- when `ShouldRun` returns an error, stop evaluating presubmits for that PR, log a warning, drop any presubmits already collected for it, and `continue`;
- only append the PR to `filteredPRs` (which becomes `sp.prs`) after all its presubmits were evaluated successfully.

Other PRs in the subpool keep their required presubmits and the subpool is still initialized. The excluded PR is rediscovered on the next sync and retried, as before.

The `trigger` and `approve` plugins hit the same 422 (see the issue). This PR only addresses the tide side, where the blast radius is the whole merge pool; what the plugins should do when the file list is unavailable is a separate behavior decision and is left for a follow-up.

## How tested

New test case `changed files error excludes only the affected PR from the subpool` in `TestPresubmitsByPull` (`pkg/tide/tide_test.go`): two PRs in one subpool, `GetPullRequestChanges` returns a 422-style error for PR 1 via the existing `ghcInterceptor`. It asserts that PR 100 still gets its `always_run` and `run_if_changed` presubmits, that its changed files are cached, and that only PR 100 remains in `sp.prs`.

The `always_run` presubmit is listed before the `run_if_changed` one on purpose: PR 1 then has one presubmit collected before `ShouldRun` fails on the second, so the assertion on the presubmit map also covers the `delete(presubmits, pr.Number)` cleanup. With that line removed the case fails with an extra `"1": [{"always_run": true, "context": "always"}]` entry in the map.

Before the fix:

```
--- FAIL: TestPresubmitsByPull (0.00s)
    --- FAIL: TestPresubmitsByPull/changed_files_error_excludes_only_the_affected_PR_from_the_subpool (0.00s)
        tide_test.go:3752: unexpected error from presubmitsByPull: error getting PR changes for #1: failed get PR changes: return code not 2XX: 422 Unprocessable Entity
FAIL
FAIL	sigs.k8s.io/prow/pkg/tide	0.079s
```

After the fix:

```
$ go test ./pkg/tide/
ok  	sigs.k8s.io/prow/pkg/tide	1.921s
$ go vet ./pkg/tide/ && gofmt -l pkg/tide/ && ./_bin/golangci-lint run ./pkg/tide/...
0 issues.
$ go build ./pkg/tide/... ./cmd/tide/
```

## Links

- Issue: https://github.com/kubernetes-sigs/prow/issues/914

This change was prepared with an AI agent operated by KR-Ravindra, who reviewed and tested it.

